### PR TITLE
feat: add --scrape-workers flag to control spec listing concurrency

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         run: CGO_ENABLED=0 go build -o bin/3gpp-mcp ./cmd/3gpp-mcp
 
       - name: Build DB
-        run: bin/3gpp-mcp build --release 19 --db 3gpp.db --convert-doc --convert-image --timeout 120s
+        run: bin/3gpp-mcp build --release 19 --db 3gpp.db --convert-doc --convert-image --timeout 120s --scrape-workers 4
 
       - name: Upload DB artifact
         uses: actions/upload-artifact@v4

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -207,7 +207,7 @@ func cmdConvertDir(args []string) {
 }
 
 // resolveSpecs fetches, parses, and filters specs based on CLI flags.
-func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, seriesFlag string, release int, allVersions, useCache bool) []*pipeline.SpecVersion {
+func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, seriesFlag string, release int, allVersions, useCache bool, scrapeConcurrency int) []*pipeline.SpecVersion {
 	var seriesFilter []string
 	if seriesFlag != "" {
 		seriesFilter = strings.Split(seriesFlag, ",")
@@ -229,7 +229,7 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 		}
 	} else {
 		fmt.Println("Fetching spec list from 3GPP archive...")
-		entries, err = pipeline.FetchSpecList(ctx, client, seriesFilter, useCache)
+		entries, err = pipeline.FetchSpecList(ctx, client, seriesFilter, useCache, scrapeConcurrency)
 		if err != nil {
 			log.Fatalf("Failed to fetch spec list: %v", err)
 		}
@@ -258,6 +258,7 @@ func cmdDownload(args []string) {
 	convertDoc := fs.Bool("convert-doc", false, "Convert .doc to .docx using LibreOffice")
 	specList := fs.String("spec-list", "", "Use spec list file instead of scraping")
 	noCache := fs.Bool("no-cache", false, "Disable spec list cache")
+	scrapeWorkers := fs.Int("scrape-workers", 0, "Concurrency for scraping spec listings (0 = auto)")
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
@@ -269,7 +270,7 @@ func cmdDownload(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache)
+	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache, *scrapeWorkers)
 
 	if len(filtered) == 0 {
 		fmt.Println("No specs matched the filters.")
@@ -304,6 +305,7 @@ func cmdPipeline(args []string) {
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
 	specList := fs.String("spec-list", "", "Use spec list file instead of scraping")
 	noCache := fs.Bool("no-cache", false, "Disable spec list cache")
+	scrapeWorkers := fs.Int("scrape-workers", 0, "Concurrency for scraping spec listings (0 = auto)")
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
@@ -325,7 +327,7 @@ func cmdPipeline(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache)
+	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache, *scrapeWorkers)
 
 	if len(filtered) == 0 {
 		fmt.Println("No specs matched the filters.")
@@ -409,6 +411,7 @@ func cmdUpdate(args []string) {
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
 	specList := fs.String("spec-list", "", "Use spec list file instead of scraping")
 	noCache := fs.Bool("no-cache", false, "Disable spec list cache")
+	scrapeWorkers := fs.Int("scrape-workers", 0, "Concurrency for scraping spec listings (0 = auto)")
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
@@ -447,7 +450,7 @@ func cmdUpdate(args []string) {
 		entries, err = pipeline.LoadSpecList(*specList)
 	} else {
 		fmt.Println("Fetching spec list from 3GPP archive...")
-		entries, err = pipeline.FetchSpecList(ctx, client, nil, useCache)
+		entries, err = pipeline.FetchSpecList(ctx, client, nil, useCache, *scrapeWorkers)
 	}
 	if err != nil {
 		_ = os.Remove(newPath)

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -176,6 +176,7 @@ func TestResolveSpecs_FromSpecList(t *testing.T) {
 			0,     // release
 			false, // allVersions
 			false, // useCache
+			0,     // scrapeConcurrency
 		)
 		if len(specs) == 0 {
 			t.Error("expected at least one spec, got 0")
@@ -218,6 +219,7 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 			0,        // release
 			false,    // allVersions
 			false,    // useCache
+			0,        // scrapeConcurrency
 		)
 		if len(specs) != 1 {
 			t.Fatalf("expected 1 spec, got %d", len(specs))
@@ -464,6 +466,7 @@ func TestResolveSpecs_FetchAllSeries(t *testing.T) {
 			0,     // release
 			false, // allVersions (latestOnly=true)
 			false, // useCache
+			0,     // scrapeConcurrency
 		)
 		if len(specs) != 1 {
 			t.Fatalf("expected 1 spec, got %d", len(specs))

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -214,9 +214,13 @@ func FetchSpecZips(ctx context.Context, client *http.Client, specID string, useC
 
 // FetchSpecList scrapes the 3GPP FTP directory for all spec zip files.
 // If useCache is true, results are cached to disk with a 24h TTL.
-func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []string, useCache bool) ([]string, error) {
+// scrapeConcurrency controls parallel HTTP requests; 0 uses defaultConcurrency().
+func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []string, useCache bool, scrapeConcurrency int) ([]string, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	if scrapeConcurrency <= 0 {
+		scrapeConcurrency = defaultConcurrency()
 	}
 
 	// Check cache
@@ -260,7 +264,7 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 	var allSpecPairs []specPair
 	var mu sync.Mutex
 	var wg sync.WaitGroup
-	sem := make(chan struct{}, defaultConcurrency())
+	sem := make(chan struct{}, scrapeConcurrency)
 
 	for _, sd := range seriesDirs {
 		sd := sd

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -318,7 +318,7 @@ func TestFetchSpecList_Race(t *testing.T) {
 		},
 	}
 
-	entries, err := FetchSpecList(context.Background(), client, nil, false)
+	entries, err := FetchSpecList(context.Background(), client, nil, false, 0)
 	if err != nil {
 		t.Fatalf("FetchSpecList: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `--scrape-workers` flag to `build`, `download`, and `update` commands to control the number of concurrent HTTP requests when scraping spec listings from the 3GPP FTP archive
- Default (`0`) uses auto-detected concurrency; lower values (e.g. `4`) reduce the chance of hitting rate limits from GitHub Actions runners
- Update Docker workflow to use `--scrape-workers 4`