### PR TITLE
fix(docx): preserve subscript and superscript formatting

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -24,6 +24,9 @@ type runInfo struct {
 	Bold   bool
 	Italic bool
 	IsCode bool // true if the run uses a monospace/code font
+	// VertAlign holds the vertical alignment of the run, either
+	// "superscript", "subscript", or "" (baseline).
+	VertAlign string
 }
 
 // parseParagraph parses a w:p XML element from raw bytes into paragraphInfo.
@@ -103,6 +106,10 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 				if inRPr && inR {
 					val := getAttrVal(t, "val")
 					currentRun.Italic = val != "false" && val != "0"
+				}
+			case "vertAlign":
+				if inRPr && inR {
+					currentRun.VertAlign = getAttrVal(t, "val")
 				}
 			case "t":
 				inT = true
@@ -274,14 +281,19 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 				continue
 			}
 			if run.Bold && run.Italic {
-				parts = append(parts, "***"+runText+"***")
+				runText = "***" + runText + "***"
 			} else if run.Bold {
-				parts = append(parts, "**"+runText+"**")
+				runText = "**" + runText + "**"
 			} else if run.Italic {
-				parts = append(parts, "*"+runText+"*")
-			} else {
-				parts = append(parts, runText)
+				runText = "*" + runText + "*"
 			}
+			switch run.VertAlign {
+			case "superscript":
+				runText = "<sup>" + runText + "</sup>"
+			case "subscript":
+				runText = "<sub>" + runText + "</sub>"
+			}
+			parts = append(parts, runText)
 		}
 		if len(parts) > 0 {
 			return strings.Join(parts, "")

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -70,6 +70,27 @@ func TestParseParagraph_ItalicFalseAttr(t *testing.T) {
 	}
 }
 
+func TestParseParagraph_VertAlign(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:t>n_78</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>1</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>2</w:t></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Runs) != 3 {
+		t.Fatalf("Runs = %d, want 3", len(info.Runs))
+	}
+	if info.Runs[0].VertAlign != "" {
+		t.Errorf("run[0]: VertAlign = %q, want empty", info.Runs[0].VertAlign)
+	}
+	if info.Runs[1].VertAlign != "superscript" {
+		t.Errorf("run[1]: VertAlign = %q, want superscript", info.Runs[1].VertAlign)
+	}
+	if info.Runs[2].VertAlign != "subscript" {
+		t.Errorf("run[2]: VertAlign = %q, want subscript", info.Runs[2].VertAlign)
+	}
+}
+
 func TestParseParagraph_TabBetweenText(t *testing.T) {
 	xml := `<w:p ` + wXMLNS + `>` +
 		`<w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r>` +
@@ -138,6 +159,43 @@ func TestParagraphToMarkdown(t *testing.T) {
 			},
 			styleName: "Normal",
 			want:      "***both***",
+		},
+		{
+			name: "superscript note mark stays separate",
+			info: paragraphInfo{
+				Text: "n_781",
+				Runs: []runInfo{
+					{Text: "n_78"},
+					{Text: "1", VertAlign: "superscript"},
+				},
+			},
+			styleName: "Normal",
+			want:      "n_78<sup>1</sup>",
+		},
+		{
+			name: "subscript run",
+			info: paragraphInfo{
+				Text: "H2O",
+				Runs: []runInfo{
+					{Text: "H"},
+					{Text: "2", VertAlign: "subscript"},
+					{Text: "O"},
+				},
+			},
+			styleName: "Normal",
+			want:      "H<sub>2</sub>O",
+		},
+		{
+			name: "bold superscript combined",
+			info: paragraphInfo{
+				Text: "x2",
+				Runs: []runInfo{
+					{Text: "x"},
+					{Text: "2", Bold: true, VertAlign: "superscript"},
+				},
+			},
+			styleName: "Normal",
+			want:      "x<sup>**2**</sup>",
 		},
 		{
 			name:      "list bullet style",

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -244,24 +244,21 @@ func writeParagraphInline(b *strings.Builder, p paragraphInfo, ctx imageContext)
 			esc := htmlpkg.EscapeString(r.Text)
 			switch {
 			case r.IsCode:
-				b.WriteString("<code>")
-				b.WriteString(esc)
-				b.WriteString("</code>")
+				esc = "<code>" + esc + "</code>"
 			case r.Bold && r.Italic:
-				b.WriteString("<strong><em>")
-				b.WriteString(esc)
-				b.WriteString("</em></strong>")
+				esc = "<strong><em>" + esc + "</em></strong>"
 			case r.Bold:
-				b.WriteString("<strong>")
-				b.WriteString(esc)
-				b.WriteString("</strong>")
+				esc = "<strong>" + esc + "</strong>"
 			case r.Italic:
-				b.WriteString("<em>")
-				b.WriteString(esc)
-				b.WriteString("</em>")
-			default:
-				b.WriteString(esc)
+				esc = "<em>" + esc + "</em>"
 			}
+			switch r.VertAlign {
+			case "superscript":
+				esc = "<sup>" + esc + "</sup>"
+			case "subscript":
+				esc = "<sub>" + esc + "</sub>"
+			}
+			b.WriteString(esc)
 		}
 	} else if p.Text != "" {
 		b.WriteString(htmlpkg.EscapeString(p.Text))

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -111,6 +111,21 @@ func TestTableToHTML_ItalicAndBoldItalic(t *testing.T) {
 	}
 }
 
+func TestTableToHTML_VertAlignRunInCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p>
+			<w:r><w:t>n_78</w:t></w:r>
+			<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>1</w:t></w:r>
+			<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>2</w:t></w:r>
+		</w:p></w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "n_78<sup>1</sup><sub>2</sub>") {
+		t.Errorf("expected superscript/subscript runs wrapped in <sup>/<sub>: %s", html)
+	}
+}
+
 func TestTableToHTML_HTMLEscape(t *testing.T) {
 	// Cell text containing HTML special characters must be escaped.
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -420,6 +420,21 @@ func TestRenderMarkdown_RawHTMLPassthrough(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_SubSupPassthrough verifies that the <sub>/<sup> tags
+// emitted by the docx converter for subscript/superscript runs survive
+// rendering, so 3GPP notation like n_78 with a superscript note mark renders
+// correctly in the web viewer.
+func TestRenderMarkdown_SubSupPassthrough(t *testing.T) {
+	content := "n_78<sup>1</sup> and H<sub>2</sub>O"
+	got := renderMarkdown(content, "TS 23.501", nil)
+	if !strings.Contains(got, "<sup>1</sup>") {
+		t.Errorf("expected <sup> to pass through, got:\n%s", got)
+	}
+	if !strings.Contains(got, "<sub>2</sub>") {
+		t.Errorf("expected <sub> to pass through, got:\n%s", got)
+	}
+}
+
 // TestRenderMarkdown_HTMLImageRewrite verifies that <img src="image://...">
 // tags embedded in raw HTML (used inside HTML tables emitted by the docx
 // converter) are rewritten to a real /specs/<id>/images/<name> URL.


### PR DESCRIPTION
Fixes #19.

3GPP specs use many subscript/superscript runs, but the DOCX parser ignored the `w:vertAlign` run property, so these runs were flattened into adjacent text (e.g. `n_78` with a superscript note mark rendered as `n_781`).

- Parse `w:vertAlign` run properties in `converter/docx/paragraph.go`
- Wrap superscript/subscript runs in `<sup>`/`<sub>` tags in both the Markdown and table-cell HTML emitters
- The web viewer's goldmark renderer already passes raw HTML through, so these tags render correctly with no change

Added parser, Markdown, table, and web-render tests.