### PR TITLE
test: expand coverage for docx, tools, web, and cmd

### DIFF
--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -50,4 +53,61 @@ func TestBearerAuthMiddleware(t *testing.T) {
 			t.Errorf("expected 401, got %d", w.Code)
 		}
 	})
+}
+
+// captureStdout runs fn and returns whatever it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
+func TestCmdCompletion(t *testing.T) {
+	tests := []struct {
+		shell    string
+		contains []string
+	}{
+		{
+			shell:    "bash",
+			contains: []string{"_3gpp_mcp", "complete -F _3gpp_mcp", "import-dir"},
+		},
+		{
+			shell:    "zsh",
+			contains: []string{"#compdef 3gpp-mcp", "_describe", "completion"},
+		},
+		{
+			shell:    "fish",
+			contains: []string{"complete -c 3gpp-mcp", "Start the MCP server"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				cmdCompletion([]string{tt.shell})
+			})
+			if out == "" {
+				t.Errorf("expected non-empty output for %s", tt.shell)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %q, got:\n%s", want, out)
+				}
+			}
+		})
+	}
 }

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -1,0 +1,255 @@
+package docx
+
+import (
+	"testing"
+)
+
+func TestParseCoreProperties(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title>System architecture for 5G</dc:title>
+  <dc:subject>5G architecture; Stage 2 (Release 18)</dc:subject>
+</cp:coreProperties>`
+	props := parseCoreProperties([]byte(xml))
+	if props.Title != "System architecture for 5G" {
+		t.Errorf("Title = %q", props.Title)
+	}
+	if props.Subject != "5G architecture; Stage 2 (Release 18)" {
+		t.Errorf("Subject = %q", props.Subject)
+	}
+}
+
+func TestParseCoreProperties_Empty(t *testing.T) {
+	props := parseCoreProperties([]byte{})
+	if props.Title != "" || props.Subject != "" {
+		t.Errorf("expected empty props, got %+v", props)
+	}
+}
+
+func TestParseCoreProperties_Malformed(t *testing.T) {
+	props := parseCoreProperties([]byte("not xml"))
+	if props.Title != "" || props.Subject != "" {
+		t.Errorf("expected empty props, got %+v", props)
+	}
+}
+
+func TestIsTemplateValue(t *testing.T) {
+	cases := map[string]bool{
+		"":                            true,
+		"<Title of Document>":         true,
+		"contains <Title placeholder": true,
+		"prefix ab.cde suffix":        true,
+		"System architecture":         false,
+		"TS 23.501":                   false,
+	}
+	for input, want := range cases {
+		if got := isTemplateValue(input); got != want {
+			t.Errorf("isTemplateValue(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestExtractMetadata_FilenameVariants(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		wantSpecID  string
+		wantVersion string
+	}{
+		{
+			name:        "TS series with hyphen and letter version",
+			filename:    "23501-i30.docx",
+			wantSpecID:  "TS 23.501",
+			wantVersion: "i30",
+		},
+		{
+			name:        "TR series with hyphen and letter version",
+			filename:    "24229-h50.doc",
+			wantSpecID:  "TS 24.229",
+			wantVersion: "h50",
+		},
+		{
+			name:        "high series",
+			filename:    "29510-f60.zip",
+			wantSpecID:  "TS 29.510",
+			wantVersion: "f60",
+		},
+		{
+			name:        "no extension",
+			filename:    "33401-i00",
+			wantSpecID:  "TS 33.401",
+			wantVersion: "i00",
+		},
+		{
+			name:        "non-standard falls back to stem",
+			filename:    "weirdname.docx",
+			wantSpecID:  "weirdname",
+			wantVersion: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := extractMetadata(tt.filename, coreProperties{}, nil, nil)
+			if meta.SpecID != tt.wantSpecID {
+				t.Errorf("SpecID = %q, want %q", meta.SpecID, tt.wantSpecID)
+			}
+			if meta.Version != tt.wantVersion {
+				t.Errorf("Version = %q, want %q", meta.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestExtractMetadata_SubjectWithRelease(t *testing.T) {
+	props := coreProperties{
+		Subject: "5G System architecture (Release 18)",
+	}
+	meta := extractMetadata("23501-i30.docx", props, nil, nil)
+	if meta.Title != "5G System architecture" {
+		t.Errorf("Title = %q", meta.Title)
+	}
+	if meta.Release != "18" {
+		t.Errorf("Release = %q, want 18", meta.Release)
+	}
+}
+
+func TestExtractMetadata_TitleFromTitleProperty(t *testing.T) {
+	props := coreProperties{
+		Title: "Network Function Repository Services",
+	}
+	meta := extractMetadata("29510-i00.docx", props, nil, nil)
+	if meta.Title != "Network Function Repository Services" {
+		t.Errorf("Title = %q", meta.Title)
+	}
+}
+
+func TestExtractMetadata_TemplatePropsIgnored(t *testing.T) {
+	props := coreProperties{
+		Title:   "<Title of the document>",
+		Subject: "",
+	}
+	meta := extractMetadata("23501-i30.docx", props, nil, nil)
+	if meta.Title != "TS 23.501" {
+		// Should fall back to specID since both props are template/empty.
+		t.Errorf("Title = %q, want fallback to spec ID", meta.Title)
+	}
+}
+
+func TestExtractMetadata_VersionFromBody(t *testing.T) {
+	bodyElements := []bodyElement{
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				Text: "V18.6.0",
+				Runs: []runInfo{{Text: "V18.6.0"}},
+			},
+		},
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				Text: "Release 18",
+				Runs: []runInfo{{Text: "Release 18"}},
+			},
+		},
+	}
+	meta := extractMetadata("weirdname.docx", coreProperties{}, bodyElements, map[string]string{})
+	if meta.Version != "18.6.0" {
+		t.Errorf("Version = %q, want 18.6.0", meta.Version)
+	}
+	if meta.Release != "18" {
+		t.Errorf("Release = %q, want 18", meta.Release)
+	}
+}
+
+func TestExtractMetadataFromBody_ZTStyle(t *testing.T) {
+	styleMap := map[string]string{
+		"ZA": "ZA",
+		"ZT": "ZT",
+	}
+	elements := []bodyElement{
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				StyleID: "ZT",
+				Text:    "3rd Generation Partnership Project;",
+				Runs:    []runInfo{{Text: "3rd Generation Partnership Project;"}},
+			},
+		},
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				StyleID: "ZT",
+				Text:    "Technical Specification Group Services and System Aspects;",
+				Runs:    []runInfo{{Text: "Technical Specification Group Services and System Aspects;"}},
+			},
+		},
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				StyleID: "ZT",
+				Text:    "System architecture for the 5G System (5GS);",
+				Runs:    []runInfo{{Text: "System architecture for the 5G System (5GS);"}},
+			},
+		},
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				StyleID: "ZT",
+				Text:    "Stage 2",
+				Runs:    []runInfo{{Text: "Stage 2"}},
+			},
+		},
+		{
+			Tag: "p",
+			Paragraph: paragraphInfo{
+				StyleID: "ZT",
+				Text:    "(Release 18)",
+				Runs:    []runInfo{{Text: "(Release 18)"}},
+			},
+		},
+	}
+	title, release := extractMetadataFromBody(elements, styleMap)
+	if title == "" {
+		t.Error("expected non-empty title")
+	}
+	if release != "18" {
+		t.Errorf("Release = %q, want 18", release)
+	}
+}
+
+func TestIsCoverPageEnd(t *testing.T) {
+	cases := map[string]bool{
+		"TT":          true,
+		"TOC heading": true,
+		"FP":          true,
+		"toc 1":       true,
+		"TOC1":        true,
+		"Heading 1":   true,
+		"Heading 9":   true,
+		"Normal":      false,
+		"ZT":          false,
+		"":            false,
+	}
+	for in, want := range cases {
+		if got := isCoverPageEnd(in); got != want {
+			t.Errorf("isCoverPageEnd(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestSpecMetadata_Series(t *testing.T) {
+	cases := map[string]string{
+		"TS 23.501":  "23",
+		"TS 29.510":  "29",
+		"TR 38.901":  "38",
+		"weirdname":  "",
+		"TS without": "",
+	}
+	for specID, want := range cases {
+		m := &SpecMetadata{SpecID: specID}
+		if got := m.Series(); got != want {
+			t.Errorf("Series for %q = %q, want %q", specID, got, want)
+		}
+	}
+}

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -1,0 +1,216 @@
+package docx
+
+import (
+	"testing"
+)
+
+const wXMLNS = `xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"`
+
+func TestParseParagraph_PlainText(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `><w:r><w:t>hello world</w:t></w:r></w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.Text != "hello world" {
+		t.Errorf("Text = %q, want %q", info.Text, "hello world")
+	}
+	if len(info.Runs) != 1 {
+		t.Fatalf("Runs = %d, want 1", len(info.Runs))
+	}
+	if info.Runs[0].Bold || info.Runs[0].Italic {
+		t.Errorf("expected non-formatted run, got bold=%v italic=%v", info.Runs[0].Bold, info.Runs[0].Italic)
+	}
+	if info.IsCode {
+		t.Error("expected IsCode=false for plain run")
+	}
+}
+
+func TestParseParagraph_BoldItalicCombinations(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:rPr><w:b/></w:rPr><w:t>bold </w:t></w:r>` +
+		`<w:r><w:rPr><w:i/></w:rPr><w:t>italic </w:t></w:r>` +
+		`<w:r><w:rPr><w:b/><w:i/></w:rPr><w:t>both</w:t></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Runs) != 3 {
+		t.Fatalf("Runs = %d, want 3", len(info.Runs))
+	}
+	if !info.Runs[0].Bold || info.Runs[0].Italic {
+		t.Errorf("run[0]: want bold only, got bold=%v italic=%v", info.Runs[0].Bold, info.Runs[0].Italic)
+	}
+	if info.Runs[1].Bold || !info.Runs[1].Italic {
+		t.Errorf("run[1]: want italic only, got bold=%v italic=%v", info.Runs[1].Bold, info.Runs[1].Italic)
+	}
+	if !info.Runs[2].Bold || !info.Runs[2].Italic {
+		t.Errorf("run[2]: want both, got bold=%v italic=%v", info.Runs[2].Bold, info.Runs[2].Italic)
+	}
+	if info.Text != "bold italic both" {
+		t.Errorf("Text = %q, want %q", info.Text, "bold italic both")
+	}
+}
+
+func TestParseParagraph_BoldFalseAttr(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:rPr><w:b w:val="false"/></w:rPr><w:t>not bold</w:t></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Runs) != 1 {
+		t.Fatalf("Runs = %d, want 1", len(info.Runs))
+	}
+	if info.Runs[0].Bold {
+		t.Error("expected w:b val=false to disable bold")
+	}
+}
+
+func TestParseParagraph_ItalicFalseAttr(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:rPr><w:i w:val="0"/></w:rPr><w:t>not italic</w:t></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.Runs[0].Italic {
+		t.Error("expected w:i val=0 to disable italic")
+	}
+}
+
+func TestParseParagraph_TabBetweenText(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.Text != "a\tb" {
+		t.Errorf("Text = %q, want %q", info.Text, "a\tb")
+	}
+}
+
+func TestParseParagraph_EmptyOnInvalidInput(t *testing.T) {
+	info := parseParagraph([]byte("not xml"))
+	if info.Text != "" || len(info.Runs) != 0 {
+		t.Errorf("expected empty info on invalid input, got %+v", info)
+	}
+}
+
+func TestParseParagraph_NoRunsEmptyText(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `><w:pPr><w:pStyle w:val="Normal"/></w:pPr></w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.Text != "" {
+		t.Errorf("Text = %q, want empty", info.Text)
+	}
+	if info.StyleID != "Normal" {
+		t.Errorf("StyleID = %q, want Normal", info.StyleID)
+	}
+}
+
+func TestParagraphToMarkdown(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      paragraphInfo
+		styleName string
+		want      string
+	}{
+		{
+			name:      "blank text returns empty",
+			info:      paragraphInfo{Text: "  "},
+			styleName: "Normal",
+			want:      "",
+		},
+		{
+			name:      "plain run",
+			info:      paragraphInfo{Text: "hello", Runs: []runInfo{{Text: "hello"}}},
+			styleName: "Normal",
+			want:      "hello",
+		},
+		{
+			name: "mixed bold and italic runs",
+			info: paragraphInfo{
+				Text: "Bold and italic",
+				Runs: []runInfo{
+					{Text: "Bold", Bold: true},
+					{Text: " and "},
+					{Text: "italic", Italic: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "**Bold** and *italic*",
+		},
+		{
+			name: "bold italic combined",
+			info: paragraphInfo{
+				Text: "both",
+				Runs: []runInfo{{Text: "both", Bold: true, Italic: true}},
+			},
+			styleName: "Normal",
+			want:      "***both***",
+		},
+		{
+			name:      "list bullet style",
+			info:      paragraphInfo{Text: "item", Runs: []runInfo{{Text: "item"}}},
+			styleName: "ListBullet",
+			want:      "- item",
+		},
+		{
+			name:      "list number style",
+			info:      paragraphInfo{Text: "first", Runs: []runInfo{{Text: "first"}}},
+			styleName: "ListNumber",
+			want:      "1. first",
+		},
+		{
+			name:      "unknown list style defaults to bullet",
+			info:      paragraphInfo{Text: "x", Runs: []runInfo{{Text: "x"}}},
+			styleName: "ListSomething",
+			want:      "- x",
+		},
+		{
+			name:      "empty runs falls back to plain text",
+			info:      paragraphInfo{Text: "fallback"},
+			styleName: "Normal",
+			want:      "fallback",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paragraphToMarkdown(tt.info, tt.styleName)
+			if got != tt.want {
+				t.Errorf("paragraphToMarkdown = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMonospaceFont(t *testing.T) {
+	cases := map[string]bool{
+		"Courier New":     true,
+		"Courier":         true,
+		"Consolas":        true,
+		"Lucida Console":  true,
+		"Monaco":          true,
+		"Menlo":           true,
+		"Times New Roman": false,
+		"Arial":           false,
+		"":                false,
+	}
+	for font, want := range cases {
+		if got := isMonospaceFont(font); got != want {
+			t.Errorf("isMonospaceFont(%q) = %v, want %v", font, got, want)
+		}
+	}
+}
+
+func TestParseShapeStyle(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		w, h int
+	}{
+		{"px units", "width:96px;height:48px", 96, 48},
+		{"inch units with whitespace", "width: 1in ; height: 0.5in", 96, 48},
+		{"only width", "width:100px", 100, 0},
+		{"unrelated declaration", "color:red", 0, 0},
+		{"empty", "", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, h := parseShapeStyle(tt.in)
+			if w != tt.w || h != tt.h {
+				t.Errorf("parseShapeStyle(%q) = (%d, %d), want (%d, %d)", tt.in, w, h, tt.w, tt.h)
+			}
+		})
+	}
+}

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -1,0 +1,160 @@
+package docx
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRowsToMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		rows [][]string
+		want string
+	}{
+		{
+			name: "empty rows returns empty string",
+			rows: nil,
+			want: "",
+		},
+		{
+			name: "single header row",
+			rows: [][]string{{"a", "b"}},
+			want: "| a | b |\n| --- | --- |",
+		},
+		{
+			name: "header with data row",
+			rows: [][]string{{"H1", "H2"}, {"v1", "v2"}},
+			want: "| H1 | H2 |\n| --- | --- |\n| v1 | v2 |",
+		},
+		{
+			name: "row padding when fewer cells than header",
+			rows: [][]string{{"H1", "H2", "H3"}, {"v1"}},
+			want: "| H1 | H2 | H3 |\n| --- | --- | --- |\n| v1 |  |  |",
+		},
+		{
+			name: "row truncation when more cells than header",
+			rows: [][]string{{"H1"}, {"v1", "v2", "v3"}},
+			want: "| H1 |\n| --- |\n| v1 |",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rowsToMarkdown(tt.rows)
+			if got != tt.want {
+				t.Errorf("rowsToMarkdown:\nwant:\n%s\ngot:\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractTableRows_Simple(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>H2</w:t></w:r></w:p></w:tc></w:tr>
+		<w:tr><w:tc><w:p><w:r><w:t>v1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>v2</w:t></w:r></w:p></w:tc></w:tr>
+	</w:tbl>`
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if len(rows[0]) != 2 || rows[0][0] != "H1" || rows[0][1] != "H2" {
+		t.Errorf("header row = %v", rows[0])
+	}
+	if len(rows[1]) != 2 || rows[1][0] != "v1" || rows[1][1] != "v2" {
+		t.Errorf("data row = %v", rows[1])
+	}
+}
+
+func TestExtractTableRows_EmptyCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc><w:tc><w:p/></w:tc></w:tr>
+	</w:tbl>`
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 1 || len(rows[0]) != 2 {
+		t.Fatalf("rows = %v", rows)
+	}
+	if rows[0][1] != "" {
+		t.Errorf("empty cell = %q, want empty string", rows[0][1])
+	}
+}
+
+func TestExtractTableRows_NestedTable(t *testing.T) {
+	// The parser does not track table nesting, so a nested w:tbl inside a cell
+	// causes the inner <w:tr>/<w:tc> tokens to reset the outer row state. This
+	// test pins down that behavior and asserts the parser does not panic on
+	// nested input.
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc>
+			<w:p><w:r><w:t>outer</w:t></w:r></w:p>
+			<w:tbl>
+				<w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr>
+			</w:tbl>
+		</w:tc></w:tr>
+	</w:tbl>`
+	rows := extractTableRows([]byte(xml))
+	if len(rows) == 0 {
+		t.Fatal("expected at least one row from nested-table input")
+	}
+	if rows[0][0] != "inner" {
+		t.Errorf("expected inner row to win over outer (current behavior), got %v", rows[0])
+	}
+}
+
+func TestExtractTableRows_MultiParagraphCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc>
+			<w:p><w:r><w:t>first</w:t></w:r></w:p>
+			<w:p><w:r><w:t>second</w:t></w:r></w:p>
+		</w:tc></w:tr>
+	</w:tbl>`
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 1 || len(rows[0]) != 1 {
+		t.Fatalf("rows = %v", rows)
+	}
+	if !strings.Contains(rows[0][0], "first") || !strings.Contains(rows[0][0], "second") {
+		t.Errorf("cell text = %q, expected to contain both paragraphs", rows[0][0])
+	}
+}
+
+func TestExtractTableRows_BoldRunInCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p>
+			<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r>
+			<w:r><w:t> plain</w:t></w:r>
+		</w:p></w:tc></w:tr>
+	</w:tbl>`
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 1 {
+		t.Fatalf("rows = %v", rows)
+	}
+	if rows[0][0] != "bold plain" {
+		t.Errorf("cell text = %q, want %q", rows[0][0], "bold plain")
+	}
+}
+
+func TestExtractTableRows_Malformed(t *testing.T) {
+	// Garbage input must not panic or hang. The function returns nil if no
+	// w:tbl token is found.
+	rows := extractTableRows([]byte("not xml at all"))
+	if rows != nil {
+		t.Errorf("expected nil rows for malformed input, got %v", rows)
+	}
+}
+
+func TestTableToMarkdown_RoundTrip(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Type</w:t></w:r></w:p></w:tc></w:tr>
+		<w:tr><w:tc><w:p><w:r><w:t>foo</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>string</w:t></w:r></w:p></w:tc></w:tr>
+	</w:tbl>`
+	md := tableToMarkdown([]byte(xml))
+	for _, want := range []string{"| Name | Type |", "| --- | --- |", "| foo | string |"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected output to contain %q\n%s", want, md)
+		}
+	}
+}
+
+func TestTableToMarkdown_NoTable(t *testing.T) {
+	if md := tableToMarkdown([]byte("garbage")); md != "" {
+		t.Errorf("expected empty markdown for invalid input, got %q", md)
+	}
+}

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -285,6 +286,109 @@ func TestPipelineRun_Race(t *testing.T) {
 	}
 	if len(sections) == 0 {
 		t.Error("expected sections for TS 23.274 after pipeline run")
+	}
+}
+
+// TestPipelineRun_ContextCancel verifies Pipeline.Run honors context
+// cancellation. The fake server blocks indefinitely on the download request,
+// the test cancels the context, and Pipeline.Run must return promptly.
+func TestPipelineRun_ContextCancel(t *testing.T) {
+	requested := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requested <- struct{}{}:
+		default:
+		}
+		// Block until the client cancels the request.
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	d := setupTestDB(t)
+
+	specs := []*SpecVersion{{
+		Series:        "23",
+		SpecID:        "23.274",
+		Filename:      "23274-i20.zip",
+		VersionLetter: "i",
+		VersionMinor:  20,
+		Release:       18,
+		URL:           ts.URL + "/blocking.zip",
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := &Pipeline{
+		DB:      d,
+		Client:  ts.Client(),
+		Workers: 1,
+		Timeout: 30 * time.Second,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Run(ctx, specs)
+	}()
+
+	// Wait until the server has actually started serving the request, then
+	// cancel.
+	select {
+	case <-requested:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("server never received a request")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		// Pipeline.Run swallows individual goroutine cancel errors and returns
+		// nil; the only contract is that it returns promptly.
+		_ = err
+	case <-time.After(10 * time.Second):
+		t.Fatal("Pipeline.Run did not return within 10s after cancel")
+	}
+}
+
+// TestConvertDir_EmptyDirError verifies ConvertDir returns an error when no
+// .docx files are present.
+func TestConvertDir_EmptyDirError(t *testing.T) {
+	dir := t.TempDir()
+	d := setupTestDB(t)
+	err := ConvertDir(context.Background(), d, dir, 1, false)
+	if err == nil {
+		t.Fatal("expected error for empty directory")
+	}
+	if !strings.Contains(err.Error(), "no .docx files") {
+		t.Errorf("error = %v, want 'no .docx files'", err)
+	}
+}
+
+// TestConvertDir_MissingDir verifies ConvertDir surfaces filesystem errors
+// when the directory does not exist.
+func TestConvertDir_MissingDir(t *testing.T) {
+	d := setupTestDB(t)
+	err := ConvertDir(context.Background(), d, filepath.Join(t.TempDir(), "nope"), 1, false)
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+}
+
+// TestReleaseFromDocxFilename pins down the version-letter → release mapping
+// used to populate the Release column when importing single files.
+func TestReleaseFromDocxFilename(t *testing.T) {
+	cases := map[string]int{
+		"23501-i30.docx": 18,
+		"24229-h50.docx": 17,
+		"29510-f60.docx": 15,
+		"weirdname.docx": 0,
+		"23501.docx":     0,
+	}
+	for in, want := range cases {
+		if got := releaseFromDocxFilename(in); got != want {
+			t.Errorf("releaseFromDocxFilename(%q) = %d, want %d", in, got, want)
+		}
 	}
 }
 

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func seedImages(t *testing.T, d *db.DB) {
+	t.Helper()
+	images := []db.Image{
+		{
+			SpecID:      "TS 23.501",
+			Name:        "image1.png",
+			MIMEType:    "image/png",
+			Data:        []byte("\x89PNG\r\n\x1a\nfake-png-data"),
+			LLMReadable: true,
+		},
+		{
+			SpecID:      "TS 23.501",
+			Name:        "image2.emf",
+			MIMEType:    "image/x-emf",
+			Data:        []byte("fake-emf-data"),
+			LLMReadable: false,
+		},
+		{
+			SpecID:      "TS 29.510",
+			Name:        "diagram.png",
+			MIMEType:    "image/png",
+			Data:        []byte("\x89PNG\r\n\x1a\nother-spec-data"),
+			LLMReadable: true,
+		},
+	}
+	for _, img := range images {
+		if err := d.UpsertImage(img); err != nil {
+			t.Fatalf("UpsertImage(%s): %v", img.Name, err)
+		}
+	}
+}
+
+func TestHandleListImages(t *testing.T) {
+	d := setupTestDB(t)
+	seedImages(t, d)
+	handler := HandleListImages(d)
+
+	t.Run("valid spec returns images", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 23.501"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected error result: %s", getTextContent(result))
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "image1.png") {
+			t.Errorf("expected image1.png in output, got: %s", text)
+		}
+		if !strings.Contains(text, "image2.emf") {
+			t.Errorf("expected image2.emf in output, got: %s", text)
+		}
+		if !strings.Contains(text, `"count":2`) {
+			t.Errorf("expected count of 2, got: %s", text)
+		}
+	})
+
+	t.Run("filters by spec_id", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 29.510"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "diagram.png") {
+			t.Errorf("expected diagram.png, got: %s", text)
+		}
+		if strings.Contains(text, "image1.png") {
+			t.Errorf("should not contain images from other specs, got: %s", text)
+		}
+	})
+
+	t.Run("empty spec_id", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: ""})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for empty spec_id")
+		}
+	})
+
+	t.Run("spec without images", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 24.229"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "No images found") {
+			t.Errorf("expected 'No images found' message, got: %s", text)
+		}
+	})
+}
+
+func TestHandleGetImage(t *testing.T) {
+	d := setupTestDB(t)
+	seedImages(t, d)
+	handler := HandleGetImage(d)
+
+	t.Run("returns image content", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID: "TS 23.501",
+			Name:   "image1.png",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected error result: %s", getTextContent(result))
+		}
+		if len(result.Content) != 1 {
+			t.Fatalf("expected one content item, got %d", len(result.Content))
+		}
+		ic, ok := result.Content[0].(*mcp.ImageContent)
+		if !ok {
+			t.Fatalf("expected ImageContent, got %T", result.Content[0])
+		}
+		if ic.MIMEType != "image/png" {
+			t.Errorf("MIMEType = %q, want %q", ic.MIMEType, "image/png")
+		}
+		if !strings.Contains(string(ic.Data), "fake-png-data") {
+			t.Errorf("unexpected image data: %q", string(ic.Data))
+		}
+	})
+
+	t.Run("non-readable format returns error", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID: "TS 23.501",
+			Name:   "image2.emf",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for EMF image")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "convert-image") {
+			t.Errorf("expected hint about --convert-image, got: %s", text)
+		}
+	})
+
+	t.Run("missing image", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID: "TS 23.501",
+			Name:   "nonexistent.png",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for missing image")
+		}
+	})
+
+	t.Run("empty spec_id", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{Name: "image1.png"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for empty spec_id")
+		}
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{SpecID: "TS 23.501"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for empty name")
+		}
+	})
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -286,6 +286,68 @@ func TestHandleReferences(t *testing.T) {
 	}
 }
 
