### PR TITLE
fix: render cross-references and images correctly inside tables

### DIFF
--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -88,8 +88,15 @@ func ConvertResultImages(ctx context.Context, result *ParseResult) int {
 // with optional dimension suffix like ", 576x432".
 var placeholderRE = regexp.MustCompile(`\[Figure:\s*(.+?)\s*\(([^,]+),\s*use get_image to retrieve(?:,\s*(\d+)x(\d+))?\)\]`)
 
+// imageRefRE matches the filename in an image:// reference (e.g. inside an HTML
+// <img src="image://image1.wmf?w=..&h=.."> tag or a Markdown image link),
+// capturing only the filename portion up to any query string or delimiter.
+var imageRefRE = regexp.MustCompile(`image://([^?"')\s]+)`)
+
 // UpdateImagePlaceholders replaces non-LLM-readable image placeholders in
-// section content with LLM-readable image links after image conversion.
+// section content with LLM-readable image links after image conversion, and
+// rewrites image:// references (e.g. HTML <img> tags emitted for table images)
+// to point at the converted PNG filenames.
 func UpdateImagePlaceholders(result *ParseResult) {
 	converted := make(map[string]string) // base name (without ext) → new PNG name
 	for _, img := range result.Images {
@@ -105,7 +112,7 @@ func UpdateImagePlaceholders(result *ParseResult) {
 
 	for _, section := range result.Sections {
 		for i, content := range section.Content {
-			section.Content[i] = placeholderRE.ReplaceAllStringFunc(content, func(match string) string {
+			content = placeholderRE.ReplaceAllStringFunc(content, func(match string) string {
 				sub := placeholderRE.FindStringSubmatch(match)
 				if len(sub) < 3 {
 					return match
@@ -125,6 +132,25 @@ func UpdateImagePlaceholders(result *ParseResult) {
 				}
 				return fmt.Sprintf("![%s](image://%s%s)", alt, newName, dimSuffix)
 			})
+
+			// Rewrite remaining image:// references (e.g. HTML <img> tags in
+			// table content) whose original filename was renamed during PNG
+			// conversion. Only the filename is replaced; any ?w=&h= suffix is kept.
+			content = imageRefRE.ReplaceAllStringFunc(content, func(match string) string {
+				sub := imageRefRE.FindStringSubmatch(match)
+				if len(sub) < 2 {
+					return match
+				}
+				filename := sub[1]
+				base := strings.TrimSuffix(filename, filepath.Ext(filename))
+				newName, ok := converted[base]
+				if !ok || newName == filename {
+					return match
+				}
+				return "image://" + newName
+			})
+
+			section.Content[i] = content
 		}
 	}
 }

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -288,3 +288,43 @@ func sofficeCanConvertImages(t *testing.T) bool {
 	}
 	return false
 }
+
+// TestUpdateImagePlaceholders_TableImageRef verifies that image:// references
+// inside HTML table content (and Markdown placeholders) are rewritten to the
+// converted PNG filename after EMF/WMF conversion. Does not require soffice.
+func TestUpdateImagePlaceholders_TableImageRef(t *testing.T) {
+	result := &ParseResult{
+		Sections: []*Section{
+			{
+				Number: "6.4.1.3.1.1",
+				Content: []string{
+					`<table><tr><td><img src="image://image1.wmf?w=100&h=50" alt="Figure"></td></tr></table>`,
+					"[Figure: Figure (image2.emf, use get_image to retrieve)]",
+					`<table><tr><td><img src="image://image3.png" alt="Figure"></td></tr></table>`,
+				},
+			},
+		},
+		// Post-conversion image list: WMF/EMF replaced by PNG, plus an untouched PNG.
+		Images: []*EmbeddedImage{
+			{Name: "image1.png", MIMEType: "image/png", LLMReadable: true},
+			{Name: "image2.png", MIMEType: "image/png", LLMReadable: true},
+			{Name: "image3.png", MIMEType: "image/png", LLMReadable: true},
+		},
+	}
+
+	UpdateImagePlaceholders(result)
+
+	got := result.Sections[0].Content
+	wantTableImg := `<table><tr><td><img src="image://image1.png?w=100&h=50" alt="Figure"></td></tr></table>`
+	if got[0] != wantTableImg {
+		t.Errorf("table WMF img not rewritten:\n got:  %q\n want: %q", got[0], wantTableImg)
+	}
+	wantPlaceholder := "![Figure](image://image2.png)"
+	if got[1] != wantPlaceholder {
+		t.Errorf("placeholder not rewritten:\n got:  %q\n want: %q", got[1], wantPlaceholder)
+	}
+	wantPNG := `<table><tr><td><img src="image://image3.png" alt="Figure"></td></tr></table>`
+	if got[2] != wantPNG {
+		t.Errorf("already-PNG table img should be unchanged:\n got:  %q\n want: %q", got[2], wantPNG)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -823,15 +823,17 @@ func rfcExtractor(m []int, content string) (string, string, bool) {
 
 // multiRefExtractor converts regex submatch indices into replacement text containing multiple links.
 // urlFor is called with (targetSpec, targetSection) and returns a URL string.
+// mkLink renders a single link from (linkText, url); it lets the caller choose
+// Markdown or HTML link syntax depending on the surrounding context.
 // Returns (replacementText, ok). When ok is false, the match is skipped.
-type multiRefExtractor func(m []int, content string, urlFor func(string, string) string) (string, bool)
+type multiRefExtractor func(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool)
 
 // multiRefSpecSections extracts (spec, []sections) from a multi-section regex match.
 // Returns ("", nil, false) if fewer than 2 sections are found.
 type multiRefSpecSections func(m []int, content string) (string, []string, bool)
 
 // tsMultiPrefixMRExtractor handles "clauses 8.2 and 16.11 of TS 23.402 [45]".
-func tsMultiPrefixMRExtractor(m []int, content string, urlFor func(string, string) string) (string, bool) {
+func tsMultiPrefixMRExtractor(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool) {
 	keyword := content[m[2]:m[3]]
 	secList := content[m[4]:m[5]]
 	specType := content[m[6]:m[7]]
@@ -844,9 +846,9 @@ func tsMultiPrefixMRExtractor(m []int, content string, urlFor func(string, strin
 	}
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
-		return "[" + sec + "](" + urlFor(spec, sec) + ")"
+		return mkLink(sec, urlFor(spec, sec))
 	})
-	specLink := "[" + specType + " " + specNum + "](" + urlFor(spec, "") + ")"
+	specLink := mkLink(specType+" "+specNum, urlFor(spec, ""))
 	result := keyword + " " + linkedSecList + " of " + specLink
 
 	if m[10] >= 0 {
@@ -869,7 +871,7 @@ func tsMultiPrefixSpecSections(m []int, content string) (string, []string, bool)
 }
 
 // tsMultiMRExtractor handles "TS 23.402 clauses 8.2 and 16.11".
-func tsMultiMRExtractor(m []int, content string, urlFor func(string, string) string) (string, bool) {
+func tsMultiMRExtractor(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool) {
 	specType := content[m[2]:m[3]]
 	specNum := content[m[4]:m[5]]
 	keyword := content[m[6]:m[7]]
@@ -882,9 +884,9 @@ func tsMultiMRExtractor(m []int, content string, urlFor func(string, string) str
 	}
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
-		return "[" + sec + "](" + urlFor(spec, sec) + ")"
+		return mkLink(sec, urlFor(spec, sec))
 	})
-	specLink := "[" + specType + " " + specNum + "](" + urlFor(spec, "") + ")"
+	specLink := mkLink(specType+" "+specNum, urlFor(spec, ""))
 	return specLink + " " + keyword + " " + linkedSecList, true
 }
 

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -44,16 +44,18 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 
 	// Build list of raw-HTML block regions (tables). goldmark does not process
 	// Markdown link syntax inside raw HTML blocks, so references in these regions
-	// must be emitted as HTML anchors instead of Markdown links.
+	// must be emitted as HTML anchors instead of Markdown links. The DOCX→HTML
+	// pipeline always emits lowercase <table>/</table> tags, so search content
+	// directly: lowercasing first could shift byte offsets for rare Unicode
+	// characters whose lowercase form has a different byte length.
 	var htmlRegions []region
-	lower := strings.ToLower(content)
-	for i := 0; i < len(lower); {
-		open := strings.Index(lower[i:], "<table")
+	for i := 0; i < len(content); {
+		open := strings.Index(content[i:], "<table")
 		if open < 0 {
 			break
 		}
 		open += i
-		rel := strings.Index(lower[open:], "</table>")
+		rel := strings.Index(content[open:], "</table>")
 		if rel < 0 {
 			htmlRegions = append(htmlRegions, region{open, len(content)})
 			break

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	htmlpkg "html"
 	"regexp"
 	"sort"
 	"strings"
@@ -8,6 +9,17 @@ import (
 
 // existingLinkRE matches Markdown link syntax [text](url) to avoid double-linking.
 var existingLinkRE = regexp.MustCompile(`\[[^\]]*\]\([^)]*\)`)
+
+// mdLink renders a Markdown link.
+func mdLink(text, url string) string {
+	return "[" + text + "](" + url + ")"
+}
+
+// htmlLink renders an HTML anchor. Used inside raw HTML blocks (e.g. tables)
+// where goldmark would not process Markdown link syntax.
+func htmlLink(text, url string) string {
+	return `<a href="` + htmlpkg.EscapeString(url) + `">` + htmlpkg.EscapeString(text) + `</a>`
+}
 
 // LinkifyRefs replaces spec/RFC/bracket references in Markdown content with Markdown links.
 // bracketMap maps bracket numbers (e.g. "19") to spec IDs (e.g. "TS 33.203"); pass nil to skip.
@@ -30,6 +42,36 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 		return false
 	}
 
+	// Build list of raw-HTML block regions (tables). goldmark does not process
+	// Markdown link syntax inside raw HTML blocks, so references in these regions
+	// must be emitted as HTML anchors instead of Markdown links.
+	var htmlRegions []region
+	lower := strings.ToLower(content)
+	for i := 0; i < len(lower); {
+		open := strings.Index(lower[i:], "<table")
+		if open < 0 {
+			break
+		}
+		open += i
+		rel := strings.Index(lower[open:], "</table>")
+		if rel < 0 {
+			htmlRegions = append(htmlRegions, region{open, len(content)})
+			break
+		}
+		end := open + rel + len("</table>")
+		htmlRegions = append(htmlRegions, region{open, end})
+		i = end
+	}
+
+	linkFor := func(start, end int) func(text, url string) string {
+		for _, r := range htmlRegions {
+			if start >= r.start && end <= r.end {
+				return htmlLink
+			}
+		}
+		return mdLink
+	}
+
 	type candidate struct {
 		start, end int
 		text       string
@@ -49,7 +91,7 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			if isExcluded(m[0], m[1]) {
 				continue
 			}
-			text, ok := pat.extract(m, content, urlFor)
+			text, ok := pat.extract(m, content, urlFor, linkFor(m[0], m[1]))
 			if !ok {
 				continue
 			}
@@ -91,7 +133,7 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			candidates = append(candidates, candidate{
 				start: m[0],
 				end:   m[1],
-				text:  "[" + matchText + "](" + u + ")",
+				text:  linkFor(m[0], m[1])(matchText, u),
 			})
 		}
 	}

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -252,3 +252,42 @@ func TestLinkifyRefs_MultipleRefs(t *testing.T) {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
 	}
 }
+
+// References inside raw HTML table blocks must be rendered as HTML anchors,
+// because goldmark does not process Markdown link syntax inside raw HTML.
+func TestLinkifyRefs_InsideTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single ref in table cell becomes HTML anchor",
+			input: "<table><tr><td><p>See TS 36.331 for details</p></td></tr></table>",
+			want:  `<table><tr><td><p>See <a href="/specs/TS 36.331">TS 36.331</a> for details</p></td></tr></table>`,
+		},
+		{
+			name:  "ref with clause in table cell",
+			input: "<table><tr><td>TS 23.501 clause 5.1</td></tr></table>",
+			want:  `<table><tr><td><a href="/specs/TS 23.501/sections/5.1">TS 23.501 clause 5.1</a></td></tr></table>`,
+		},
+		{
+			name:  "multi-section ref in table cell",
+			input: "<table><tr><td>TS 23.402 clauses 8.2 and 16.11</td></tr></table>",
+			want:  `<table><tr><td><a href="/specs/TS 23.402">TS 23.402</a> clauses <a href="/specs/TS 23.402/sections/8.2">8.2</a> and <a href="/specs/TS 23.402/sections/16.11">16.11</a></td></tr></table>`,
+		},
+		{
+			name:  "ref outside table stays Markdown, ref inside table is HTML",
+			input: "See TS 38.300.\n\n<table><tr><td>See TS 36.331</td></tr></table>",
+			want:  `See [TS 38.300](/specs/TS 38.300).` + "\n\n" + `<table><tr><td>See <a href="/specs/TS 36.331">TS 36.331</a></td></tr></table>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, nil, urlFor)
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two issues where elements inside tables were broken in the web viewer, both rooted in the fact that tables are emitted as raw HTML during DOCX→Markdown conversion.

### #14 — Cross-references inside tables were not hyperlinked

Table content is emitted as a raw HTML block, which goldmark passes through without processing Markdown link syntax. As a result, references inside tables showed literal text like `(/specs/TS%2036.331)` instead of a link.

`LinkifyRefs` now emits HTML `<a>` anchors for matches inside `<table>...</table>` regions, while keeping Markdown links everywhere else.

### #15 — WMF/EMF images inside tables were broken / "missing from DB"

Table images are emitted as ``'&lt;img src="image://image1.wmf"&gt;'`` (using the original filename) during parsing. When `--convert-image` converts WMF/EMF to PNG, the images are renamed to `image1.png` in the DB, but only the Markdown `[Figure: ...]` placeholders were updated — the table HTML `<img src>` still pointed at the now-missing `image1.wmf`.

`UpdateImagePlaceholders` now also rewrites `image://<filename>` references in section content to the converted PNG filename (preserving any `?w=&h=` suffix).

## Changes

- `db/linkify.go`, `db/db.go`: context-aware link rendering (HTML anchors inside tables, Markdown links elsewhere)
- `converter/docx/emf.go`: rewrite `image://` references to converted PNG names

## Tests

- `db/linkify_test.go`: cross-references inside table regions render as HTML anchors; references outside tables stay Markdown; multi-section refs covered
- `converter/docx/emf_test.go`: table ``'&lt;img src="image://x.wmf"&gt;'`` is rewritten to the PNG name after conversion (no soffice required)
- `go test -short ./...`, `gofmt`, `go vet`, `go build ./...` all pass

Fixes #14
Fixes #15