### PR TITLE
feat: add multi-arch Docker image for ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+bin
+data
+specs
+*.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Docker
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          sudo docker image prune -af
+          df -h
+
+      - name: Install LibreOffice
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libreoffice
+
+      - name: Build binary
+        run: CGO_ENABLED=0 go build -o bin/3gpp-mcp ./cmd/3gpp-mcp
+
+      - name: Build DB
+        run: bin/3gpp-mcp build --release 19 --db 3gpp.db --convert-doc --convert-image --timeout 120s
+
+      - name: Upload DB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 3gpp-rel19-db
+          path: 3gpp.db
+          retention-days: 7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/higebu/3gpp-mcp:latest
+            ghcr.io/higebu/3gpp-mcp:rel19

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/*.db
 data/*.db-shm
 data/*.db-wal
 !data/.gitkeep
+3gpp.db
 
 # IDE
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS go-builder
+ARG TARGETARCH
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+    -ldflags="-s -w" \
+    -o /3gpp-mcp ./cmd/3gpp-mcp
+
+FROM scratch
+COPY --from=go-builder /3gpp-mcp /3gpp-mcp
+COPY 3gpp.db /3gpp.db
+ENTRYPOINT ["/3gpp-mcp"]
+CMD ["serve", "--db", "/3gpp.db"]


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile (scratch final image) with Rel-19 DB baked in
- Cross-compile Go binary for `linux/amd64` and `linux/arm64`; build DB only once on the host platform
- Add weekly GitHub Actions workflow to build and push to `ghcr.io/higebu/3gpp-mcp`

## Usage

```json
{
  "mcpServers": {
    "3gpp": {
      "command": "docker",
      "args": ["run", "-i", "--rm", "ghcr.io/higebu/3gpp-mcp"]
    }
  }
}
```