### PR TITLE
feat(docx): emit tables as HTML to preserve merged cells and formatting

### DIFF
--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -218,9 +218,9 @@ func parseSections(elements []bodyElement, styleMap map[string]string, relMap ma
 		switch elem.Tag {
 		case "tbl":
 			flushCodeBlock()
-			md := rowsToMarkdown(elem.Table.Rows)
-			if md != "" && currentSection != nil {
-				currentSection.Content = append(currentSection.Content, md)
+			html := tableToHTML(elem.Table, imageContext{relMap: relMap, images: images})
+			if html != "" && currentSection != nil {
+				currentSection.Content = append(currentSection.Content, html)
 			}
 		case "p":
 			info := elem.Paragraph

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -186,13 +186,13 @@ func TestParseDocx(t *testing.T) {
 	} else {
 		hasTable := false
 		for _, c := range s.Content {
-			if strings.Contains(c, "|") && strings.Contains(c, "---") {
+			if strings.Contains(c, "<table>") {
 				hasTable = true
 				break
 			}
 		}
 		if !hasTable {
-			t.Error("Section 3.2 should contain a markdown table")
+			t.Error("Section 3.2 should contain an HTML table")
 		}
 	}
 
@@ -240,7 +240,7 @@ func TestParseDocx(t *testing.T) {
 	} else {
 		hasTable := false
 		for _, c := range s.Content {
-			if strings.Contains(c, "|") {
+			if strings.Contains(c, "<table>") {
 				hasTable = true
 				break
 			}
@@ -381,33 +381,34 @@ func TestSectionToMarkdown_ConsecutiveTables(t *testing.T) {
 		Title:  "Create Session Request",
 		Level:  3,
 		Content: []string{
-			"| H1 | H2 |\n| --- | --- |\n| A | B |",
-			"| H3 | H4 |\n| --- | --- |\n| C | D |",
+			"<table><tbody><tr><td><p>A</p></td><td><p>B</p></td></tr></tbody></table>",
+			"<table><tbody><tr><td><p>C</p></td><td><p>D</p></td></tr></tbody></table>",
 		},
 	}
 	md := SectionToMarkdown(section)
-	// Two tables must be separated by a blank line
-	if !strings.Contains(md, "| A | B |\n\n| H3 | H4 |") {
+	// Two HTML tables must be separated by a blank line so goldmark treats
+	// them as separate raw HTML blocks.
+	if !strings.Contains(md, "</table>\n\n<table>") {
 		t.Errorf("Consecutive tables not properly separated:\n%s", md)
 	}
 }
 
-func TestTableToMarkdown(t *testing.T) {
-	// Simple table XML
+func TestTableToHTML(t *testing.T) {
 	tableXML := `<tbl>
 		<tr><tc><p><r><t>Header1</t></r></p></tc><tc><p><r><t>Header2</t></r></p></tc></tr>
 		<tr><tc><p><r><t>Cell1</t></r></p></tc><tc><p><r><t>Cell2</t></r></p></tc></tr>
 	</tbl>`
 
-	md := tableToMarkdown([]byte(tableXML))
-	if !strings.Contains(md, "| Header1 | Header2 |") {
-		t.Errorf("Expected header row, got:\n%s", md)
-	}
-	if !strings.Contains(md, "| --- | --- |") {
-		t.Errorf("Expected separator row, got:\n%s", md)
-	}
-	if !strings.Contains(md, "| Cell1 | Cell2 |") {
-		t.Errorf("Expected data row, got:\n%s", md)
+	info := extractTable([]byte(tableXML))
+	html := tableToHTML(info, imageContext{})
+	for _, want := range []string{
+		"<table>",
+		"<tr><td><p>Header1</p></td><td><p>Header2</p></td></tr>",
+		"<tr><td><p>Cell1</p></td><td><p>Cell2</p></td></tr>",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("Expected output to contain %q, got:\n%s", want, html)
+		}
 	}
 }
 

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -3,75 +3,334 @@ package docx
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
+	htmlpkg "html"
+	"strconv"
 	"strings"
+)
+
+// vMergeKind represents the OOXML w:vMerge attribute state for a cell.
+// The zero value means "not part of a vertical merge".
+type vMergeKind int
+
+const (
+	vMergeRestart vMergeKind = iota + 1
+	vMergeContinue
 )
 
 // tableInfo holds parsed data from a w:tbl element.
 type tableInfo struct {
-	Rows      [][]string      // cell text grid for markdown conversion
-	CellParas []paragraphInfo // all paragraphs found inside table cells
+	Rows      []tableRow      // structured rows for HTML rendering
+	CellParas []paragraphInfo // all paragraphs found inside table cells (used by metadata extraction)
 }
 
-// tableToMarkdown converts a w:tbl XML element to a markdown table string.
-func tableToMarkdown(tblData []byte) string {
-	rows := extractTableRows(tblData)
-	return rowsToMarkdown(rows)
+// tableRow holds a parsed w:tr.
+type tableRow struct {
+	IsHeader bool // tblHeader flag from w:trPr
+	Cells    []tableCell
 }
 
-// rowsToMarkdown formats table rows as a markdown table.
-func rowsToMarkdown(rows [][]string) string {
-	if len(rows) == 0 {
+// tableCell holds a parsed w:tc.
+type tableCell struct {
+	GridSpan int        // w:gridSpan w:val (defaults to 1)
+	VMerge   vMergeKind // w:vMerge w:val ("restart" / "" → continue / absent → none)
+	Paras    []paragraphInfo
+}
+
+// imageContext bundles the relationship and image maps used to render
+// embedded image references inside table cells.
+type imageContext struct {
+	relMap map[string]string
+	images map[string]*EmbeddedImage
+}
+
+// tableToHTML converts a parsed table into an HTML <table> string.
+//
+// Merged cells (w:gridSpan, w:vMerge) are preserved via colspan/rowspan;
+// header rows flagged with w:tblHeader are emitted inside <thead> using <th>.
+// Cell text is HTML-escaped; bold/italic/code runs are wrapped in
+// <strong>/<em>/<code>. Images inside cells become <img src="image://..."> tags
+// using the same URL scheme as the markdown image placeholder, so the web
+// viewer rewrites them to real URLs.
+func tableToHTML(info tableInfo, ctx imageContext) string {
+	if len(info.Rows) == 0 {
 		return ""
 	}
 
-	var lines []string
-
-	// Header row
-	lines = append(lines, "| "+strings.Join(rows[0], " | ")+" |")
-	// Separator
-	seps := make([]string, len(rows[0]))
-	for i := range seps {
-		seps[i] = "---"
+	// Resolve column positions per cell, accounting for gridSpan, so vMerge
+	// continuations can be aligned with their restart cell column.
+	type cellPos struct {
+		col   int
+		width int
 	}
-	lines = append(lines, "| "+strings.Join(seps, " | ")+" |")
-
-	// Data rows
-	headerLen := len(rows[0])
-	for _, row := range rows[1:] {
-		// Pad row to match header length
-		for len(row) < headerLen {
-			row = append(row, "")
+	rowCellPositions := make([][]cellPos, len(info.Rows))
+	for i, row := range info.Rows {
+		col := 0
+		positions := make([]cellPos, len(row.Cells))
+		for j, c := range row.Cells {
+			width := c.GridSpan
+			if width < 1 {
+				width = 1
+			}
+			positions[j] = cellPos{col: col, width: width}
+			col += width
 		}
-		// Truncate to header length
-		row = row[:headerLen]
-		lines = append(lines, "| "+strings.Join(row, " | ")+" |")
+		rowCellPositions[i] = positions
 	}
 
-	return strings.Join(lines, "\n")
+	// Compute rowspan for each cell: 1 for non-restart cells; for restart
+	// cells, count themselves plus the immediately following rows whose
+	// column at the same starting position has vMerge=continue.
+	rowspans := make([][]int, len(info.Rows))
+	for i, row := range info.Rows {
+		rowspans[i] = make([]int, len(row.Cells))
+		for j, c := range row.Cells {
+			if c.VMerge != vMergeRestart {
+				rowspans[i][j] = 1
+				continue
+			}
+			startCol := rowCellPositions[i][j].col
+			span := 1
+			for ri := i + 1; ri < len(info.Rows); ri++ {
+				next := info.Rows[ri]
+				matched := false
+				for k, nc := range next.Cells {
+					if rowCellPositions[ri][k].col == startCol && nc.VMerge == vMergeContinue {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					break
+				}
+				span++
+			}
+			rowspans[i][j] = span
+		}
+	}
+
+	// Count leading header rows (rows with tblHeader at the top of the table).
+	headerRows := 0
+	for _, row := range info.Rows {
+		if !row.IsHeader {
+			break
+		}
+		headerRows++
+	}
+
+	var b strings.Builder
+	b.WriteString("<table>")
+	if headerRows > 0 {
+		b.WriteString("<thead>")
+		for i := 0; i < headerRows; i++ {
+			writeRowHTML(&b, info.Rows[i], rowspans[i], true, ctx)
+		}
+		b.WriteString("</thead>")
+	}
+	if headerRows < len(info.Rows) {
+		b.WriteString("<tbody>")
+		for i := headerRows; i < len(info.Rows); i++ {
+			writeRowHTML(&b, info.Rows[i], rowspans[i], false, ctx)
+		}
+		b.WriteString("</tbody>")
+	}
+	b.WriteString("</table>")
+	return b.String()
 }
 
-// extractTableRows extracts rows of cell text from a w:tbl XML element.
-func extractTableRows(data []byte) [][]string {
+func writeRowHTML(b *strings.Builder, row tableRow, rowspans []int, asHeader bool, ctx imageContext) {
+	b.WriteString("<tr>")
+	tag := "td"
+	if asHeader {
+		tag = "th"
+	}
+	for j, c := range row.Cells {
+		if c.VMerge == vMergeContinue {
+			continue
+		}
+		b.WriteByte('<')
+		b.WriteString(tag)
+		if c.GridSpan > 1 {
+			fmt.Fprintf(b, ` colspan="%d"`, c.GridSpan)
+		}
+		if rowspans[j] > 1 {
+			fmt.Fprintf(b, ` rowspan="%d"`, rowspans[j])
+		}
+		b.WriteByte('>')
+		writeCellContent(b, c, ctx)
+		b.WriteString("</")
+		b.WriteString(tag)
+		b.WriteByte('>')
+	}
+	b.WriteString("</tr>")
+}
+
+// listKind classifies a paragraph's list context based on its style ID.
+type listKind int
+
+const (
+	notList listKind = iota
+	bulletList
+	numberList
+)
+
+// classifyListPara approximates list detection from the paragraph's StyleID.
+// In 3GPP DOCX files, list paragraphs commonly use style IDs starting with
+// "List" (e.g. "ListBullet", "ListNumber"). When the style ID is opaque (a
+// numeric ID), the paragraph is treated as a non-list paragraph.
+func classifyListPara(p paragraphInfo) listKind {
+	sid := p.StyleID
+	if !strings.HasPrefix(sid, "List") && !strings.HasPrefix(sid, "list") {
+		return notList
+	}
+	if strings.Contains(sid, "Number") || strings.Contains(sid, "number") {
+		return numberList
+	}
+	return bulletList
+}
+
+func writeCellContent(b *strings.Builder, c tableCell, ctx imageContext) {
+	if len(c.Paras) == 0 {
+		return
+	}
+	var inList = notList
+	closeList := func() {
+		switch inList {
+		case bulletList:
+			b.WriteString("</ul>")
+		case numberList:
+			b.WriteString("</ol>")
+		}
+		inList = notList
+	}
+	openList := func(kind listKind) {
+		switch kind {
+		case bulletList:
+			b.WriteString("<ul>")
+		case numberList:
+			b.WriteString("<ol>")
+		}
+		inList = kind
+	}
+
+	for _, p := range c.Paras {
+		kind := classifyListPara(p)
+		if kind != inList {
+			closeList()
+			if kind != notList {
+				openList(kind)
+			}
+		}
+		switch kind {
+		case notList:
+			b.WriteString("<p>")
+			writeParagraphInline(b, p, ctx)
+			b.WriteString("</p>")
+		default:
+			b.WriteString("<li>")
+			writeParagraphInline(b, p, ctx)
+			b.WriteString("</li>")
+		}
+	}
+	closeList()
+}
+
+func writeParagraphInline(b *strings.Builder, p paragraphInfo, ctx imageContext) {
+	if len(p.Runs) > 0 {
+		for _, r := range p.Runs {
+			if r.Text == "" {
+				continue
+			}
+			esc := htmlpkg.EscapeString(r.Text)
+			switch {
+			case r.IsCode:
+				b.WriteString("<code>")
+				b.WriteString(esc)
+				b.WriteString("</code>")
+			case r.Bold && r.Italic:
+				b.WriteString("<strong><em>")
+				b.WriteString(esc)
+				b.WriteString("</em></strong>")
+			case r.Bold:
+				b.WriteString("<strong>")
+				b.WriteString(esc)
+				b.WriteString("</strong>")
+			case r.Italic:
+				b.WriteString("<em>")
+				b.WriteString(esc)
+				b.WriteString("</em>")
+			default:
+				b.WriteString(esc)
+			}
+		}
+	} else if p.Text != "" {
+		b.WriteString(htmlpkg.EscapeString(p.Text))
+	}
+
+	for _, ref := range p.Images {
+		if html := imageHTML(ctx, ref); html != "" {
+			b.WriteString(html)
+		}
+	}
+}
+
+// imageHTML returns an HTML <img> tag for an embedded image reference, using
+// the same image://name?w&h URL convention as the markdown image placeholder
+// so the web viewer can rewrite it to a real URL.
+func imageHTML(ctx imageContext, ref imageRef) string {
+	if ctx.relMap == nil {
+		return ""
+	}
+	target, ok := ctx.relMap[ref.RID]
+	if !ok {
+		return ""
+	}
+	img, ok := ctx.images[target]
+	if !ok {
+		return ""
+	}
+	dimSuffix := ""
+	dimAttrs := ""
+	if ref.WidthPx > 0 && ref.HeightPx > 0 {
+		dimSuffix = fmt.Sprintf("?w=%d&h=%d", ref.WidthPx, ref.HeightPx)
+		dimAttrs = fmt.Sprintf(` width="%d" height="%d"`, ref.WidthPx, ref.HeightPx)
+	}
+	alt := img.Name
+	if ref.AltText != "" {
+		alt = ref.AltText
+	} else if img.LLMReadable {
+		alt = "Figure"
+	}
+	return fmt.Sprintf(`<img src="image://%s%s" alt="%s"%s>`,
+		img.Name, dimSuffix, htmlpkg.EscapeString(alt), dimAttrs)
+}
+
+// extractTable parses a w:tbl XML element and returns its parsed structure.
+// Used by tests; the main parser path uses parseTableFromDecoder directly.
+func extractTable(data []byte) tableInfo {
 	decoder := xml.NewDecoder(bytes.NewReader(data))
 	for {
 		tok, err := decoder.Token()
 		if err != nil {
-			return nil
+			return tableInfo{}
 		}
 		if se, ok := tok.(xml.StartElement); ok && se.Name.Local == "tbl" {
-			return parseTableFromDecoder(decoder, se).Rows
+			return parseTableFromDecoder(decoder, se)
 		}
 	}
 }
 
 // parseTableFromDecoder parses a w:tbl element from an existing decoder.
-// The start element has already been consumed; this reads through the matching end element.
-// It produces both Rows (for markdown) and CellParas (for metadata extraction) in a single pass.
+// The start element has already been consumed; this reads through the matching
+// end element.
+//
+// Nested tables inside a cell are skipped in their entirety: we don't model
+// them and would otherwise corrupt the outer row/cell state.
 func parseTableFromDecoder(d *xml.Decoder, _ xml.StartElement) tableInfo {
 	var info tableInfo
-	var currentRow []string
-	var inRow, inCell bool
-	var cellTexts []string
+	var currentRow *tableRow
+	var currentCell *tableCell
+	var inRow, inCell, inRowProps, inCellProps bool
 
 	depth := 1
 	const maxTokens = 10_000_000 // safety bound against malformed XML
@@ -86,25 +345,61 @@ func parseTableFromDecoder(d *xml.Decoder, _ xml.StartElement) tableInfo {
 			depth++
 			local := t.Name.Local
 			switch local {
+			case "tbl":
+				// Nested table — skip the whole subtree.
+				if inCell {
+					if err := d.Skip(); err == nil {
+						depth--
+					}
+				}
 			case "tr":
-				inRow = true
-				currentRow = nil
+				if !inCell {
+					inRow = true
+					currentRow = &tableRow{}
+				}
+			case "trPr":
+				if inRow && !inCell {
+					inRowProps = true
+				}
+			case "tblHeader":
+				if inRowProps && currentRow != nil {
+					val := getAttrVal(t, "val")
+					if val != "false" && val != "0" {
+						currentRow.IsHeader = true
+					}
+				}
 			case "tc":
 				if inRow {
 					inCell = true
-					cellTexts = nil
+					currentCell = &tableCell{GridSpan: 1}
+				}
+			case "tcPr":
+				if inCell {
+					inCellProps = true
+				}
+			case "gridSpan":
+				if inCellProps && currentCell != nil {
+					if v := getAttrVal(t, "val"); v != "" {
+						if n, err := strconv.Atoi(v); err == nil && n > 0 {
+							currentCell.GridSpan = n
+						}
+					}
+				}
+			case "vMerge":
+				if inCellProps && currentCell != nil {
+					val := getAttrVal(t, "val")
+					if val == "restart" {
+						currentCell.VMerge = vMergeRestart
+					} else {
+						currentCell.VMerge = vMergeContinue
+					}
 				}
 			case "p":
-				if inCell {
-					// parseParagraphFromDecoder consumes all tokens through the
-					// matching </w:p> end element, so depth-- accounts for that.
+				if inCell && currentCell != nil {
 					pInfo := parseParagraphFromDecoder(d, t)
 					depth--
 					info.CellParas = append(info.CellParas, pInfo)
-					// Also accumulate text for the cell's Rows entry
-					if pInfo.Text != "" {
-						cellTexts = append(cellTexts, pInfo.Text)
-					}
+					currentCell.Paras = append(currentCell.Paras, pInfo)
 				}
 			}
 		case xml.EndElement:
@@ -113,16 +408,20 @@ func parseTableFromDecoder(d *xml.Decoder, _ xml.StartElement) tableInfo {
 			switch local {
 			case "tr":
 				if inRow && currentRow != nil {
-					info.Rows = append(info.Rows, currentRow)
+					info.Rows = append(info.Rows, *currentRow)
 				}
 				inRow = false
+				currentRow = nil
+			case "trPr":
+				inRowProps = false
 			case "tc":
-				if inCell {
-					cellText := strings.TrimSpace(strings.Join(cellTexts, ""))
-					cellText = strings.ReplaceAll(cellText, "\n", " ")
-					currentRow = append(currentRow, cellText)
-					inCell = false
+				if inCell && currentRow != nil && currentCell != nil {
+					currentRow.Cells = append(currentRow.Cells, *currentCell)
 				}
+				inCell = false
+				currentCell = nil
+			case "tcPr":
+				inCellProps = false
 			}
 		}
 	}

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -5,83 +5,49 @@ import (
 	"testing"
 )
 
-func TestRowsToMarkdown(t *testing.T) {
-	tests := []struct {
-		name string
-		rows [][]string
-		want string
-	}{
-		{
-			name: "empty rows returns empty string",
-			rows: nil,
-			want: "",
-		},
-		{
-			name: "single header row",
-			rows: [][]string{{"a", "b"}},
-			want: "| a | b |\n| --- | --- |",
-		},
-		{
-			name: "header with data row",
-			rows: [][]string{{"H1", "H2"}, {"v1", "v2"}},
-			want: "| H1 | H2 |\n| --- | --- |\n| v1 | v2 |",
-		},
-		{
-			name: "row padding when fewer cells than header",
-			rows: [][]string{{"H1", "H2", "H3"}, {"v1"}},
-			want: "| H1 | H2 | H3 |\n| --- | --- | --- |\n| v1 |  |  |",
-		},
-		{
-			name: "row truncation when more cells than header",
-			rows: [][]string{{"H1"}, {"v1", "v2", "v3"}},
-			want: "| H1 |\n| --- |\n| v1 |",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := rowsToMarkdown(tt.rows)
-			if got != tt.want {
-				t.Errorf("rowsToMarkdown:\nwant:\n%s\ngot:\n%s", tt.want, got)
-			}
-		})
+func TestTableToHTML_Empty(t *testing.T) {
+	if got := tableToHTML(tableInfo{}, imageContext{}); got != "" {
+		t.Errorf("tableToHTML(empty) = %q, want empty", got)
 	}
 }
 
-func TestExtractTableRows_Simple(t *testing.T) {
+func TestTableToHTML_BasicTwoRows(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr><w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>H2</w:t></w:r></w:p></w:tc></w:tr>
 		<w:tr><w:tc><w:p><w:r><w:t>v1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>v2</w:t></w:r></w:p></w:tc></w:tr>
 	</w:tbl>`
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 2 {
-		t.Fatalf("rows = %d, want 2", len(rows))
+	info := extractTable([]byte(xml))
+	if len(info.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(info.Rows))
 	}
-	if len(rows[0]) != 2 || rows[0][0] != "H1" || rows[0][1] != "H2" {
-		t.Errorf("header row = %v", rows[0])
-	}
-	if len(rows[1]) != 2 || rows[1][0] != "v1" || rows[1][1] != "v2" {
-		t.Errorf("data row = %v", rows[1])
+	html := tableToHTML(info, imageContext{})
+	for _, want := range []string{
+		"<table>",
+		"<tbody>",
+		"<tr><td><p>H1</p></td><td><p>H2</p></td></tr>",
+		"<tr><td><p>v1</p></td><td><p>v2</p></td></tr>",
+		"</tbody></table>",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected output to contain %q\ngot: %s", want, html)
+		}
 	}
 }
 
-func TestExtractTableRows_EmptyCell(t *testing.T) {
+func TestTableToHTML_EmptyCell(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr><w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc><w:tc><w:p/></w:tc></w:tr>
 	</w:tbl>`
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 1 || len(rows[0]) != 2 {
-		t.Fatalf("rows = %v", rows)
-	}
-	if rows[0][1] != "" {
-		t.Errorf("empty cell = %q, want empty string", rows[0][1])
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<td><p>H1</p></td><td><p></p></td>") {
+		t.Errorf("empty cell HTML not as expected: %s", html)
 	}
 }
 
-func TestExtractTableRows_NestedTable(t *testing.T) {
-	// The parser does not track table nesting, so a nested w:tbl inside a cell
-	// causes the inner <w:tr>/<w:tc> tokens to reset the outer row state. This
-	// test pins down that behavior and asserts the parser does not panic on
-	// nested input.
+func TestTableToHTML_NestedTableSkipped(t *testing.T) {
+	// Nested tables are skipped to avoid corrupting outer row/cell state. The
+	// outer cell's own paragraph is preserved; the inner table's text is dropped.
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr><w:tc>
 			<w:p><w:r><w:t>outer</w:t></w:r></w:p>
@@ -90,80 +56,88 @@ func TestExtractTableRows_NestedTable(t *testing.T) {
 			</w:tbl>
 		</w:tc></w:tr>
 	</w:tbl>`
-	rows := extractTableRows([]byte(xml))
-	if len(rows) == 0 {
-		t.Fatal("expected at least one row from nested-table input")
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<p>outer</p>") {
+		t.Errorf("expected outer paragraph to survive: %s", html)
 	}
-	if rows[0][0] != "inner" {
-		t.Errorf("expected inner row to win over outer (current behavior), got %v", rows[0])
+	if strings.Contains(html, "inner") {
+		t.Errorf("expected nested-table content to be dropped: %s", html)
 	}
 }
 
-func TestExtractTableRows_MultiParagraphCell(t *testing.T) {
+func TestTableToHTML_MultiParagraphCell(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr><w:tc>
 			<w:p><w:r><w:t>first</w:t></w:r></w:p>
 			<w:p><w:r><w:t>second</w:t></w:r></w:p>
 		</w:tc></w:tr>
 	</w:tbl>`
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 1 || len(rows[0]) != 1 {
-		t.Fatalf("rows = %v", rows)
-	}
-	if !strings.Contains(rows[0][0], "first") || !strings.Contains(rows[0][0], "second") {
-		t.Errorf("cell text = %q, expected to contain both paragraphs", rows[0][0])
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<p>first</p><p>second</p>") {
+		t.Errorf("expected two <p> tags in cell, got: %s", html)
 	}
 }
 
-func TestExtractTableRows_BoldRunInCell(t *testing.T) {
+func TestTableToHTML_BoldRunInCell(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr><w:tc><w:p>
 			<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r>
 			<w:r><w:t> plain</w:t></w:r>
 		</w:p></w:tc></w:tr>
 	</w:tbl>`
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 1 {
-		t.Fatalf("rows = %v", rows)
-	}
-	if rows[0][0] != "bold plain" {
-		t.Errorf("cell text = %q, want %q", rows[0][0], "bold plain")
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<strong>bold</strong> plain") {
+		t.Errorf("expected bold run wrapped in <strong>: %s", html)
 	}
 }
 
-func TestExtractTableRows_Malformed(t *testing.T) {
-	// Garbage input must not panic or hang. The function returns nil if no
-	// w:tbl token is found.
-	rows := extractTableRows([]byte("not xml at all"))
-	if rows != nil {
-		t.Errorf("expected nil rows for malformed input, got %v", rows)
-	}
-}
-
-func TestTableToMarkdown_RoundTrip(t *testing.T) {
+func TestTableToHTML_ItalicAndBoldItalic(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-		<w:tr><w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Type</w:t></w:r></w:p></w:tc></w:tr>
-		<w:tr><w:tc><w:p><w:r><w:t>foo</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>string</w:t></w:r></w:p></w:tc></w:tr>
+		<w:tr><w:tc><w:p>
+			<w:r><w:rPr><w:i/></w:rPr><w:t>italic</w:t></w:r>
+			<w:r><w:rPr><w:b/><w:i/></w:rPr><w:t>both</w:t></w:r>
+		</w:p></w:tc></w:tr>
 	</w:tbl>`
-	md := tableToMarkdown([]byte(xml))
-	for _, want := range []string{"| Name | Type |", "| --- | --- |", "| foo | string |"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected output to contain %q\n%s", want, md)
-		}
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<em>italic</em>") {
+		t.Errorf("expected italic run: %s", html)
+	}
+	if !strings.Contains(html, "<strong><em>both</em></strong>") {
+		t.Errorf("expected bold+italic run: %s", html)
 	}
 }
 
-func TestTableToMarkdown_NoTable(t *testing.T) {
-	if md := tableToMarkdown([]byte("garbage")); md != "" {
-		t.Errorf("expected empty markdown for invalid input, got %q", md)
+func TestTableToHTML_HTMLEscape(t *testing.T) {
+	// Cell text containing HTML special characters must be escaped.
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p><w:r><w:t>a &lt;b&gt; &amp; "c"</w:t></w:r></w:p></w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	// The XML decoder unescapes entities, so the text we receive is literal
+	// `a <b> & "c"`. tableToHTML must re-escape it.
+	if !strings.Contains(html, `a &lt;b&gt; &amp; &#34;c&#34;`) {
+		t.Errorf("expected HTML-escaped cell content, got: %s", html)
 	}
 }
 
-// TestExtractTableRows_GridSpanMergedCells pins down current behaviour for
-// tables with horizontally merged cells (w:gridSpan). 3GPP protocol flow
-// tables rely on gridSpan for header rows, so this documents how the parser
-// treats them today — if the behaviour changes, review the diff carefully.
-func TestExtractTableRows_GridSpanMergedCells(t *testing.T) {
+func TestTableToHTML_Malformed(t *testing.T) {
+	info := extractTable([]byte("not xml at all"))
+	if len(info.Rows) != 0 {
+		t.Errorf("expected empty rows for malformed input, got %d", len(info.Rows))
+	}
+	if got := tableToHTML(info, imageContext{}); got != "" {
+		t.Errorf("expected empty HTML for empty info, got %q", got)
+	}
+}
+
+// TestTableToHTML_GridSpanMergedCells verifies horizontal cell merges via
+// w:gridSpan are translated to colspan attributes.
+func TestTableToHTML_GridSpanMergedCells(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr>
 			<w:tc>
@@ -176,22 +150,19 @@ func TestExtractTableRows_GridSpanMergedCells(t *testing.T) {
 			<w:tc><w:p><w:r><w:t>a2</w:t></w:r></w:p></w:tc>
 		</w:tr>
 	</w:tbl>`
-
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 2 {
-		t.Fatalf("rows = %d, want 2", len(rows))
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, `<td colspan="2"><p>merged-header</p></td>`) {
+		t.Errorf("expected colspan=2 cell, got: %s", html)
 	}
-	if rows[0][0] != "merged-header" {
-		t.Errorf("row[0] cell[0] = %q, want 'merged-header'", rows[0][0])
-	}
-	if len(rows[1]) != 2 || rows[1][0] != "a1" || rows[1][1] != "a2" {
-		t.Errorf("row[1] = %v, want [a1 a2]", rows[1])
+	if !strings.Contains(html, `<td><p>a1</p></td><td><p>a2</p></td>`) {
+		t.Errorf("expected unmerged data row, got: %s", html)
 	}
 }
 
-// TestExtractTableRows_VMergedCells pins down behaviour for vertically merged
-// cells (w:vMerge). The parser currently treats continuation cells as empty.
-func TestExtractTableRows_VMergedCells(t *testing.T) {
+// TestTableToHTML_VMergedCells verifies vertical cell merges via w:vMerge are
+// translated to rowspan on the restart cell, with continuation cells skipped.
+func TestTableToHTML_VMergedCells(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr>
 			<w:tc>
@@ -208,24 +179,20 @@ func TestExtractTableRows_VMergedCells(t *testing.T) {
 			<w:tc><w:p><w:r><w:t>r2</w:t></w:r></w:p></w:tc>
 		</w:tr>
 	</w:tbl>`
-
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 2 {
-		t.Fatalf("rows = %d, want 2", len(rows))
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, `<td rowspan="2"><p>top</p></td>`) {
+		t.Errorf("expected rowspan=2 on restart cell, got: %s", html)
 	}
-	if rows[0][0] != "top" || rows[0][1] != "r1" {
-		t.Errorf("row[0] = %v, want [top r1]", rows[0])
-	}
-	// The continuation row has an empty first cell (current behaviour, pinned).
-	if rows[1][0] != "" || rows[1][1] != "r2" {
-		t.Errorf("row[1] = %v, want ['' r2]", rows[1])
+	// Continuation row should only emit the second cell, not the merged one.
+	if !strings.Contains(html, `<tr><td><p>r2</p></td></tr>`) {
+		t.Errorf("expected continuation row with only r2, got: %s", html)
 	}
 }
 
-// TestExtractTableRows_VaryingRowWidths verifies the parser accepts rows with
-// differing cell counts without panicking, and that rowsToMarkdown pads/trims
-// to the header width when rendering.
-func TestExtractTableRows_VaryingRowWidths(t *testing.T) {
+// TestTableToHTML_VaryingRowWidths checks that rows with differing cell counts
+// are emitted as-is (each row reflects what was in the source).
+func TestTableToHTML_VaryingRowWidths(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr>
 			<w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc>
@@ -242,31 +209,25 @@ func TestExtractTableRows_VaryingRowWidths(t *testing.T) {
 			<w:tc><w:p><w:r><w:t>extra</w:t></w:r></w:p></w:tc>
 		</w:tr>
 	</w:tbl>`
-
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 3 {
-		t.Fatalf("rows = %d, want 3", len(rows))
+	info := extractTable([]byte(xml))
+	if len(info.Rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(info.Rows))
 	}
-	md := rowsToMarkdown(rows)
-	// Header defines width=3, so the single-cell row pads to 3 and the 4-cell
-	// row truncates to 3.
+	html := tableToHTML(info, imageContext{})
 	for _, want := range []string{
-		"| H1 | H2 | H3 |",
-		"| only-one |  |  |",
-		"| a | b | c |",
+		"<tr><td><p>H1</p></td><td><p>H2</p></td><td><p>H3</p></td></tr>",
+		"<tr><td><p>only-one</p></td></tr>",
+		"<tr><td><p>a</p></td><td><p>b</p></td><td><p>c</p></td><td><p>extra</p></td></tr>",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected markdown to contain %q, got:\n%s", want, md)
+		if !strings.Contains(html, want) {
+			t.Errorf("expected HTML to contain %q, got:\n%s", want, html)
 		}
-	}
-	if strings.Contains(md, "extra") {
-		t.Errorf("expected extra cell to be dropped, got:\n%s", md)
 	}
 }
 
-// TestExtractTableRows_StyledHeaderRow exercises a header row with tblHeader
-// styling applied via tcPr — the parser should still include it as row[0].
-func TestExtractTableRows_StyledHeaderRow(t *testing.T) {
+// TestTableToHTML_StyledHeaderRow verifies a row with w:trPr/w:tblHeader is
+// emitted inside <thead> using <th>.
+func TestTableToHTML_StyledHeaderRow(t *testing.T) {
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
 		<w:tr>
 			<w:trPr><w:tblHeader/></w:trPr>
@@ -284,15 +245,54 @@ func TestExtractTableRows_StyledHeaderRow(t *testing.T) {
 			<w:tc><w:p><w:r><w:t>v1</w:t></w:r></w:p></w:tc>
 		</w:tr>
 	</w:tbl>`
+	info := extractTable([]byte(xml))
+	if len(info.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(info.Rows))
+	}
+	if !info.Rows[0].IsHeader {
+		t.Errorf("row[0] IsHeader = false, want true")
+	}
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "<thead>") || !strings.Contains(html, "</thead>") {
+		t.Errorf("expected <thead> wrapper, got: %s", html)
+	}
+	if !strings.Contains(html, "<th><p><strong>Name</strong></p></th>") {
+		t.Errorf("expected <th> with bold Name, got: %s", html)
+	}
+	if !strings.Contains(html, "<tr><td><p>k1</p></td><td><p>v1</p></td></tr>") {
+		t.Errorf("expected data row in tbody with <td>, got: %s", html)
+	}
+}
 
-	rows := extractTableRows([]byte(xml))
-	if len(rows) != 2 {
-		t.Fatalf("rows = %d, want 2", len(rows))
+// TestTableToHTML_ImageInCell verifies that an image reference inside a cell
+// is emitted as an <img src="image://..."> tag using the relMap/images context.
+func TestTableToHTML_ImageInCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+		xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+		xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+		xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+		<w:tr><w:tc>
+			<w:p><w:r>
+				<w:drawing>
+					<wp:inline>
+						<wp:extent cx="952500" cy="952500"/>
+						<a:graphic><a:graphicData>
+							<a:blip r:embed="rId7"/>
+						</a:graphicData></a:graphic>
+					</wp:inline>
+				</w:drawing>
+			</w:r></w:p>
+		</w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	ctx := imageContext{
+		relMap: map[string]string{"rId7": "media/image1.png"},
+		images: map[string]*EmbeddedImage{
+			"media/image1.png": {Name: "image1.png", LLMReadable: true},
+		},
 	}
-	if rows[0][0] != "Name" || rows[0][1] != "Value" {
-		t.Errorf("header row = %v, want [Name Value]", rows[0])
-	}
-	if rows[1][0] != "k1" || rows[1][1] != "v1" {
-		t.Errorf("data row = %v, want [k1 v1]", rows[1])
+	html := tableToHTML(info, ctx)
+	if !strings.Contains(html, `<img src="image://image1.png?w=100&h=100" alt="Figure" width="100" height="100">`) {
+		t.Errorf("expected <img> tag with image:// src in cell, got: %s", html)
 	}
 }

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	imageRE  = regexp.MustCompile(`!\[([^\]]*)\]\(image://([^?)]+)(?:\?w=(\d+)&h=(\d+))?\)`)
-	figureRE = regexp.MustCompile(`\[Figure:\s*([^(]+?)\s*\(([^,]+),\s*use get_image to retrieve(?:,\s*(\d+)x(\d+))?\)\]`)
+	imageRE     = regexp.MustCompile(`!\[([^\]]*)\]\(image://([^?)]+)(?:\?w=(\d+)&h=(\d+))?\)`)
+	figureRE    = regexp.MustCompile(`\[Figure:\s*([^(]+?)\s*\(([^,]+),\s*use get_image to retrieve(?:,\s*(\d+)x(\d+))?\)\]`)
+	htmlImageRE = regexp.MustCompile(`(<img\s+[^>]*?\bsrc=")image://([^"?]+)(?:\?[^"]*)?("[^>]*>)`)
 )
 
 var md goldmark.Markdown
@@ -74,6 +75,12 @@ func renderMarkdown(content, specID string, bracketMap map[string]string) string
 				src, htmlpkg.EscapeString(alt), sub[3], sub[4])
 		}
 		return fmt.Sprintf("![%s](%s)", alt, src)
+	})
+	content = htmlImageRE.ReplaceAllStringFunc(content, func(match string) string {
+		sub := htmlImageRE.FindStringSubmatch(match)
+		prefix, name, suffix := sub[1], sub[2], sub[3]
+		src := "/specs/" + escapedSpec + "/images/" + url.PathEscape(name)
+		return prefix + src + suffix
 	})
 	content = figureRE.ReplaceAllStringFunc(content, func(match string) string {
 		sub := figureRE.FindStringSubmatch(match)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -420,6 +420,20 @@ func TestRenderMarkdown_RawHTMLPassthrough(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_HTMLImageRewrite verifies that <img src="image://...">
+// tags embedded in raw HTML (used inside HTML tables emitted by the docx
+// converter) are rewritten to a real /specs/<id>/images/<name> URL.
+func TestRenderMarkdown_HTMLImageRewrite(t *testing.T) {
+	content := `<table><tbody><tr><td><img src="image://fig.png?w=200&h=100" alt="diag" width="200" height="100"></td></tr></tbody></table>`
+	got := renderMarkdown(content, "TS 23.501", nil)
+	if !strings.Contains(got, `src="/specs/TS%2023.501/images/fig.png"`) {
+		t.Errorf("expected image:// to be rewritten to spec-relative URL, got:\n%s", got)
+	}
+	if strings.Contains(got, "image://") {
+		t.Errorf("expected no remaining image:// URL, got:\n%s", got)
+	}
+}
+
 // TestHandleOpenAPI_NotFound verifies the error path when requesting a missing
 // OpenAPI spec returns 404 rather than 500.
 func TestHandleOpenAPI_NotFound(t *testing.T) {


### PR DESCRIPTION
3GPP DOCX tables were previously converted to GFM pipe Markdown, which
silently dropped information:

- `w:gridSpan` (horizontal cell merges) — a header spanning N columns
  collapsed to a single cell, mis-aligning with data rows that were then
  padded or truncated
- `w:vMerge` (vertical cell merges) — continuation cells became empty
- Run-level formatting inside cells (bold / italic / monospace)
- Multi-paragraph cell structure (paragraphs joined with a space)
- Header-row semantics (`w:tblHeader`)
- Image references inside cells

Tables are now emitted as `<table>` HTML, preserving structure and
formatting via `colspan` / `rowspan` / `<thead>` / `<th>` /
`<strong>` / `<em>` / `<code>` / `<img src="image://...">`. The web
viewer's goldmark is configured with `html.WithUnsafe()`, so the raw
HTML is rendered as-is, and LLM consumers of `get_section` can read
HTML tables natively. A regex was added to `web/markdown.go` to rewrite
`image://` URLs inside HTML `<img>` tags to spec-relative URLs.