### PR TITLE
docs: default container and Cloud Build to latest specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w" \
     -o /3gpp-mcp ./cmd/3gpp-mcp
 
-# 2) Build the database for the requested release. LibreOffice is required for
-#    --convert-doc / --convert-image but lives only in this stage, so it never
-#    bloats the final image. Temp files are deleted as each spec is processed,
-#    keeping disk usage low.
+# 2) Build the database. By default the latest version of every spec across all
+#    releases is baked in; pass --build-arg RELEASE=19 to restrict to a single
+#    release. LibreOffice is required for --convert-doc / --convert-image but
+#    lives only in this stage, so it never bloats the final image. Temp files are
+#    deleted as each spec is processed, keeping disk usage low.
 FROM golang:1.26-bookworm AS db-builder
-ARG RELEASE=19
+ARG RELEASE=latest
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libreoffice ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /3gpp-mcp /3gpp-mcp
-RUN /3gpp-mcp build \
-    --release ${RELEASE} \
+RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
+        SELECT="--latest"; \
+    else \
+        SELECT="--release ${RELEASE}"; \
+    fi \
+    && /3gpp-mcp build ${SELECT} \
     --db /3gpp.db \
     --convert-doc \
     --convert-image \

--- a/README.md
+++ b/README.md
@@ -42,15 +42,22 @@ definitions, and embedded images) baked in. No pre-built database is needed in
 the build context.
 
 ```bash
-# Build an image with the Release 19 database baked in (default RELEASE=19)
+# Build an image with the latest version of every spec baked in (default)
+docker build -t 3gpp-mcp:latest .
+
+# ...or restrict the database to a single release
 docker build --build-arg RELEASE=19 -t 3gpp-mcp:rel19 .
 
 # stdio transport (Claude Code / IDE integration)
-docker run --rm -i 3gpp-mcp:rel19
+docker run --rm -i 3gpp-mcp:latest
 
 # HTTP transport
-docker run --rm -p 8080:8080 3gpp-mcp:rel19 serve --db /3gpp.db --transport http --addr :8080
+docker run --rm -p 8080:8080 3gpp-mcp:latest serve --db /3gpp.db --transport http --addr :8080
 ```
+
+`RELEASE` defaults to `latest`, which bakes in the latest version of every spec
+across all releases. Set `--build-arg RELEASE=<n>` (e.g. `19`) to restrict the
+database to a single release.
 
 ### Deploy to Cloud Run
 
@@ -72,7 +79,10 @@ Requires Go 1.26+. LibreOffice is optional (needed for `.doc` to `.docx` convers
 Download and import specifications into the database. Temporary files are deleted after each spec is processed, minimizing disk usage.
 
 ```bash
-# Download and import all Release 19 specs
+# Download and import the latest version of every spec (all releases)
+3gpp-mcp build --latest --db data/3gpp.db --convert-doc --convert-image
+
+# ...or restrict to a single release
 3gpp-mcp build --release 19 --db data/3gpp.db --convert-doc --convert-image
 ```
 
@@ -232,7 +242,7 @@ The `build` command extracts images from DOCX files and stores them in the datab
 
 ```bash
 # Convert EMF/WMF to PNG for LLM viewing (requires LibreOffice)
-3gpp-mcp build --release 19 --db data/3gpp.db --convert-image
+3gpp-mcp build --latest --db data/3gpp.db --convert-image
 ```
 
 ## Tips

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,15 @@
 # it is not associated with a GitHub commit and posts no GitHub status check.
 # The same config works for both one-off and scheduled deploys.
 #
-# Manual run:
+# _RELEASE defaults to "latest", baking in the latest version of every spec
+# across all releases. Set it to a release number (e.g. _RELEASE=19) to restrict
+# the database to a single release.
+#
+# Manual run (latest of every spec):
+#   gcloud builds submit --no-source --config cloudbuild.yaml \
+#     --substitutions=_REF=main,_REGION=asia-northeast1,_REPO=3gpp-mcp,_SERVICE=3gpp-mcp
+#
+# Manual run (single release):
 #   gcloud builds submit --no-source --config cloudbuild.yaml \
 #     --substitutions=_REF=main,_RELEASE=19,_REGION=asia-northeast1,_REPO=3gpp-mcp,_SERVICE=3gpp-mcp
 #
@@ -18,7 +26,9 @@
 
 substitutions:
   _REF: "main"
-  _RELEASE: "19"
+  # "latest" = latest version of every spec across all releases; or a release
+  # number such as "19" to restrict the database to a single release.
+  _RELEASE: "latest"
   _REGION: "asia-northeast1"
   _REPO: "3gpp-mcp"
   _SERVICE: "3gpp-mcp"


### PR DESCRIPTION
## Summary

Make the container image, Cloud Build pipeline, and README consistent with the `make build-db` default introduced in #12: build the **latest version of every spec across all releases** by default, while still allowing a single release to be selected.

## Changes

- **Dockerfile**: `ARG RELEASE` now defaults to `latest`. The build step selects `--latest` when `RELEASE` is `latest` (or empty) and `--release <n>` otherwise.
- **cloudbuild.yaml**: `_RELEASE` defaults to `latest`; documented both the latest and single-release manual-run invocations.
- **README.md**: Docker build and `3gpp-mcp build` examples now show the latest-by-default behavior with the `RELEASE=<n>` / `--release` override. The "Separate databases per release" section is intentionally left release-specific.

## Notes

- The shell conditional in the Dockerfile was verified with `sh`: `RELEASE=latest`/empty → `--latest`, `RELEASE=19` → `--release 19`.
- Pure docs/config; no Go code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CckXPrzVCnnNSeddjXDr4Y)_