### PR TITLE
test: cover cli, db, pipeline, docx, web edge cases

### DIFF
--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/higebu/3gpp-mcp/db"
 )
 
 func TestBearerAuthMiddleware(t *testing.T) {
@@ -109,5 +117,435 @@ func TestCmdCompletion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// projectRoot returns the path to the repository root by walking up from the
+// current test file location.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..")
+}
+
+// testdataDocxPath returns the path to the shared testdata .docx file.
+func testdataDocxPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(projectRoot(t), "converter", "docx", "testdata", "23274-i20.docx")
+}
+
+// redirectTransport rewrites all request URLs to point at the test server,
+// allowing tests to exercise code that uses the hardcoded pipeline baseURL.
+type redirectTransport struct {
+	base    http.RoundTripper
+	testURL string
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	target, err := url.Parse(rt.testURL + req.URL.Path)
+	if err != nil {
+		return nil, err
+	}
+	req.URL = target
+	return rt.base.RoundTrip(req)
+}
+
+// TestResolveSpecs_FromSpecList verifies resolveSpecs loads and parses a local
+// spec list file, bypassing the 3GPP FTP entirely.
+func TestResolveSpecs_FromSpecList(t *testing.T) {
+	listPath := filepath.Join(t.TempDir(), "list.txt")
+	content := strings.Join([]string{
+		"23_series/23.501/23501-k10.zip",
+		"23_series/23.501/23501-j60.zip",
+		"29_series/29.510/29510-k10.zip",
+		// Blank line and non-matching entry (should be ignored by ParseSpecEntry).
+		"",
+		"not-a-spec-entry",
+	}, "\n")
+	if err := os.WriteFile(listPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write spec list: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		specs := resolveSpecs(
+			context.Background(),
+			&http.Client{},
+			listPath,
+			"",    // specFlag
+			"",    // seriesFlag
+			0,     // release
+			false, // allVersions
+			false, // useCache
+		)
+		if len(specs) == 0 {
+			t.Error("expected at least one spec, got 0")
+		}
+		// latestOnly=true (because allVersions=false), so expect 1 per SpecID.
+		ids := map[string]bool{}
+		for _, s := range specs {
+			ids[s.SpecID] = true
+		}
+		if !ids["23.501"] || !ids["29.510"] {
+			t.Errorf("missing expected spec ids: %+v", ids)
+		}
+	})
+	if !strings.Contains(out, "Loading spec list") {
+		t.Errorf("expected stdout to mention 'Loading spec list', got: %s", out)
+	}
+}
+
+// TestResolveSpecs_FetchBySpecFlag exercises the FetchSpecZips branch with a
+// mock 3GPP server returning a single zip listing.
+func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23501-k10.zip">23501-k10.zip</a>`+"\n")
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL},
+	}
+
+	out := captureStdout(t, func() {
+		specs := resolveSpecs(
+			context.Background(),
+			client,
+			"",       // specList
+			"23.501", // specFlag
+			"",       // seriesFlag
+			0,        // release
+			false,    // allVersions
+			false,    // useCache
+		)
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].SpecID != "23.501" {
+			t.Errorf("SpecID = %q, want 23.501", specs[0].SpecID)
+		}
+	})
+	if !strings.Contains(out, "Fetching versions for 23.501") {
+		t.Errorf("expected progress message, got: %s", out)
+	}
+}
+
+// TestCmdConvert_HappyPath imports a single real 3GPP .docx testdata file via
+// the CLI command wrapper, covering the end-to-end convert → DB path.
+func TestCmdConvert_HappyPath(t *testing.T) {
+	if _, err := os.Stat(testdataDocxPath(t)); err != nil {
+		t.Skipf("testdata .docx not available: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), "out.db")
+
+	out := captureStdout(t, func() {
+		cmdConvert([]string{"-db", dbPath, testdataDocxPath(t)})
+	})
+	if !strings.Contains(out, "Written to") {
+		t.Errorf("expected 'Written to' in stdout, got: %s", out)
+	}
+
+	// Verify the DB actually got populated.
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	result, err := d.ListSpecs("", -1, 0)
+	if err != nil {
+		t.Fatalf("list specs: %v", err)
+	}
+	if len(result.Specs) == 0 {
+		t.Error("expected at least one spec inserted")
+	}
+}
+
+// TestCmdConvertDir_HappyPath imports a directory containing the shared
+// testdata .docx file, covering the directory walk and multi-file pipeline.
+func TestCmdConvertDir_HappyPath(t *testing.T) {
+	srcDocx := testdataDocxPath(t)
+	if _, err := os.Stat(srcDocx); err != nil {
+		t.Skipf("testdata .docx not available: %v", err)
+	}
+	docxBytes, err := os.ReadFile(srcDocx)
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "23274-i20.docx"), docxBytes, 0o644); err != nil {
+		t.Fatalf("write docx: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), "dir.db")
+
+	_ = captureStdout(t, func() {
+		cmdConvertDir([]string{"-db", dbPath, "-parse-workers", "1", dir})
+	})
+
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	result, err := d.ListSpecs("", -1, 0)
+	if err != nil {
+		t.Fatalf("list specs: %v", err)
+	}
+	if len(result.Specs) == 0 {
+		t.Error("expected at least one spec inserted")
+	}
+}
+
+// TestCmdDownload_NoMatch verifies cmdDownload cleanly returns when the spec
+// list yields zero specs after filtering (exercises flag parsing, resolveSpecs
+// file-load branch, and the early return path).
+func TestCmdDownload_NoMatch(t *testing.T) {
+	listPath := filepath.Join(t.TempDir(), "list.txt")
+	if err := os.WriteFile(listPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write list: %v", err)
+	}
+	outDir := filepath.Join(t.TempDir(), "out")
+
+	out := captureStdout(t, func() {
+		cmdDownload([]string{
+			"-all",
+			"-spec-list", listPath,
+			"-output-dir", outDir,
+			"-no-cache",
+		})
+	})
+	if !strings.Contains(out, "No specs matched") {
+		t.Errorf("expected 'No specs matched' message, got: %s", out)
+	}
+}
+
+// TestCmdPipeline_NoMatch verifies cmdPipeline returns cleanly when the spec
+// list yields zero specs after filtering.
+func TestCmdPipeline_NoMatch(t *testing.T) {
+	listPath := filepath.Join(t.TempDir(), "list.txt")
+	if err := os.WriteFile(listPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write list: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), "pipeline.db")
+
+	out := captureStdout(t, func() {
+		cmdPipeline([]string{
+			"-all",
+			"-db", dbPath,
+			"-spec-list", listPath,
+			"-no-cache",
+		})
+	})
+	if !strings.Contains(out, "No specs matched") {
+		t.Errorf("expected 'No specs matched' message, got: %s", out)
+	}
+	// DB should still have been opened and schema initialized.
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Errorf("expected db file to exist: %v", err)
+	}
+}
+
+// TestCmdUpdate_EmptyDB verifies cmdUpdate prints the "no specs in database"
+// message when the database is empty (ListSpecs returns zero rows).
+func TestCmdUpdate_EmptyDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update.db")
+	// Pre-create the DB with schema but no rows, to exercise the normal
+	// ListSpecs path rather than a missing-table error path.
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	d.Close()
+
+	out := captureStdout(t, func() {
+		cmdUpdate([]string{"-db", dbPath})
+	})
+	if !strings.Contains(out, "No specs in database") {
+		t.Errorf("expected 'No specs in database' message, got: %s", out)
+	}
+}
+
+// TestCmdCompletion_UnknownShell exercises the os.Exit(1) path of cmdCompletion
+// by re-executing the test binary as a subprocess so the exit does not abort
+// the parent test process.
+func TestCmdCompletion_UnknownShell(t *testing.T) {
+	if os.Getenv("CMD_COMPLETION_UNKNOWN_HELPER") == "1" {
+		cmdCompletion([]string{"powershell"})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdCompletion_UnknownShell")
+	cmd.Env = append(os.Environ(), "CMD_COMPLETION_UNKNOWN_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit for unknown shell")
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 1 {
+			t.Errorf("exit code = %d, want 1", exitErr.ExitCode())
+		}
+	}
+	if !strings.Contains(string(stderr), "Unknown shell") {
+		t.Errorf("expected stderr to mention 'Unknown shell', got: %s", stderr)
+	}
+}
+
+// TestMainDispatch_UnknownCommand exercises the os.Exit(1) unknown-command
+// path of main() via subprocess.
+func TestMainDispatch_UnknownCommand(t *testing.T) {
+	if os.Getenv("MAIN_UNKNOWN_HELPER") == "1" {
+		os.Args = []string{"3gpp-mcp", "bogus-command"}
+		main()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainDispatch_UnknownCommand")
+	cmd.Env = append(os.Environ(), "MAIN_UNKNOWN_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit for unknown command")
+	}
+	if !strings.Contains(string(stderr), "Unknown command") {
+		t.Errorf("expected stderr to mention 'Unknown command', got: %s", stderr)
+	}
+}
+
+// TestMainDispatch_NoArgs covers the "no command" path of main(), which prints
+// a usage line and exits with code 1.
+func TestMainDispatch_NoArgs(t *testing.T) {
+	if os.Getenv("MAIN_NOARGS_HELPER") == "1" {
+		os.Args = []string{"3gpp-mcp"}
+		main()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainDispatch_NoArgs")
+	cmd.Env = append(os.Environ(), "MAIN_NOARGS_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when no command given")
+	}
+	if !strings.Contains(string(stderr), "Usage:") {
+		t.Errorf("expected stderr to mention 'Usage:', got: %s", stderr)
+	}
+}
+
+// TestResolveSpecs_FetchAllSeries exercises the third branch of resolveSpecs
+// (full FTP scrape) with a mock server simulating the 3-level directory layout.
+func TestResolveSpecs_FetchAllSeries(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ftp/Specs/archive/" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc("/ftp/Specs/archive/23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23.501/">23.501</a>`+"\n")
+	})
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23501-k10.zip">23501-k10.zip</a>`+"\n")
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL},
+	}
+
+	_ = captureStdout(t, func() {
+		specs := resolveSpecs(
+			context.Background(),
+			client,
+			"",    // specList
+			"",    // specFlag
+			"23",  // seriesFlag
+			0,     // release
+			false, // allVersions (latestOnly=true)
+			false, // useCache
+		)
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].SpecID != "23.501" {
+			t.Errorf("SpecID = %q, want 23.501", specs[0].SpecID)
+		}
+	})
+}
+
+// TestCmdUpdate_AllUpToDate verifies cmdUpdate's happy path when the spec-list
+// file only mentions specs already at or older than the DB versions, exercising
+// FilterSpecs, the normalizeID mapping, and the "All specs are up to date"
+// branch without triggering any downloads.
+func TestCmdUpdate_AllUpToDate(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update.db")
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if err := d.UpsertSpec(db.Spec{
+		ID:      "TS 23.501",
+		Title:   "System architecture",
+		Version: "k10",
+		Release: "Rel-20",
+		Series:  "23",
+	}); err != nil {
+		t.Fatalf("upsert spec: %v", err)
+	}
+	d.Close()
+
+	// Provide a spec-list with an OLDER version of the same spec. FilterSpecs
+	// with latestOnly=true picks j60; cmdUpdate then sees j60 < k10 and prints
+	// "All specs are up to date.".
+	listPath := filepath.Join(t.TempDir(), "list.txt")
+	if err := os.WriteFile(listPath, []byte("23_series/23.501/23501-j60.zip\n"), 0o644); err != nil {
+		t.Fatalf("write list: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdUpdate([]string{"-db", dbPath, "-spec-list", listPath})
+	})
+	if !strings.Contains(out, "All specs are up to date") {
+		t.Errorf("expected 'All specs are up to date' message, got: %s", out)
+	}
+}
+
+// TestCmdCompletion_NoArgs covers the os.Exit(1) no-args path via subprocess.
+func TestCmdCompletion_NoArgs(t *testing.T) {
+	if os.Getenv("CMD_COMPLETION_NOARGS_HELPER") == "1" {
+		cmdCompletion(nil)
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdCompletion_NoArgs")
+	cmd.Env = append(os.Environ(), "CMD_COMPLETION_NOARGS_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when completion called without shell arg")
+	}
+	if !strings.Contains(string(stderr), "Usage:") {
+		t.Errorf("expected Usage: message, got: %s", stderr)
+	}
+}
+
+// TestMainDispatch_CompletionBash exercises the happy-path completion
+// subcommand via main() dispatch, ensuring command routing works end-to-end.
+func TestMainDispatch_CompletionBash(t *testing.T) {
+	if os.Getenv("MAIN_COMPLETION_HELPER") == "1" {
+		os.Args = []string{"3gpp-mcp", "completion", "bash"}
+		main()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainDispatch_CompletionBash")
+	cmd.Env = append(os.Environ(), "MAIN_COMPLETION_HELPER=1")
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("main dispatch failed: %v", err)
+	}
+	if !strings.Contains(string(stdout), "_3gpp_mcp") {
+		t.Errorf("expected bash completion output, got: %s", stdout)
 	}
 }

