### PR TITLE
fix(pipeline): include suffixed specs and base-36 version tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,14 @@ go vet ./...                        # Static analysis
 golangci-lint run                   # Full lint (config: .golangci.yml)
 
 # Build database (download + import)
-make build-db RELEASE=19            # Download and import specs into DB
+make build-db                       # Download + import latest version of every spec
+make build-db RELEASE=19            # ...or restrict to a single release
 make import FILE=path/to/spec.docx  # Import single file
 make import-dir SPECS_DIR=specs     # Import directory
 
 # Download only (no import)
-make download-specs RELEASE=19      # Download specs for a specific release
+make download-specs                 # Download latest version of every spec
+make download-specs RELEASE=19      # ...or restrict to a single release
 make download-latest-specs          # Download latest version of each spec
 make update-specs                   # Update DB to latest versions
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@
 SPECS_DIR ?= specs
 DB_PATH ?= data/3gpp.db
 BIN_DIR ?= bin
-RELEASE ?= 19
+# RELEASE selects which versions to build/download. The default "latest" builds
+# the latest version of every spec across all releases (full coverage, including
+# specs that have no Release-19 version such as TS 34.108). Set RELEASE to a
+# number (e.g. RELEASE=19) to restrict to a single release.
+RELEASE ?= latest
+release_flag = $(if $(filter latest,$(RELEASE)),--latest,--release $(RELEASE))
 
 # Build the MCP server
 build:
@@ -21,13 +26,15 @@ import: build
 import-dir: build
 	./$(BIN_DIR)/3gpp-mcp import-dir --db $(DB_PATH) $(SPECS_DIR)
 
-# Download + import in one step (recommended)
+# Download + import in one step (recommended). Builds the latest version of
+# every spec by default; pass RELEASE=19 to restrict to a single release.
 build-db: build
-	./$(BIN_DIR)/3gpp-mcp build --release $(RELEASE) --db $(DB_PATH) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp build $(release_flag) --db $(DB_PATH) --convert-doc
 
-# Download specs for a specific release (download only, no conversion)
+# Download specs (download only, no conversion). Latest of every spec by
+# default; pass RELEASE=19 to restrict to a single release.
 download-specs: build
-	./$(BIN_DIR)/3gpp-mcp download --release $(RELEASE) --output-dir $(SPECS_DIR) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp download $(release_flag) --output-dir $(SPECS_DIR) --convert-doc
 
 # Download the single latest version of each spec across all releases
 download-latest-specs: build

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -19,14 +19,21 @@ import (
 	"github.com/higebu/3gpp-mcp/db"
 )
 
-// docxVersionRE matches 3GPP docx filenames like "21900-j10.docx" to extract the version letter.
-var docxVersionRE = regexp.MustCompile(`(?i).+-([a-z])\d+\.docx$`)
+// docxVersionRE matches 3GPP docx filenames like "21900-j10.docx" or
+// "38101-1-j50.docx" to capture the base-36 version token.
+var docxVersionRE = regexp.MustCompile(`(?i)-([0-9a-z]{2,})\.docx$`)
 
 // releaseFromDocxFilename extracts the release number from a 3GPP docx filename.
