### PR TITLE
feat(images): auto-crop white margins from converted PNGs

### DIFF
--- a/converter/docx/crop.go
+++ b/converter/docx/crop.go
@@ -1,0 +1,127 @@
+package docx
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+)
+
+const (
+	// cropWhiteThreshold is the minimum per-channel value (0–255) for a pixel
+	// to be treated as background "white". LibreOffice-rendered equations often
+	// have slightly off-white anti-aliased edges, so a small tolerance below
+	// 255 avoids treating faint content as margin.
+	cropWhiteThreshold = 250
+	// cropAlphaThreshold is the maximum alpha (0–255) for a pixel to be treated
+	// as transparent background. EMF renders frequently carry an alpha channel.
+	cropAlphaThreshold = 8
+	// cropPadding is the number of background pixels kept around the detected
+	// content so the crop is not flush against the drawing.
+	cropPadding = 4
+)
+
+// autoCropPNG removes surrounding white/transparent margins from a PNG image.
+// It decodes the image, computes the bounding box of non-background pixels
+// (background = near-white opaque OR nearly transparent), adds a small padding,
+// and re-encodes the cropped region. If the input is not a decodable PNG, has
+// no content, or would not shrink meaningfully, the original bytes are returned
+// unchanged so the caller can always rely on getting a usable image back.
+func autoCropPNG(data []byte) []byte {
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return data
+	}
+
+	bounds := img.Bounds()
+	minX, minY := bounds.Max.X, bounds.Max.Y
+	maxX, maxY := bounds.Min.X, bounds.Min.Y
+	found := false
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			if isBackgroundPixel(img.At(x, y)) {
+				continue
+			}
+			found = true
+			if x < minX {
+				minX = x
+			}
+			if x > maxX {
+				maxX = x
+			}
+			if y < minY {
+				minY = y
+			}
+			if y > maxY {
+				maxY = y
+			}
+		}
+	}
+
+	// Entirely background: nothing to crop.
+	if !found {
+		return data
+	}
+
+	// Add padding and clamp to the image bounds.
+	minX -= cropPadding
+	minY -= cropPadding
+	maxX += cropPadding
+	maxY += cropPadding
+	if minX < bounds.Min.X {
+		minX = bounds.Min.X
+	}
+	if minY < bounds.Min.Y {
+		minY = bounds.Min.Y
+	}
+	if maxX >= bounds.Max.X {
+		maxX = bounds.Max.X - 1
+	}
+	if maxY >= bounds.Max.Y {
+		maxY = bounds.Max.Y - 1
+	}
+
+	crop := image.Rect(minX, minY, maxX+1, maxY+1)
+	// Nothing gained if the crop covers the whole image.
+	if crop.Eq(bounds) {
+		return data
+	}
+
+	cropped := subImage(img, crop)
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, cropped); err != nil {
+		return data
+	}
+	return buf.Bytes()
+}
+
+// isBackgroundPixel reports whether c is margin: nearly transparent, or an
+// opaque near-white pixel.
+func isBackgroundPixel(c interface{ RGBA() (r, g, b, a uint32) }) bool {
+	r, g, b, a := c.RGBA()
+	// Convert from 16-bit (0–65535) to 8-bit (0–255).
+	r8, g8, b8, a8 := r>>8, g>>8, b>>8, a>>8
+	if a8 <= cropAlphaThreshold {
+		return true
+	}
+	return r8 >= cropWhiteThreshold && g8 >= cropWhiteThreshold && b8 >= cropWhiteThreshold
+}
+
+// subImage returns the sub-region r of img. Standard library image types expose
+// a SubImage method that shares pixels without copying; for any other image
+// type the region is copied into a fresh NRGBA image.
+func subImage(img image.Image, r image.Rectangle) image.Image {
+	if sub, ok := img.(interface {
+		SubImage(r image.Rectangle) image.Image
+	}); ok {
+		return sub.SubImage(r)
+	}
+	dst := image.NewNRGBA(image.Rect(0, 0, r.Dx(), r.Dy()))
+	for y := 0; y < r.Dy(); y++ {
+		for x := 0; x < r.Dx(); x++ {
+			dst.Set(x, y, img.At(r.Min.X+x, r.Min.Y+y))
+		}
+	}
+	return dst
+}