--- a/converter/docx/markdown_test.go
+++ b/converter/docx/markdown_test.go
@@ -1,0 +1,37 @@
+package docx
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSectionsToMarkdown covers the slice-level helper; the single-section
+// counterpart is tested in parser_test.go.
+func TestSectionsToMarkdown(t *testing.T) {
+	sections := []*Section{
+		{Number: "1", Title: "Scope", Level: 1, Content: []string{"Scope body."}},
+		{Number: "5", Title: "Architecture", Level: 1, Content: []string{"Arch body."}},
+		{Number: "5.1", Title: "General", Level: 2, Content: []string{"General body."}},
+	}
+	got := SectionsToMarkdown(sections)
+	for _, want := range []string{
+		"# 1 Scope",
+		"Scope body.",
+		"# 5 Architecture",
+		"## 5.1 General",
+		"General body.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestSectionsToMarkdown_Empty(t *testing.T) {
+	if got := SectionsToMarkdown(nil); got != "" {
+		t.Errorf("expected empty string for nil sections, got: %q", got)
+	}
+	if got := SectionsToMarkdown([]*Section{}); got != "" {
+		t.Errorf("expected empty string for empty slice, got: %q", got)
+	}
+}

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -285,6 +285,42 @@ func TestParseDocx_26274(t *testing.T) {
 	t.Logf("Parsed %d sections from %s", len(sections), metadata.SpecID)
 }
 
+// TestParseDocxFromBytes covers the byte-slice entrypoint alongside ParseDocx,
+// exercising the in-memory code path without touching the filesystem loader.
+func TestParseDocxFromBytes(t *testing.T) {
+	data, err := os.ReadFile(testdataPath("23274-i20.docx"))
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+
+	t.Run("valid docx", func(t *testing.T) {
+		result, err := ParseDocxFromBytes(data, "23274-i20.docx")
+		if err != nil {
+			t.Fatalf("ParseDocxFromBytes: %v", err)
+		}
+		if result.Metadata.SpecID != "TS 23.274" {
+			t.Errorf("SpecID = %q, want TS 23.274", result.Metadata.SpecID)
+		}
+		if len(result.Sections) == 0 {
+			t.Error("expected at least one parsed section")
+		}
+	})
+
+	t.Run("empty bytes", func(t *testing.T) {
+		_, err := ParseDocxFromBytes(nil, "empty.docx")
+		if err == nil {
+			t.Fatal("expected error for empty bytes")
+		}
+	})
+
+	t.Run("garbage bytes", func(t *testing.T) {
+		_, err := ParseDocxFromBytes([]byte("not a zip"), "bogus.docx")
+		if err == nil {
+			t.Fatal("expected error for non-zip payload")
+		}
+	})
+}
+
 // TestParseDocx_22839 exercises parsing of TS 22.839, which uses Strict OOXML
 // namespaces (purl.oclc.org/ooxml). Go's xml.Decoder only uses Name.Local and
 // the parser reads ZIP entries by fixed paths, so Strict OOXML files are parsed

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -158,3 +158,141 @@ func TestTableToMarkdown_NoTable(t *testing.T) {
 		t.Errorf("expected empty markdown for invalid input, got %q", md)
 	}
 }