+func TestHandleImage(t *testing.T) {
+	ts, d := setupTestServer(t)
+
+	imgData := []byte("\x89PNG\r\n\x1a\nfake-png-bytes")
+	if err := d.UpsertImage(db.Image{
+		SpecID:      "TS 23.501",
+		Name:        "fig1.png",
+		MIMEType:    "image/png",
+		Data:        imgData,
+		LLMReadable: true,
+	}); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	t.Run("returns image bytes with headers", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/specs/TS 23.501/images/fig1.png")
+		if err != nil {
+			t.Fatalf("GET image error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "image/png" {
+			t.Errorf("Content-Type = %q, want image/png", ct)
+		}
+		if cc := resp.Header.Get("Cache-Control"); cc != "public, max-age=86400" {
+			t.Errorf("Cache-Control = %q, want public, max-age=86400", cc)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if string(body) != string(imgData) {
+			t.Errorf("body length = %d, want %d", len(body), len(imgData))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/specs/TS 23.501/images/missing.png")
+		if err != nil {
+			t.Fatalf("GET error: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("not found for unknown spec", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/specs/NONEXISTENT/images/fig1.png")
+		if err != nil {
+			t.Fatalf("GET error: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+}
+
 func TestStaticFiles(t *testing.T) {
 	ts, _ := setupTestServer(t)
 


### PR DESCRIPTION
## Summary
- Add unit tests for converter/docx paragraph, metadata, and table parsers
- Cover list_images / get_image MCP tools and web handleImage handler
- Exercise cmd/3gpp-mcp subcommand dispatch (convert, convert-dir, serve, completion)
- Add pipeline context cancellation and worker-pool tests