-// Returns 0 if the filename does not match the expected pattern.
+// The release is encoded in the first character of the version token (base-36:
+// a=10, k=20, ..., and plain digits for legacy releases). Returns 0 if the
+// filename does not match the expected pattern.
 func releaseFromDocxFilename(filename string) int {
-	if m := docxVersionRE.FindStringSubmatch(filename); m != nil {
-		return letterToRelease(m[1])
+	m := docxVersionRE.FindStringSubmatch(filename)
+	if m == nil {
+		return 0
+	}
+	if r := base36Digit(strings.ToLower(m[1])[0]); r > 0 {
+		return r
 	}
 	return 0
 }

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,10 +36,11 @@ func defaultConcurrency() int {
 // SpecVersion represents a specific version of a 3GPP spec available for download.
 type SpecVersion struct {
 	Series        string // e.g., "23"
-	SpecID        string // e.g., "23.501"
+	SpecID        string // e.g., "23.501" or "38.101-1"
 	Filename      string // e.g., "23501-k10.zip"
-	VersionLetter string // e.g., "k" or "" for legacy
-	VersionMinor  int    // e.g., 10
+	Version       string // raw version token, e.g. "k10", "f20", "fa0", "300"
+	VersionLetter string // first version character if it is a letter, else ""
+	VersionMinor  int    // base-36 value of the characters after the first (for sorting)
 	Release       int    // e.g., 20 or 0 for legacy
 	URL           string // full download URL
 }
@@ -48,33 +48,52 @@ type SpecVersion struct {
 const baseURL = "https://www.3gpp.org/ftp/Specs/archive/"
 
 var (
-	versionRE   = regexp.MustCompile(`(?i).+-([a-z])(\d+)\.zip$`)
-	legacyRE    = regexp.MustCompile(`.+-(\d{3,})\.zip$`)
 	seriesDirRE = regexp.MustCompile(`(\d+)_series$`)
-	specDirRE   = regexp.MustCompile(`^\d+\.\d+$`)
-	hrefRE      = regexp.MustCompile(`href="([^"]+)"`)
-	verLetterRE = regexp.MustCompile(`(?i)^([a-zA-Z])(\d+)$`)
-	verNumRE    = regexp.MustCompile(`^(\d+)$`)
+	// specDirRE matches spec directory names, including the multi-part specs
+	// that carry a numeric suffix such as "38.101-1" or "34.123-2".
+	specDirRE = regexp.MustCompile(`^\d+\.\d+(-\d+)?$`)
+	hrefRE    = regexp.MustCompile(`href="([^"]+)"`)
+	// versionTokenRE matches a 3GPP version token. The version is a base-36
+	// string where every character can be a digit or a letter, e.g. "k10",
+	// "f20", "3a0" or "fb0" — not just a letter followed by digits.
+	versionTokenRE = regexp.MustCompile(`^[0-9a-z]{2,}$`)
 )
 
-// letterToRelease converts version letter to release number: a=10, b=11, ..., j=19, k=20, ...
-func letterToRelease(letter string) int {
-	if len(letter) == 0 {
-		return 0
+// base36Digit returns the base-36 value of a single version character
+// ('0'-'9' -> 0-9, 'a'-'z' -> 10-35), or -1 if the character is invalid.
+func base36Digit(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'z':
+		return int(c-'a') + 10
+	default:
+		return -1
 	}
-	ch := strings.ToLower(letter)[0]
-	return int(ch-'a') + 10
 }
 
-// SpecVersionString returns the version string for DB comparison.
+// versionValue converts a base-36 version token into a comparable integer.
+// Returns 0 if the token contains an invalid character.
+func versionValue(v string) int64 {
+	v = strings.ToLower(strings.TrimSpace(v))
+	var n int64
+	for i := 0; i < len(v); i++ {
+		d := base36Digit(v[i])
+		if d < 0 {
+			return 0
+		}
+		n = n*36 + int64(d)
+	}
+	return n
+}
+
+// SpecVersionString returns the raw version token for DB comparison/display.
 func SpecVersionString(sv *SpecVersion) string {
-	if sv.VersionLetter != "" {
-		return fmt.Sprintf("%s%d", sv.VersionLetter, sv.VersionMinor)
-	}
-	return fmt.Sprintf("%d", sv.VersionMinor)
+	return sv.Version
 }
 
-// ParseSpecEntry parses a spec list entry like "23_series/23.501/23501-k10.zip".
+// ParseSpecEntry parses a spec list entry like "23_series/23.501/23501-k10.zip"
+// or "38_series/38.101-1/38101-1-j50.zip".
 func ParseSpecEntry(entry string) *SpecVersion {
 	entry = strings.TrimSpace(entry)
 	if entry == "" || !strings.HasSuffix(entry, ".zip") {
@@ -91,41 +110,41 @@ func ParseSpecEntry(entry string) *SpecVersion {
 	if seriesMatch == nil {
 		return nil
 	}
+	if !specDirRE.MatchString(specDir) {
+		return nil
+	}
 	series := seriesMatch[1]
 	specID := specDir
 
-	if match := versionRE.FindStringSubmatch(filename); match != nil {
-		letter := strings.ToLower(match[1])
-		minor, err := strconv.Atoi(match[2])
-		if err != nil {
-			return nil
-		}
-		return &SpecVersion{
-			Series:        series,
-			SpecID:        specID,
-			Filename:      filename,
-			VersionLetter: letter,
-			VersionMinor:  minor,
-			Release:       letterToRelease(letter),
-			URL:           baseURL + entry,
-		}
+	// The version is the final hyphen-delimited token of the filename, e.g.
+	// "k10" in "23501-k10.zip" or "j50" in "38101-1-j50.zip". Each character is
+	// a base-36 digit; the first character encodes the release (a=10, k=20, ...,
+	// and plain digits for legacy releases such as "300" -> release 3).
+	base := strings.TrimSuffix(filename, ".zip")
+	idx := strings.LastIndex(base, "-")
+	if idx < 0 {
+		return nil
+	}
+	token := strings.ToLower(base[idx+1:])
+	if !versionTokenRE.MatchString(token) {
+		return nil
 	}
 
-	if match := legacyRE.FindStringSubmatch(filename); match != nil {
-		minor, err := strconv.Atoi(match[1])
-		if err != nil {
-			return nil
-		}
-		return &SpecVersion{
-			Series:       series,
-			SpecID:       specID,
-			Filename:     filename,
-			VersionMinor: minor,
-			URL:          baseURL + entry,
-		}
+	letter := ""
+	if token[0] >= 'a' && token[0] <= 'z' {
+		letter = token[0:1]
 	}
 
-	return nil
+	return &SpecVersion{
+		Series:        series,
+		SpecID:        specID,
+		Filename:      filename,
+		Version:       token,
+		VersionLetter: letter,
+		VersionMinor:  int(versionValue(token[1:])),
+		Release:       base36Digit(token[0]),
+		URL:           baseURL + entry,
+	}
 }
 
 // IsNewerVersion compares version strings (e.g., "k10" vs "j60").
@@ -133,26 +152,7 @@ func IsNewerVersion(newVer, oldVer string) bool {
 	if oldVer == "" {
 		return true
 	}
-	return parseVer(newVer) > parseVer(oldVer)
-}
-
-func parseVer(v string) int64 {
-	if m := verLetterRE.FindStringSubmatch(v); m != nil {
-		major := int64(strings.ToLower(m[1])[0]-'a') + 10
-		minor, err := strconv.ParseInt(m[2], 10, 64)
-		if err != nil {
-			return 0
-		}
-		return major*10000 + minor
-	}
-	if m := verNumRE.FindStringSubmatch(v); m != nil {
-		n, err := strconv.ParseInt(m[1], 10, 64)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
+	return versionValue(newVer) > versionValue(oldVer)
 }
 
 // FetchSpecZips fetches zip file entries for a single spec directly,

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -20,7 +20,15 @@ func TestParseSpecEntry(t *testing.T) {
 		wantRe int    // expected Release
 	}{
 		{"modern version", "23_series/23.501/23501-k10.zip", "23.501", 20},
-		{"legacy version", "23_series/23.501/23501-300.zip", "23.501", 0},
+		// Legacy all-digit versions encode the release in the first digit:
+		// "300" -> release 3 (Release 1999).
+		{"legacy version", "23_series/23.501/23501-300.zip", "23.501", 3},
+		// Suffixed (multi-part) spec directories must be accepted.
+		{"suffix spec dir", "38_series/38.101-1/38101-1-j50.zip", "38.101-1", 19},
+		{"suffix spec dir part 2", "38_series/38.521-1/38521-1-j40.zip", "38.521-1", 19},
+		// Base-36 versions with letters in the 2nd/3rd position must parse.
+		{"base36 digit-major", "34_series/34.108/34108-3a0.zip", "34.108", 3},
+		{"base36 letter-major", "34_series/34.108/34108-fb0.zip", "34.108", 15},
 		{"empty string", "", "", 0},
 		{"no zip suffix", "23_series/23.501/23501-k10.docx", "", 0},
 		{"wrong parts count", "23501-k10.zip", "", 0},
@@ -63,6 +71,10 @@ func TestIsNewerVersion(t *testing.T) {
 		{"", "", true}, // oldVer=="" always returns true
 		{"300", "200", true},
 		{"200", "300", false},
+		// Base-36 versions: "fa0" (technical=10) is newer than "f20".
+		{"fa0", "f20", true},
+		{"f20", "fa0", false},
+		{"j50", "j40", true},
 	}
 
 	for _, tt := range tests {
@@ -136,8 +148,9 @@ func TestSpecVersionString(t *testing.T) {
 		sv   *SpecVersion
 		want string
 	}{
-		{&SpecVersion{VersionLetter: "k", VersionMinor: 10}, "k10"},
-		{&SpecVersion{VersionMinor: 300}, "300"},
+		{&SpecVersion{Version: "k10"}, "k10"},
+		{&SpecVersion{Version: "300"}, "300"},
+		{&SpecVersion{Version: "fa0"}, "fa0"},
 	}
 	for _, tt := range tests {
 		got := SpecVersionString(tt.sv)


### PR DESCRIPTION
## Summary

Some specifications were missing from the database. Investigating against the live 3GPP FTP archive revealed two distinct bugs in the spec-list scraper plus a build-default that excluded older specs.

### Root causes

1. **Suffixed (multi-part) spec directories were dropped** (e.g. `38.101-1`, `38.521-1`, `34.123-2`). `specDirRE` only matched `\d+\.\d+` and rejected the `-N` suffix, so these directories were never scraped. (Fixes #10)

2. **Base-36 version tokens were dropped.** 3GPP version strings are 3-character base-36 tokens where *any* position can be a letter (e.g. `3a0`, `fb0`, `fa0`). The old `versionRE` (`[a-z]\d+`) / `legacyRE` (`\d{3,}`) handled only a single leading letter followed by digits, so files like `34108-3a0.zip` matched neither pattern and were silently discarded — which could also yield a wrong "latest" selection.

3. **`34.108` was excluded by the build default.** `make build-db` was pinned to `--release 19`, but 34.108's latest version is `f20` (Rel-15) and it has no Release-19 version, so it never made it into the DB.

### Changes

- `converter/pipeline/speclist.go`
  - `specDirRE` now accepts an optional numeric suffix: `^\d+\.\d+(-\d+)?$`.
  - Version parsing takes the final hyphen-delimited token and interprets it as base-36, deriving the release from the first character (`a=10`, `k=20`, …, and plain digits for legacy releases such as `300` → Rel-3).
  - Comparison and `SpecVersionString` operate on the raw token, so letters in any position order correctly.
- `converter/pipeline/pipeline.go`: `releaseFromDocxFilename` uses the same base-36 logic.
- `Makefile` / `AGENTS.md`: `make build-db` / `download-specs` now default to the latest version of **every** spec across all releases (`--latest`); pass `RELEASE=19` to restrict to a single release.
- Tests for suffixed dirs and base-36 versions.

### Verification

`gofmt`, `go vet`, and the full test suite pass. Verified against the live 3GPP archive:

| spec | zips | parsed | latest |
|------|------|--------|--------|
| 38.101-1 | 111 | 111 (100%) | j50 (Rel-19) |
| 38.521-1 | 52 | 52 (100%) | j40 (Rel-19) |
| 34.108 | 106 | 106 (100%) | f20 (Rel-15) |

Closes #10