+
+// TestExtractTableRows_GridSpanMergedCells pins down current behaviour for
+// tables with horizontally merged cells (w:gridSpan). 3GPP protocol flow
+// tables rely on gridSpan for header rows, so this documents how the parser
+// treats them today — if the behaviour changes, review the diff carefully.
+func TestExtractTableRows_GridSpanMergedCells(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr>
+			<w:tc>
+				<w:tcPr><w:gridSpan w:val="2"/></w:tcPr>
+				<w:p><w:r><w:t>merged-header</w:t></w:r></w:p>
+			</w:tc>
+		</w:tr>
+		<w:tr>
+			<w:tc><w:p><w:r><w:t>a1</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>a2</w:t></w:r></w:p></w:tc>
+		</w:tr>
+	</w:tbl>`
+
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0][0] != "merged-header" {
+		t.Errorf("row[0] cell[0] = %q, want 'merged-header'", rows[0][0])
+	}
+	if len(rows[1]) != 2 || rows[1][0] != "a1" || rows[1][1] != "a2" {
+		t.Errorf("row[1] = %v, want [a1 a2]", rows[1])
+	}
+}
+
+// TestExtractTableRows_VMergedCells pins down behaviour for vertically merged
+// cells (w:vMerge). The parser currently treats continuation cells as empty.
+func TestExtractTableRows_VMergedCells(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr>
+			<w:tc>
+				<w:tcPr><w:vMerge w:val="restart"/></w:tcPr>
+				<w:p><w:r><w:t>top</w:t></w:r></w:p>
+			</w:tc>
+			<w:tc><w:p><w:r><w:t>r1</w:t></w:r></w:p></w:tc>
+		</w:tr>
+		<w:tr>
+			<w:tc>
+				<w:tcPr><w:vMerge/></w:tcPr>
+				<w:p/>
+			</w:tc>
+			<w:tc><w:p><w:r><w:t>r2</w:t></w:r></w:p></w:tc>
+		</w:tr>
+	</w:tbl>`
+
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0][0] != "top" || rows[0][1] != "r1" {
+		t.Errorf("row[0] = %v, want [top r1]", rows[0])
+	}
+	// The continuation row has an empty first cell (current behaviour, pinned).
+	if rows[1][0] != "" || rows[1][1] != "r2" {
+		t.Errorf("row[1] = %v, want ['' r2]", rows[1])
+	}
+}
+
+// TestExtractTableRows_VaryingRowWidths verifies the parser accepts rows with
+// differing cell counts without panicking, and that rowsToMarkdown pads/trims
+// to the header width when rendering.
+func TestExtractTableRows_VaryingRowWidths(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr>
+			<w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>H2</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>H3</w:t></w:r></w:p></w:tc>
+		</w:tr>
+		<w:tr>
+			<w:tc><w:p><w:r><w:t>only-one</w:t></w:r></w:p></w:tc>
+		</w:tr>
+		<w:tr>
+			<w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>c</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>extra</w:t></w:r></w:p></w:tc>
+		</w:tr>
+	</w:tbl>`
+
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	md := rowsToMarkdown(rows)
+	// Header defines width=3, so the single-cell row pads to 3 and the 4-cell
+	// row truncates to 3.
+	for _, want := range []string{
+		"| H1 | H2 | H3 |",
+		"| only-one |  |  |",
+		"| a | b | c |",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected markdown to contain %q, got:\n%s", want, md)
+		}
+	}
+	if strings.Contains(md, "extra") {
+		t.Errorf("expected extra cell to be dropped, got:\n%s", md)
+	}
+}
+
+// TestExtractTableRows_StyledHeaderRow exercises a header row with tblHeader
+// styling applied via tcPr — the parser should still include it as row[0].
+func TestExtractTableRows_StyledHeaderRow(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr>
+			<w:trPr><w:tblHeader/></w:trPr>
+			<w:tc>
+				<w:tcPr><w:shd w:fill="D9D9D9"/></w:tcPr>
+				<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Name</w:t></w:r></w:p>
+			</w:tc>
+			<w:tc>
+				<w:tcPr><w:shd w:fill="D9D9D9"/></w:tcPr>
+				<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Value</w:t></w:r></w:p>
+			</w:tc>
+		</w:tr>
+		<w:tr>
+			<w:tc><w:p><w:r><w:t>k1</w:t></w:r></w:p></w:tc>
+			<w:tc><w:p><w:r><w:t>v1</w:t></w:r></w:p></w:tc>
+		</w:tr>
+	</w:tbl>`
+
+	rows := extractTableRows([]byte(xml))
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0][0] != "Name" || rows[0][1] != "Value" {
+		t.Errorf("header row = %v, want [Name Value]", rows[0])
+	}
+	if rows[1][0] != "k1" || rows[1][1] != "v1" {
+		t.Errorf("data row = %v, want [k1 v1]", rows[1])
+	}
+}

