### PR TITLE
fix(docx): merge adjacent same-style runs to avoid stray asterisks

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -278,6 +278,32 @@ func getAttrVal(elem xml.StartElement, localName string) string {
 	return ""
 }
 
+// mergeAdjacentRuns coalesces consecutive runs that share identical
+// formatting (ignoring Text) into a single run. DOCX frequently splits one
+// visually-continuous span of text across multiple <w:r> elements for
+// reasons unrelated to formatting (bookmarks, proofing-error ranges,
+// revisions); without merging, each fragment gets wrapped in its own
+// markdown emphasis delimiters, producing stray/unbalanced asterisks
+// mid-word.
+func mergeAdjacentRuns(runs []runInfo) []runInfo {
+	var merged []runInfo
+	for _, run := range runs {
+		if run.Text == "" {
+			continue
+		}
+		if n := len(merged); n > 0 {
+			last := &merged[n-1]
+			if last.Bold == run.Bold && last.Italic == run.Italic &&
+				last.VertAlign == run.VertAlign && last.IsCode == run.IsCode {
+				last.Text += run.Text
+				continue
+			}
+		}
+		merged = append(merged, run)
+	}
+	return merged
+}
+
 // paragraphToMarkdown converts a paragraph to markdown text.
 func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 	text := strings.TrimSpace(info.Text)
@@ -299,11 +325,8 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 	// Handle bold/italic at run level
 	if len(info.Runs) > 0 {
 		var parts []string
-		for _, run := range info.Runs {
+		for _, run := range mergeAdjacentRuns(info.Runs) {
 			runText := run.Text
-			if runText == "" {
-				continue
-			}
 			if run.Bold && run.Italic {
 				runText = "***" + runText + "***"
 			} else if run.Bold {

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -263,6 +263,81 @@ func TestParagraphToMarkdown(t *testing.T) {
 			styleName: "Normal",
 			want:      "fallback",
 		},
+		{
+			name: "word split across adjacent italic runs merges into one emphasis",
+			info: paragraphInfo{
+				Text: "mpe-Reporting-FR2",
+				Runs: []runInfo{
+					{Text: "mpe-Reporting", Italic: true},
+					{Text: "-FR2", Italic: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "*mpe-Reporting-FR2*",
+		},
+		{
+			name: "italic fragment split across runs surrounded by plain text",
+			info: paragraphInfo{
+				Text: "preAABBpost",
+				Runs: []runInfo{
+					{Text: "pre"},
+					{Text: "AA", Italic: true},
+					{Text: "BB", Italic: true},
+					{Text: "post"},
+				},
+			},
+			styleName: "Normal",
+			want:      "pre*AABB*post",
+		},
+		{
+			name: "adjacent bold+italic runs merge into one wrapper",
+			info: paragraphInfo{
+				Text: "ab",
+				Runs: []runInfo{
+					{Text: "a", Bold: true, Italic: true},
+					{Text: "b", Bold: true, Italic: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "***ab***",
+		},
+		{
+			name: "adjacent same-superscript runs merge into one tag",
+			info: paragraphInfo{
+				Text: "ab",
+				Runs: []runInfo{
+					{Text: "a", VertAlign: "superscript"},
+					{Text: "b", VertAlign: "superscript"},
+				},
+			},
+			styleName: "Normal",
+			want:      "<sup>ab</sup>",
+		},
+		{
+			name: "empty run between same-styled italic runs still merges",
+			info: paragraphInfo{
+				Text: "ab",
+				Runs: []runInfo{
+					{Text: "a", Italic: true},
+					{Text: ""},
+					{Text: "b", Italic: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "*ab*",
+		},
+		{
+			name: "adjacent runs differing only in VertAlign do not merge",
+			info: paragraphInfo{
+				Text: "ab",
+				Runs: []runInfo{
+					{Text: "a", VertAlign: "superscript"},
+					{Text: "b", VertAlign: "subscript"},
+				},
+			},
+			styleName: "Normal",
+			want:      "<sup>a</sup><sub>b</sub>",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #24: a stray literal `*` appeared mid-word when an italic (or bold) phrase in the source DOCX was split across multiple `w:r` XML runs for reasons unrelated to formatting (bookmarks, proofing ranges, revisions).
- `paragraphToMarkdown` now merges consecutive runs that share identical formatting (Bold, Italic, VertAlign, IsCode) before wrapping them in markdown emphasis delimiters, so a visually continuous span always gets exactly one `*...*` / `**...**` / `***...***` wrapper instead of one per underlying XML run.

## Changes
- `converter/docx/paragraph.go`: add `mergeAdjacentRuns` and use it in `paragraphToMarkdown`.
- `converter/docx/paragraph_test.go`: add regression tests for split italic/bold/superscript runs, an empty run between two same-styled runs, and a negative case where differing `VertAlign` must not merge.