--- a/converter/docx/crop_test.go
+++ b/converter/docx/crop_test.go
@@ -1,0 +1,117 @@
+package docx
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+// encodePNG renders img to PNG bytes for use as test input.
+func encodePNG(t *testing.T, img image.Image) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodePNG decodes PNG bytes back into an image for assertions.
+func decodePNG(t *testing.T, data []byte) image.Image {
+	t.Helper()
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode PNG: %v", err)
+	}
+	return img
+}
+
+func TestAutoCropPNG_WhiteMargin(t *testing.T) {
+	// 100x100 white canvas with a 20x20 black square at (40,40)-(60,60).
+	const size = 100
+	img := image.NewNRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, color.NRGBA{R: 255, G: 255, B: 255, A: 255})
+		}
+	}
+	for y := 40; y < 60; y++ {
+		for x := 40; x < 60; x++ {
+			img.Set(x, y, color.NRGBA{R: 0, G: 0, B: 0, A: 255})
+		}
+	}
+
+	out := autoCropPNG(encodePNG(t, img))
+	cropped := decodePNG(t, out)
+	b := cropped.Bounds()
+
+	// Content is 20x20; with cropPadding=4 on each side the result is 28x28.
+	wantW, wantH := 20+2*cropPadding, 20+2*cropPadding
+	if b.Dx() != wantW || b.Dy() != wantH {
+		t.Errorf("cropped size = %dx%d, want %dx%d", b.Dx(), b.Dy(), wantW, wantH)
+	}
+	if b.Dx() >= size || b.Dy() >= size {
+		t.Errorf("crop did not shrink image: %dx%d", b.Dx(), b.Dy())
+	}
+}
+
+func TestAutoCropPNG_TransparentMargin(t *testing.T) {
+	const size = 80
+	img := image.NewNRGBA(image.Rect(0, 0, size, size)) // fully transparent
+	// Opaque red content at (30,30)-(50,50).
+	for y := 30; y < 50; y++ {
+		for x := 30; x < 50; x++ {
+			img.Set(x, y, color.NRGBA{R: 200, G: 0, B: 0, A: 255})
+		}
+	}
+
+	out := autoCropPNG(encodePNG(t, img))
+	cropped := decodePNG(t, out)
+	b := cropped.Bounds()
+
+	wantW, wantH := 20+2*cropPadding, 20+2*cropPadding
+	if b.Dx() != wantW || b.Dy() != wantH {
+		t.Errorf("cropped size = %dx%d, want %dx%d", b.Dx(), b.Dy(), wantW, wantH)
+	}
+}
+
+func TestAutoCropPNG_AllBackground(t *testing.T) {
+	const size = 50
+	img := image.NewNRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, color.NRGBA{R: 255, G: 255, B: 255, A: 255})
+		}
+	}
+	in := encodePNG(t, img)
+	out := autoCropPNG(in)
+	if !bytes.Equal(in, out) {
+		t.Error("all-white image should be returned unchanged")
+	}
+}
+
+func TestAutoCropPNG_NoMargin(t *testing.T) {
+	// Image that is entirely content should be returned unchanged (crop == bounds).
+	const size = 30
+	img := image.NewNRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, color.NRGBA{R: 0, G: 0, B: 0, A: 255})
+		}
+	}
+	in := encodePNG(t, img)
+	out := autoCropPNG(in)
+	if !bytes.Equal(in, out) {
+		t.Error("full-content image should be returned unchanged")
+	}
+}
+
+func TestAutoCropPNG_InvalidData(t *testing.T) {
+	in := []byte("not a png")
+	out := autoCropPNG(in)
+	if !bytes.Equal(in, out) {
+		t.Error("invalid PNG data should be returned unchanged")
+	}
+}

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -293,7 +293,9 @@ func batchConvertToPNG(ctx context.Context, items []*batchItem) error {
 			item.err = fmt.Errorf("read converted PNG: %w", err)
 			continue
 		}
-		item.pngData = pngData
+		// Trim the large white/transparent margins LibreOffice leaves around
+		// EMF/WMF renders (notably equations and matrices, see issue #18).
+		item.pngData = autoCropPNG(pngData)
 		anySuccess = true
 	}
 


### PR DESCRIPTION
Fixes #18

## Problem

EMF/WMF images converted to PNG—especially equations and matrices—come out with large white/transparent margins, making the content hard to read. LibreOffice renders EMF/WMF at the source canvas (frame/page) bounds, so drawings that occupy only part of the canvas keep wide surrounding margins.

## Change

Apply a bounding-box crop to each PNG right after conversion in `batchConvertToPNG`. The new `autoCropPNG` (`converter/docx/crop.go`) detects non-background pixels (background = near-white opaque **or** nearly transparent), adds a small padding, and re-encodes the cropped region. Implemented with Go's standard `image`/`image/png` only—no new dependency and no CGO, matching the project's pure-Go policy.

The crop is applied across all conversion paths (pipeline / import / import-dir / update). If the input is not a decodable PNG, is entirely background, or would not shrink, the original bytes are returned unchanged.

Unit tests in `converter/docx/crop_test.go` cover white margins, transparent margins, all-background, no-margin, and invalid input, and do not require `soffice`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016p16oupWZt3g7AURJSXkDZ)_