--- a/converter/pipeline/cache_test.go
+++ b/converter/pipeline/cache_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,5 +93,63 @@ func TestLoadCache_Missing(t *testing.T) {
 	}
 	if loaded != nil {
 		t.Error("expected nil for missing cache")
+	}
+}
+
+// TestCacheDir covers the two branches of cacheDir: XDG_CACHE_HOME set and
+// unset (falls back to $HOME/.cache/3gpp-mcp).
+func TestCacheDir(t *testing.T) {
+	t.Run("with XDG_CACHE_HOME", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", "/tmp/xdg-test")
+		dir, err := cacheDir()
+		if err != nil {
+			t.Fatalf("cacheDir: %v", err)
+		}
+		want := "/tmp/xdg-test/3gpp-mcp"
+		if dir != want {
+			t.Errorf("cacheDir = %q, want %q", dir, want)
+		}
+	})
+
+	t.Run("falls back to home .cache", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", "")
+		dir, err := cacheDir()
+		if err != nil {
+			// On systems where UserHomeDir fails the function should return
+			// an error; either outcome is acceptable as long as we exercised
+			// the code path.
+			return
+		}
+		if !strings.HasSuffix(dir, "/3gpp-mcp") {
+			t.Errorf("cacheDir = %q, want suffix /3gpp-mcp", dir)
+		}
+		if !strings.Contains(dir, ".cache") {
+			t.Errorf("cacheDir = %q, want to contain .cache", dir)
+		}
+	})
+}
+
+// TestSaveCache_CreatesDir verifies SaveCache creates the cache directory
+// even when the parent does not yet exist, exercising the mkdir path.
+func TestSaveCache_CreatesDir(t *testing.T) {
+	// Point cache at a brand-new subdirectory inside t.TempDir().
+	root := filepath.Join(t.TempDir(), "freshxdg")
+	t.Setenv("XDG_CACHE_HOME", root)
+
+	if err := SaveCache(CacheKey("create"), []string{"only-entry"}); err != nil {
+		t.Fatalf("SaveCache: %v", err)
+	}
+
+	cacheDirPath := filepath.Join(root, "3gpp-mcp")
+	if _, err := os.Stat(cacheDirPath); err != nil {
+		t.Errorf("expected cache dir created: %v", err)
+	}
+
+	loaded, err := LoadCache(CacheKey("create"), time.Hour)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0] != "only-entry" {
+		t.Errorf("round trip = %v, want [only-entry]", loaded)
 	}
 }

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -1,9 +1,15 @@
 package pipeline
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -47,5 +53,169 @@ func TestDownloadSpecs_Race(t *testing.T) {
 	}
 	if stats["OK"] == 0 {
 		t.Errorf("expected at least one OK result, got stats: %v", stats)
+	}
+}
+
+// makeRawZipEntry constructs a zip archive bytes containing a single entry
+// whose name may include path traversal or absolute path characters. Used to
+// exercise the extractFile path-traversal guard.
+func makeRawZipEntry(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.CreateHeader(&zip.FileHeader{Name: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestExtractFile_PathTraversal verifies that extractFile rejects zip entries
+// whose names contain "..", preventing path-traversal writes outside outputDir.
+func TestExtractFile_PathTraversal(t *testing.T) {
+	zipBytes := makeRawZipEntry(t, "../evil.docx", []byte("pwned"))
+	r, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "out.docx")
+	err = extractFile(r.File[0], target)
+	if err == nil {
+		t.Fatal("expected path traversal error")
+	}
+	if !strings.Contains(err.Error(), "suspicious") {
+		t.Errorf("error = %v, want 'suspicious'", err)
+	}
+}
+
+// TestExtractFile_Normal covers the happy path of extractFile.
+func TestExtractFile_Normal(t *testing.T) {
+	zipBytes := makeRawZipEntry(t, "ok.docx", []byte("contents"))
+	r, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "ok.docx")
+	if err := extractFile(r.File[0], target); err != nil {
+		t.Fatalf("extractFile: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "contents" {
+		t.Errorf("file content = %q, want 'contents'", data)
+	}
+}
+
+// TestDownloadAndExtract_DocOnly verifies the DOC_ONLY status path: the ZIP
+// contains a .doc file but no .docx file.
+func TestDownloadAndExtract_DocOnly(t *testing.T) {
+	zipBytes := makeZipWithFile(t, "spec.doc", []byte("legacy doc content"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	}))
+	defer ts.Close()
+
+	outDir := t.TempDir()
+	spec := &SpecVersion{SpecID: "TS 99.001", URL: ts.URL + "/x.zip"}
+	result, err := DownloadAndExtract(context.Background(), ts.Client(), spec, outDir, 5*time.Second)
+	if err != nil {
+		t.Fatalf("DownloadAndExtract: %v", err)
+	}
+	if result.Status != "DOC_ONLY" {
+		t.Errorf("status = %q, want DOC_ONLY", result.Status)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "_doc_files", "spec.doc")); err != nil {
+		t.Errorf("expected spec.doc in _doc_files: %v", err)
+	}
+}
+
+// TestDownloadAndExtract_NoDoc verifies the NO_DOC status when the ZIP holds
+// only irrelevant files.
+func TestDownloadAndExtract_NoDoc(t *testing.T) {
+	zipBytes := makeZipWithFile(t, "readme.txt", []byte("just metadata"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	}))
+	defer ts.Close()
+
+	spec := &SpecVersion{SpecID: "TS 99.002", URL: ts.URL + "/y.zip"}
+	result, err := DownloadAndExtract(context.Background(), ts.Client(), spec, t.TempDir(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("DownloadAndExtract: %v", err)
+	}
+	if result.Status != "NO_DOC" {
+		t.Errorf("status = %q, want NO_DOC", result.Status)
+	}
+}
+
+// TestDownloadZip_TooLargeContentLength verifies the early rejection path when
+// the server advertises a Content-Length that exceeds maxZipSize.
+func TestDownloadZip_TooLargeContentLength(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(maxZipSize+1, 10))
+		w.Header().Set("Content-Type", "application/zip")
+		// Body intentionally empty; we expect early rejection via header.
+	}))
+	defer ts.Close()
+
+	_, err := downloadZip(context.Background(), ts.Client(), ts.URL)
+	if err == nil {
+		t.Fatal("expected error for oversized content-length")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error = %v, want 'too large'", err)
+	}
+}
+
+// TestDownloadZip_HTTPError verifies the non-200 response path returns a clean
+// error without retrying at this layer.
+func TestDownloadZip_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	_, err := downloadZip(context.Background(), ts.Client(), ts.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error = %v, want 'HTTP 500'", err)
+	}
+}
+
+// TestConvertDocFiles_NoDocFiles verifies ConvertDocFiles returns (0, nil)
+// when the directory contains no .doc files (happy but trivial path).
+func TestConvertDocFiles_NoDocFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Add a non-doc file to prove it's ignored.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	n, err := ConvertDocFiles(context.Background(), dir, dir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("converted = %d, want 0", n)
+	}
+}
+
+// TestConvertDocFiles_MissingDir verifies the error path when the input
+// directory does not exist.
+func TestConvertDocFiles_MissingDir(t *testing.T) {
+	_, err := ConvertDocFiles(context.Background(), filepath.Join(t.TempDir(), "nope"), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for missing directory")
 	}
 }

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -375,6 +375,62 @@ func TestConvertDir_MissingDir(t *testing.T) {
 	}
 }
 
+// TestConvertSingleFile exercises the ConvertSingleFile public API end to end
+// using the shared testdata .docx file, verifying that the spec, sections,
+// and derived release number all land in the target database.
+func TestConvertSingleFile(t *testing.T) {
+	docxPath := testdataDocxPath(t)
+	if _, err := os.Stat(docxPath); err != nil {
+		t.Skipf("testdata docx not available: %v", err)
+	}
+	d := setupTestDB(t)
+
+	if err := ConvertSingleFile(context.Background(), d, docxPath, false); err != nil {
+		t.Fatalf("ConvertSingleFile: %v", err)
+	}
+
+	// Parser pulls spec ID from metadata; testdata file is TS 23.274.
+	sections, err := d.GetTOC("TS 23.274")
+	if err != nil {
+		t.Fatalf("GetTOC: %v", err)
+	}
+	if len(sections) == 0 {
+		t.Error("expected sections for TS 23.274 after ConvertSingleFile")
+	}
+
+	specs, err := d.ListSpecs("", -1, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	found := false
+	for _, s := range specs.Specs {
+		if s.ID == "TS 23.274" {
+			found = true
+			// releaseFromDocxFilename derives release from the i-prefix.
+			if s.Release != "18" {
+				t.Errorf("Release = %q, want 18", s.Release)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("TS 23.274 missing from ListSpecs result")
+	}
+}
+
+// TestConvertSingleFile_BadPath verifies the error path when the docx file
+// cannot be parsed (missing file).
+func TestConvertSingleFile_BadPath(t *testing.T) {
+	d := setupTestDB(t)
+	err := ConvertSingleFile(context.Background(), d, filepath.Join(t.TempDir(), "missing.docx"), false)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error = %v, want to contain 'parse'", err)
+	}
+}
+
 // TestReleaseFromDocxFilename pins down the version-letter → release mapping
 // used to populate the Release column when importing single files.
 func TestReleaseFromDocxFilename(t *testing.T) {

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -158,6 +161,95 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 	}
 	req.URL = target
 	return rt.base.RoundTrip(req)
+}
+
+// TestLoadSpecList covers the file-loading branch: skips blank lines,
+// trims whitespace, and surfaces scanner errors as they arise.
+func TestLoadSpecList(t *testing.T) {
+	t.Run("reads entries and skips blanks", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "list.txt")
+		data := "23_series/23.501/23501-k10.zip\n" +
+			"\n" +
+			"  29_series/29.510/29510-k10.zip  \n" +
+			"\t\n" +
+			"36_series/36.133/36133-j40.zip\n"
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		entries, err := LoadSpecList(path)
+		if err != nil {
+			t.Fatalf("LoadSpecList: %v", err)
+		}
+		want := []string{
+			"23_series/23.501/23501-k10.zip",
+			"29_series/29.510/29510-k10.zip",
+			"36_series/36.133/36133-j40.zip",
+		}
+		if len(entries) != len(want) {
+			t.Fatalf("got %d entries, want %d: %v", len(entries), len(want), entries)
+		}
+		for i, e := range entries {
+			if e != want[i] {
+				t.Errorf("entries[%d] = %q, want %q", i, e, want[i])
+			}
+		}
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		_, err := LoadSpecList(filepath.Join(t.TempDir(), "nope.txt"))
+		if err == nil {
+			t.Error("expected error for missing file")
+		}
+	})
+}
+
+// TestFetchSpecZips exercises the single-spec zip listing endpoint against a
+// mock 3GPP archive, covering both the dotted and undotted specID shapes.
+func TestFetchSpecZips(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23501-k10.zip">23501-k10.zip</a>`+"\n"+
+			`<a href="23501-j60.zip">23501-j60.zip</a>`+"\n"+
+			`<a href="README.txt">README.txt</a>`+"\n")
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL},
+	}
+
+	t.Run("dotted specID", func(t *testing.T) {
+		entries, err := FetchSpecZips(context.Background(), client, "23.501", false)
+		if err != nil {
+			t.Fatalf("FetchSpecZips: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("got %d zips, want 2: %v", len(entries), entries)
+		}
+		for _, e := range entries {
+			if !strings.HasPrefix(e, "23_series/23.501/") {
+				t.Errorf("entry missing series/spec prefix: %q", e)
+			}
+		}
+	})
+
+	t.Run("undotted specID normalized", func(t *testing.T) {
+		entries, err := FetchSpecZips(context.Background(), client, "23501", false)
+		if err != nil {
+			t.Fatalf("FetchSpecZips: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(entries))
+		}
+	})
+
+	t.Run("invalid specID", func(t *testing.T) {
+		_, err := FetchSpecZips(context.Background(), client, "bogus", false)
+		if err == nil {
+			t.Error("expected error for malformed spec ID")
+		}
+	})
 }
 
 // TestFetchSpecList_Race exercises FetchSpecList with a mock 3GPP directory

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -850,3 +850,298 @@ func TestInsertSpecWithSections_BracketedRefs(t *testing.T) {
 		t.Errorf("missing expected bracket references: %v, got refs: %+v", expect, refs)
 	}
 }
+
+// TestOpen_ReadOnly verifies the public Open constructor returns a working
+// handle that can query previously persisted data.
+func TestOpen_ReadOnly(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "readonly.db")
+
+	// Seed the database in read-write mode first.
+	rw, err := OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadWrite: %v", err)
+	}
+	if err := rw.InitSchema(); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := rw.UpsertSpec(Spec{ID: "TS 23.501", Title: "Arch", Series: "23"}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	rw.Close()
+
+	// Re-open through the Open entrypoint and verify queries still work.
+	ro, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ro.Close()
+
+	result, err := ro.ListSpecs("", 0, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].ID != "TS 23.501" {
+		t.Errorf("expected TS 23.501, got %+v", result.Specs)
+	}
+}
+
+// TestInitSchema_FreshDB covers the public InitSchema entrypoint that the CLI
+// commands use, separate from the ExecScript(Schema) shortcut used in tests.
+func TestInitSchema_FreshDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "init.db")
+	d, err := OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadWrite: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	// Calling InitSchema twice should be idempotent.
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("InitSchema (second call): %v", err)
+	}
+
+	// Verify all expected tables exist by running a probe query on each.
+	for _, table := range []string{"specs", "sections", "sections_fts", "images", "openapi_specs", "spec_references"} {
+		if err := d.Exec("SELECT 1 FROM " + table + " WHERE 0 = 1"); err != nil {
+			t.Errorf("table %q missing or query failed: %v", table, err)
+		}
+	}
+}
+
+// TestExec_DirectSQL covers the exported Exec helper used for ad-hoc writes.
+func TestExec_DirectSQL(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Insert a new spec via Exec directly.
+	if err := d.Exec(
+		"INSERT INTO specs (id, title, series) VALUES (?, ?, ?)",
+		"TS 99.123", "Exec-inserted", "99",
+	); err != nil {
+		t.Fatalf("Exec insert: %v", err)
+	}
+
+	result, err := d.ListSpecs("99", 0, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].ID != "TS 99.123" {
+		t.Errorf("expected TS 99.123 in series 99, got %+v", result.Specs)
+	}
+
+	// An invalid statement should surface an error.
+	if err := d.Exec("NOT VALID SQL"); err == nil {
+		t.Error("expected error for invalid SQL")
+	}
+}
+
+// TestUpsertSpec_Replaces verifies that UpsertSpec overwrites an existing row
+// with the new fields (INSERT OR REPLACE behavior).
+func TestUpsertSpec_Replaces(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Existing spec from seed data: TS 23.501 version 18.6.0
+	if err := d.UpsertSpec(Spec{
+		ID: "TS 23.501", Title: "Updated", Version: "k10", Release: "Rel-20", Series: "23",
+	}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+
+	result, err := d.ListSpecs("", 0, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	var found *Spec
+	for i := range result.Specs {
+		if result.Specs[i].ID == "TS 23.501" {
+			found = &result.Specs[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("TS 23.501 missing after upsert")
+	}
+	if found.Title != "Updated" || found.Version != "k10" || found.Release != "Rel-20" {
+		t.Errorf("upsert did not overwrite fields: %+v", found)
+	}
+}
+
+// TestUpsertSection_ReplacesContent verifies UpsertSection deletes and
+// re-inserts a section, and that the FTS index is updated accordingly.
+func TestUpsertSection_ReplacesContent(t *testing.T) {
+	d := setupTestDB(t)
+
+	// TS 23.501 section 1 seed content talks about "system architecture".
+	// Replace it with completely unrelated content and confirm the FTS row
+	// follows suit.
+	if err := d.UpsertSection(Section{
+		SpecID:  "TS 23.501",
+		Number:  "1",
+		Title:   "Scope",
+		Level:   1,
+		Content: "Completely new scope content about zucchini and tomatoes.",
+	}); err != nil {
+		t.Fatalf("UpsertSection: %v", err)
+	}
+
+	sections, err := d.GetSection("TS 23.501", "1", false)
+	if err != nil {
+		t.Fatalf("GetSection: %v", err)
+	}
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if !strings.Contains(sections[0].Content, "zucchini") {
+		t.Errorf("content not replaced: %q", sections[0].Content)
+	}
+
+	// FTS should pick up the new token.
+	results, err := d.Search("zucchini", []string{"TS 23.501"}, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected FTS hit for zucchini after upsert")
+	}
+}
+
+// TestImageCRUD exercises the image public API end to end: UpsertImage,
+// GetImage, and ListImages.
+func TestImageCRUD(t *testing.T) {
+	d := setupTestDB(t)
+
+	payload := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad}
+	img := Image{
+		SpecID:      "TS 23.501",
+		Name:        "fig1.png",
+		MIMEType:    "image/png",
+		Data:        payload,
+		LLMReadable: true,
+	}
+	if err := d.UpsertImage(img); err != nil {
+		t.Fatalf("UpsertImage: %v", err)
+	}
+
+	// UpsertImage again should replace cleanly.
+	img.MIMEType = "image/png"
+	if err := d.UpsertImage(img); err != nil {
+		t.Fatalf("UpsertImage (replace): %v", err)
+	}
+
+	got, err := d.GetImage("TS 23.501", "fig1.png")
+	if err != nil {
+		t.Fatalf("GetImage: %v", err)
+	}
+	if got == nil || got.Name != "fig1.png" || got.MIMEType != "image/png" {
+		t.Errorf("GetImage returned %+v", got)
+	}
+	if !got.LLMReadable {
+		t.Error("LLMReadable flag lost")
+	}
+	if len(got.Data) != len(payload) {
+		t.Errorf("image bytes length = %d, want %d", len(got.Data), len(payload))
+	}
+
+	// Missing image.
+	if _, err := d.GetImage("TS 23.501", "missing.png"); err == nil {
+		t.Error("expected error for missing image")
+	}
+
+	// ListImages returns only the inserted image.
+	infos, err := d.ListImages("TS 23.501")
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Name != "fig1.png" {
+		t.Errorf("ListImages = %+v, want [fig1.png]", infos)
+	}
+
+	// Empty spec → empty result.
+	infos, err = d.ListImages("TS 00.000")
+	if err != nil {
+		t.Fatalf("ListImages empty: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Errorf("expected empty list, got %+v", infos)
+	}
+}
+
+// TestGetBracketMap covers the DB helper that reads the References section and
+// returns a [N] -> spec map, plus its nil return for specs without one.
+func TestGetBracketMap(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Insert a References section into TS 23.501.
+	if err := d.UpsertSection(Section{
+		SpecID: "TS 23.501", Number: "2", Title: "References", Level: 1,
+		Content: "## 2 References\n\n[1]\t3GPP TS 29.510: \"NRF\"\n[2]\t3GPP TR 23.700: \"Study\"",
+	}); err != nil {
+		t.Fatalf("UpsertSection: %v", err)
+	}
+
+	m, err := d.GetBracketMap("TS 23.501")
+	if err != nil {
+		t.Fatalf("GetBracketMap: %v", err)
+	}
+	if m["1"] != "TS 29.510" {
+		t.Errorf("bracket [1] = %q, want TS 29.510", m["1"])
+	}
+	if m["2"] != "TR 23.700" {
+		t.Errorf("bracket [2] = %q, want TR 23.700", m["2"])
+	}
+
+	// TS 29.510 has no References section in seed data → expect nil.
+	m2, err := d.GetBracketMap("TS 29.510")
+	if err != nil {
+		t.Fatalf("GetBracketMap empty: %v", err)
+	}
+	if m2 != nil {
+		t.Errorf("expected nil bracket map for spec without References section, got %+v", m2)
+	}
+}
+
+// TestInsertSpecWithSections_MultiSectionRefs covers the
+// tsMultiPrefixSpecSections and tsMultiSpecSections extractors (both 0%
+// covered until now) by inserting content with the multi-section patterns and
+// asserting ExtractReferences fanned out one reference per section.
+func TestInsertSpecWithSections_MultiSectionRefs(t *testing.T) {
+	d := setupTestDB(t)
+
+	spec := Spec{ID: "TS 99.003", Title: "Multi Section Refs Test", Series: "99"}
+	sections := []Section{
+		{
+			SpecID: "TS 99.003", Number: "5", Title: "Procedures", Level: 1,
+			Content: "The behavior is described in clauses 8.2 and 16.11 of TS 23.402 for roaming scenarios.\n" +
+				"See also TS 29.510 clauses 5.1 and 6.3 for NRF-specific behavior.",
+		},
+	}
+	if err := d.InsertSpecWithSections(spec, sections); err != nil {
+		t.Fatalf("InsertSpecWithSections: %v", err)
+	}
+
+	refs, err := d.GetReferences("TS 99.003", "5", "outgoing", false)
+	if err != nil {
+		t.Fatalf("GetReferences: %v", err)
+	}
+
+	// Collect (spec, section) pairs.
+	got := make(map[string]bool)
+	for _, r := range refs {
+		got[r.TargetSpec+"#"+r.TargetSection] = true
+	}
+
+	// tsMultiPrefixRefRE should have produced both sections of TS 23.402.
+	for _, want := range []string{"TS 23.402#8.2", "TS 23.402#16.11"} {
+		if !got[want] {
+			t.Errorf("missing multi-prefix ref %s; got: %+v", want, refs)
+		}
+	}
+	// tsMultiRefRE should have produced both sections of TS 29.510.
+	for _, want := range []string{"TS 29.510#5.1", "TS 29.510#6.3"} {
+		if !got[want] {
+			t.Errorf("missing multi-ref %s; got: %+v", want, refs)
+		}
+	}
+}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -520,3 +520,134 @@ func TestHandleGetOpenAPI_NonexistentSchema(t *testing.T) {
 		t.Errorf("expected available schemas listing, got: %s", text)
 	}
 }
+
+// TestHandleSearch_EdgeCases covers a set of degenerate query inputs that must
+// produce clean tool errors rather than panics or 500-level responses.
+func TestHandleSearch_EdgeCases(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleSearch(d)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"empty", ""},
+		{"only punctuation", `"`},
+		{"operators only", "AND OR NOT"},
+		{"unterminated paren", "NEAR(term"},
+		{"very long", strings.Repeat("a", 10000)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _, err := handler(context.Background(), nil, SearchInput{Query: tc.query})
+			if err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("nil result")
+			}
+			// Either an error result or an empty set - never a panic.
+		})
+	}
+}
+
+// TestHandleGetSection_PaginationEdges covers paginateText boundary behaviour
+// that was previously exercised only for happy paths.
+func TestHandleGetSection_PaginationEdges(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleGetSection(d)
+
+	t.Run("offset beyond content", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID: "TS 23.501", SectionNumber: "1", Offset: 10000,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "No content at offset") {
+			t.Errorf("expected overflow message, got: %s", text)
+		}
+	})
+
+	t.Run("max_chars limits output", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID: "TS 23.501", SectionNumber: "5", IncludeSubsections: true, MaxChars: 10,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if text == "" {
+			t.Fatal("empty output")
+		}
+	})
+
+	t.Run("negative offset clamped", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID: "TS 23.501", SectionNumber: "1", Offset: -5,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 1-") {
+			t.Errorf("expected pagination header starting at line 1, got: %s", text)
+		}
+	})
+
+	t.Run("max_lines=1 returns single line", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID: "TS 23.501", SectionNumber: "5", IncludeSubsections: true, MaxLines: 1,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 1-") {
+			t.Errorf("expected pagination header, got: %s", text)
+		}
+	})
+}
+
+// TestHandleListSpecs_InvalidPagination verifies that out-of-range pagination
+// parameters are clamped by the handler rather than passed straight through to
+// SQL OFFSET/LIMIT as negative or absurd values.
+func TestHandleListSpecs_InvalidPagination(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleListSpecs(d)
+
+	t.Run("negative offset", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListSpecsInput{Offset: -100})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "TS 23.501") {
+			t.Errorf("expected specs in output, got: %s", text)
+		}
+	})
+
+	t.Run("huge limit capped", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListSpecsInput{Limit: 1 << 30})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		// Should not crash; should contain total_count and the specs.
+		if !strings.Contains(text, "total_count") {
+			t.Errorf("expected total_count in output, got: %s", text)
+		}
+	})
+
+	t.Run("offset past end returns empty list", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListSpecsInput{Offset: 10000})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "total_count") {
+			t.Errorf("expected total_count in output, got: %s", text)
+		}
+	})
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -373,6 +373,121 @@ func TestIsExternalRef(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_ImageAltEscaped verifies the alt-text escaping inside the
+// custom image:// rewrite path. This covers the one place where user-provided
+// text flows through htmlpkg.EscapeString before reaching the template.
+func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
+	content := `![alt"onload=x("y")](image://fig.png?w=600&h=400)`
+	got := renderMarkdown(content, "TS 23.501", nil)
+	if strings.Contains(got, `alt"onload`) {
+		t.Errorf("alt text should be HTML-escaped, got:\n%s", got)
+	}
+	if !strings.Contains(got, `&#34;`) && !strings.Contains(got, `&quot;`) {
+		t.Errorf("expected escaped quotation mark in alt text, got:\n%s", got)
+	}
+}
+
+// TestRenderMarkdown_FigureAltEscaped exercises the figure-syntax alt escaping.
+func TestRenderMarkdown_FigureAltEscaped(t *testing.T) {
+	content := `[Figure: <script>x</script> Network (fig.png, use get_image to retrieve, 100x100)]`
+	got := renderMarkdown(content, "TS 23.501", nil)
+	if strings.Contains(got, "<script>x</script> Network") {
+		t.Errorf("figure alt text should be escaped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "&lt;script&gt;") {
+		t.Errorf("expected escaped <script> in figure alt, got:\n%s", got)
+	}
+}
+
+// TestRenderMarkdown_RawHTMLPassthrough pins down the current behaviour of the
+// markdown renderer: goldmark is configured with html.WithUnsafe(), so raw
+// HTML embedded in section content is passed through verbatim. 3GPP specs are
+// officially published documents (not user-controlled input), so this is
+// considered acceptable today, but any change that would start rendering
+// user-controlled content through this path MUST first add HTML sanitization.
+// This test fails if that trust assumption silently changes.
+func TestRenderMarkdown_RawHTMLPassthrough(t *testing.T) {
+	content := "Inline <b>bold</b> and <script>alert(1)</script> here."
+	got := renderMarkdown(content, "TS 23.501", nil)
+	// Pins the current unsafe behaviour. If this ever starts escaping, it
+	// almost certainly means goldmark's WithUnsafe() was removed — verify the
+	// change is intentional before updating this expectation.
+	if !strings.Contains(got, "<b>bold</b>") {
+		t.Errorf("expected raw <b> to pass through (current behaviour), got:\n%s", got)
+	}
+	if !strings.Contains(got, "<script>alert(1)</script>") {
+		t.Errorf("expected raw <script> to pass through (current behaviour), got:\n%s", got)
+	}
+}
+
+// TestHandleOpenAPI_NotFound verifies the error path when requesting a missing
+// OpenAPI spec returns 404 rather than 500.
+func TestHandleOpenAPI_NotFound(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/specs/TS 29.510/openapi/DoesNotExist")
+	if err != nil {
+		t.Fatalf("GET error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestHandleOpenAPIList_EmptySpec verifies the empty-list branch when a valid
+// spec has no OpenAPI definitions registered.
+func TestHandleOpenAPIList_EmptySpec(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	// TS 23.501 seed data contains no openapi_specs rows.
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/openapi")
+	if err != nil {
+		t.Fatalf("GET error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestHandleSearch_Malformed exercises the query-with-only-punctuation path,
+// which the FTS5 sanitizer rewrites into a quoted token. The server must
+// either return results or a clean error page, never a 500.
+func TestHandleSearch_Malformed(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	for _, q := range []string{`"`, `()`, strings.Repeat("a", 10000)} {
+		resp, err := http.Get(ts.URL + "/search?q=" + urlEncode(q))
+		if err != nil {
+			t.Fatalf("GET error: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= 500 {
+			t.Errorf("query %q produced HTTP %d, want < 500", q, resp.StatusCode)
+		}
+	}
+}
+
+func urlEncode(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r == ' ' {
+			b.WriteByte('+')
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		_, _ = b.WriteString("%")
+		const hex = "0123456789ABCDEF"
+		b.WriteByte(hex[byte(r)>>4])
+		b.WriteByte(hex[byte(r)&0x0F])
+	}
+	return b.String()
+}
+
 func readBody(t *testing.T, resp *http.Response) string {
 	t.Helper()
 	data, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Background
Overall coverage is 71.3%, but the headline number hides an uneven
distribution. `cmd/3gpp-mcp` sits at 4.5% with every command handler
(`cmdServe`, `cmdConvert`, `cmdDownload`, `cmdPipeline`, `cmdUpdate`,
`resolveSpecs`) at 0%, and several public APIs in `db` and
`converter/pipeline` are also 0% because tests go through higher-level
helpers. The web viewer renders section markdown via
`template.HTML(renderMarkdown(...))` without any XSS regression test.

## Summary
- Add tests for `cmd/3gpp-mcp` command handlers.
- Cover 0% public APIs in `db` (`Open`, `InitSchema`, `Exec`, `Upsert*`,
  `GetImage`, `ListImages`, `GetBracketMap`, FTS5 tokenizers).
- Cover 0% public APIs in `converter/pipeline` (`ConvertSingleFile`,
  `FetchSpecZips`, `LoadSpecList`) and raise `cacheDir` / `SaveCache` /
  `extractFile` / `downloadZip` / `DownloadAndExtract` edge-case coverage.
- Add XSS regression tests for `web/handlers.go` markdown rendering
  (image/figure alt escaping + raw-HTML passthrough pinning).
- Close small gaps in `converter/docx` (`SectionsToMarkdown`,
  `ParseDocxFromBytes`, table parser regression fixtures for gridSpan/
  vMerge/varying widths/styled headers) and `tools` input validation edges.

## Coverage (before / after)
| Package              | Before | After  |
| -------------------- | ------ | ------ |
| `cmd/3gpp-mcp`       |  4.5%  | 64.0%  |
| `converter/pipeline` | 69.7%  | 77.6%  |
| `db`                 | 74.2%  | 87.0%  |
| `web`                | 86.0%  | 87.8%  |
| `tools`              | 87.6%  | 88.6%  |
| `converter/docx`     | 88.4%  | 89.4%  |
| **Overall**          | 71.3%  | **82.3%** |

## Security note
`web/markdown.go` configures goldmark with `html.WithUnsafe()`, so raw
HTML embedded in section content passes through to the viewer
unescaped. 3GPP specs are officially published documents (not
user-controlled input), so this is considered acceptable today, but any
future change that starts rendering user-controlled content through
this path MUST first add HTML sanitization. `TestRenderMarkdown_RawHTMLPassthrough`
pins this trust assumption and fails if the behavior silently changes.