### PR TITLE
fix(docx): correctly render diagrams and equations in specs like 38.101-1

### DIFF
--- a/converter/docx/group_shape_integration_test.go
+++ b/converter/docx/group_shape_integration_test.go
@@ -1,0 +1,109 @@
+package docx
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestParseDocx_GroupShapeDiagramAndEquation builds a minimal DOCX in memory
+// reproducing the issue #25 scenario from TS 38.101-1 clause 5.3A.3: a
+// grouped VML diagram with text-box labels and no embedded picture, followed
+// by a display equation whose paragraph starts with a <w:tab/> and uses
+// adjacent same-VertAlign runs. It verifies the full ParseDocx path no
+// longer emits garbled diagram text or a literal, unrendered <sub> tag.
+func TestParseDocx_GroupShapeDiagramAndEquation(t *testing.T) {
+	const contentTypes = `<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+
+	const rels = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+	// A grouped VML diagram with two text-box labels and no blip/imagedata
+	// anywhere inside it — the exact issue #25 shape (arrows/labels, no
+	// embedded picture).
+	diagram := `<w:r><w:pict><group>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Lower Edge</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Resource block</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`</group></w:pict></w:r>`
+
+	// The display equation: leading <w:tab/> plus two adjacent subscript
+	// runs (a plain "edge,high" run followed by a subscript-marked space).
+	equation := `<w:p><w:r><w:tab/></w:r>` +
+		`<w:r><w:t>BW</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>Channel_CA</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t xml:space="preserve"> </w:t></w:r>` +
+		`<w:r><w:t>= F</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>edge,high</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t xml:space="preserve"> </w:t></w:r>` +
+		`<w:r><w:t>- F</w:t></w:r>` +
+		`<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>edge,low</w:t></w:r>` +
+		`<w:r><w:t xml:space="preserve"> (MHz).</w:t></w:r>` +
+		`</w:p>`
+
+	doc := `<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>
+<w:p><w:pPr><w:pStyle w:val="Heading 1"/></w:pPr><w:r><w:t>5 Test</w:t></w:r></w:p>
+<w:p>` + diagram + `</w:p>
+<w:p><w:r><w:t>Figure 5.3A.3-1: Definition of Aggregated Channel Bandwidth</w:t></w:r></w:p>
+` + equation + `
+</w:body>
+</w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range map[string]string{
+		"[Content_Types].xml":          contentTypes,
+		"_rels/.rels":                  rels,
+		"word/document.xml":            doc,
+		"word/_rels/document.xml.rels": `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`,
+	} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ParseDocxFromBytes(buf.Bytes(), "38101-1-test.docx")
+	if err != nil {
+		t.Fatalf("ParseDocxFromBytes: %v", err)
+	}
+	if len(result.Sections) == 0 {
+		t.Fatal("no sections parsed")
+	}
+
+	all := strings.Join(result.Sections[0].Content, "\n")
+	t.Logf("section content:\n%s", all)
+
+	// The diagram's labels must not appear as jumbled plain-text prose...
+	if strings.Contains(all, "Lower EdgeResource block") {
+		t.Errorf("diagram labels leaked as jumbled text:\n%s", all)
+	}
+	// ...but must still be surfaced via the diagnostic placeholder.
+	if !strings.Contains(all, "[Figure: diagram not extracted") ||
+		!strings.Contains(all, "Lower Edge") || !strings.Contains(all, "Resource block") {
+		t.Errorf("expected diagram placeholder with labels:\n%s", all)
+	}
+
+	// The equation must render as normal markdown with real <sub> tags, not
+	// inside a fenced code block (which would make them literal text).
+	if strings.Contains(all, "```") {
+		t.Errorf("equation must not be fenced as a code block:\n%s", all)
+	}
+	if !strings.Contains(all, "BW<sub>Channel_CA </sub>= F<sub>edge,high </sub>- F<sub>edge,low</sub> (MHz).") {
+		t.Errorf("expected merged, unfenced subscript equation:\n%s", all)
+	}
+}

--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -16,6 +16,14 @@ type paragraphInfo struct {
 	Runs    []runInfo
 	Images  []imageRef
 	IsCode  bool // true if the paragraph uses a monospace/code font
+	// SkippedDiagramLabels holds text-box labels found inside a grouped
+	// vector diagram (VML v:group, or DrawingML wpg:wgp reached through
+	// mc:AlternateContent) that had no embeddable raster image anywhere in
+	// it. Such diagrams can't be rendered by this converter, and the raw XML
+	// order of their labels rarely matches the visual reading order, so the
+	// labels are kept out of Text/Runs to avoid emitting garbled prose; see
+	// diagramPlaceholder in parser.go.
+	SkippedDiagramLabels []string
 }
 
 // runInfo holds extracted information from a w:r element.
@@ -77,6 +85,35 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 						delim = "$$"
 					}
 					info.Runs = append(info.Runs, runInfo{Text: delim + latex + delim})
+				}
+				continue
+			}
+			// Grouped vector diagrams (VML v:group, or DrawingML wpg:wgp
+			// reached through mc:AlternateContent) are not embeddable
+			// pictures: their text-box labels are ordinary WordprocessingML
+			// runs with no ancestor markers, so without this interception
+			// they'd flatten straight into info.Runs in raw XML document
+			// order, which rarely matches the diagram's visual reading order
+			// (see issue #25). scanDrawingSubtree consumes the whole subtree
+			// itself, so rebalance depth afterwards like the OMML case above.
+			if local == "group" || local == "AlternateContent" {
+				imgs, labels, hasGroup, hasRaster := scanDrawingSubtree(d, t)
+				depth--
+				if local == "group" {
+					hasGroup = true
+				}
+				info.Images = append(info.Images, imgs...)
+				if hasGroup && !hasRaster {
+					info.SkippedDiagramLabels = append(info.SkippedDiagramLabels, labels...)
+				} else {
+					// Not a pure-vector group diagram (either a plain
+					// annotated shape with no grouping, or a group that also
+					// contains a raster image): preserve the pre-existing
+					// behavior of folding any text-box labels into the
+					// paragraph's own text.
+					for _, label := range labels {
+						info.Runs = append(info.Runs, runInfo{Text: label})
+					}
 				}
 				continue
 			}
@@ -257,6 +294,96 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 	return info
 }
 
+// scanDrawingSubtree walks a VML v:group/v:shape subtree — or an
+// mc:AlternateContent wrapper around one — looking for embedded raster
+// images and text-box labels. It recurses into every unrecognized child so
+// the decoder always stays balanced, regardless of how deeply the shapes
+// are nested (3GPP diagrams commonly nest v:group three or four levels
+// deep). hasGroup reports whether a v:group was found anywhere in the
+// subtree (including the root, if the caller already knows that); hasRaster
+// reports whether any embeddable picture was found.
+//
+// mc:Choice is always skipped via d.Skip(): Word emits it alongside an
+// equivalent mc:Fallback in the legacy VML form for compatibility, and this
+// converter only understands VML shapes, so processing both would double
+// every label and image.
+func scanDrawingSubtree(d *xml.Decoder, _ xml.StartElement) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "Choice":
+				_ = d.Skip()
+			case "imagedata":
+				// VML image: <v:imagedata r:id="rId9" o:title="..."/>
+				rid := getAttrValNS(t, "id")
+				if rid == "" {
+					rid = getAttrVal(t, "id")
+				}
+				if rid != "" {
+					imgs = append(imgs, imageRef{RID: rid, AltText: getAttrVal(t, "title")})
+					hasRaster = true
+				}
+				_ = d.Skip()
+			case "blip":
+				// DrawingML image: <a:blip r:embed="rId5"/>
+				rid := getAttrValNS(t, "embed")
+				if rid == "" {
+					rid = getAttrVal(t, "embed")
+				}
+				if rid != "" {
+					imgs = append(imgs, imageRef{RID: rid})
+					hasRaster = true
+				}
+				_ = d.Skip()
+			case "txbxContent":
+				labels = append(labels, scanTextBoxLabels(d)...)
+			default:
+				if t.Name.Local == "group" {
+					hasGroup = true
+				}
+				subImgs, subLabels, subHasGroup, subHasRaster := scanDrawingSubtree(d, t)
+				imgs = append(imgs, subImgs...)
+				labels = append(labels, subLabels...)
+				hasGroup = hasGroup || subHasGroup
+				hasRaster = hasRaster || subHasRaster
+			}
+		case xml.EndElement:
+			return
+		}
+	}
+}
+
+// scanTextBoxLabels consumes a w:txbxContent element (the start element has
+// already been consumed by the caller) and returns the trimmed text of each
+// paragraph inside it, in document order.
+func scanTextBoxLabels(d *xml.Decoder) []string {
+	var labels []string
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return labels
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "p" {
+				pInfo := parseParagraphFromDecoder(d, t)
+				if text := strings.TrimSpace(pInfo.Text); text != "" {
+					labels = append(labels, text)
+				}
+			} else {
+				_ = d.Skip()
+			}
+		case xml.EndElement:
+			return labels
+		}
+	}
+}
+
 // getAttrValNS returns the value of a namespaced attribute by its local name,
 // ignoring the namespace prefix. This is needed for attributes like r:id or r:embed
 // where the namespace varies.
@@ -343,7 +470,12 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 			parts = append(parts, runText)
 		}
 		if len(parts) > 0 {
-			return strings.Join(parts, "")
+			// Trim leading/trailing whitespace (e.g. a leading <w:tab/> used
+			// to center an equation via tab stops): a line that starts with
+			// a tab or 4+ spaces is parsed as an indented code block by
+			// CommonMark, inside which HTML tags like <sub> are never
+			// interpreted and show up as literal text (see issue #25).
+			return strings.TrimSpace(strings.Join(parts, ""))
 		}
 	}
 

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -1,6 +1,7 @@
 package docx
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -365,6 +366,97 @@ func TestIsMonospaceFont(t *testing.T) {
 		if got := isMonospaceFont(font); got != want {
 			t.Errorf("isMonospaceFont(%q) = %v, want %v", font, got, want)
 		}
+	}
+}
+
+func TestParagraphToMarkdown_LeadingTabTrimmed(t *testing.T) {
+	// A leading <w:tab/> (e.g. used to center an equation via a paragraph
+	// style's tab stops) must not survive into the returned markdown: a
+	// line starting with a tab is parsed as an indented code block by
+	// CommonMark, inside which raw HTML tags like <sub> are never
+	// interpreted and show up as literal text (issue #25).
+	info := paragraphInfo{
+		Text: "\tBW= F",
+		Runs: []runInfo{
+			{Text: "\t"},
+			{Text: "BW"},
+			{Text: "Channel_CA", VertAlign: "subscript"},
+			{Text: " ", VertAlign: "subscript"},
+			{Text: "= F"},
+		},
+	}
+	got := paragraphToMarkdown(info, "Normal")
+	want := "BW<sub>Channel_CA </sub>= F"
+	if got != want {
+		t.Errorf("paragraphToMarkdown = %q, want %q", got, want)
+	}
+	if strings.HasPrefix(got, "\t") || strings.HasPrefix(got, " ") {
+		t.Errorf("expected no leading whitespace, got %q", got)
+	}
+}
+
+func TestParseParagraph_GroupShapeNoImage_SkipsLabels(t *testing.T) {
+	// A grouped VML diagram (v:group containing several v:shape/v:textbox
+	// labels) with no embedded picture anywhere inside it must not have its
+	// labels flattened into the paragraph's own text/runs.
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:pict><group>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Lower Edge</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Resource block</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`</group></w:pict></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if strings.Contains(info.Text, "Lower Edge") || strings.Contains(info.Text, "Resource block") {
+		t.Errorf("expected group-shape labels excluded from Text, got %q", info.Text)
+	}
+	if len(info.Images) != 0 {
+		t.Errorf("expected no images, got %d", len(info.Images))
+	}
+	if len(info.SkippedDiagramLabels) != 2 {
+		t.Fatalf("SkippedDiagramLabels = %v, want 2 entries", info.SkippedDiagramLabels)
+	}
+	if info.SkippedDiagramLabels[0] != "Lower Edge" || info.SkippedDiagramLabels[1] != "Resource block" {
+		t.Errorf("SkippedDiagramLabels = %v, want [Lower Edge, Resource block]", info.SkippedDiagramLabels)
+	}
+}
+
+func TestParseParagraph_GroupShapeWithImage_KeepsImageDropsLabels(t *testing.T) {
+	// A group that mixes a raster picture with textbox callouts should keep
+	// extracting the image (existing behavior), and should not classify the
+	// group as an unrenderable diagram.
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:pict><group>` +
+		`<shape><imagedata r:id="rId9"/></shape>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Callout</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`</group></w:pict></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Images) != 1 || info.Images[0].RID != "rId9" {
+		t.Fatalf("expected 1 image with RID rId9, got %+v", info.Images)
+	}
+	if info.SkippedDiagramLabels != nil {
+		t.Errorf("expected no SkippedDiagramLabels when a raster image is present, got %v", info.SkippedDiagramLabels)
+	}
+}
+
+func TestParseParagraph_AlternateContentGroupFallback(t *testing.T) {
+	// mc:AlternateContent wrapping a DrawingML wpg:wgp Choice and an
+	// equivalent VML v:group Fallback must only process the Fallback side —
+	// otherwise labels would be duplicated (once per side).
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><AlternateContent>` +
+		`<Choice><wgp><shape><textbox><txbxContent><w:p><w:r><w:t>DrawingML Label</w:t></w:r></w:p></txbxContent></textbox></shape></wgp></Choice>` +
+		`<Fallback><pict><group>` +
+		`<shape><textbox><txbxContent><w:p><w:r><w:t>Lower Edge</w:t></w:r></w:p></txbxContent></textbox></shape>` +
+		`</group></pict></Fallback>` +
+		`</AlternateContent></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if strings.Contains(info.Text, "DrawingML Label") {
+		t.Errorf("expected mc:Choice content to be skipped, got Text = %q", info.Text)
+	}
+	if len(info.SkippedDiagramLabels) != 1 || info.SkippedDiagramLabels[0] != "Lower Edge" {
+		t.Fatalf("SkippedDiagramLabels = %v, want [Lower Edge]", info.SkippedDiagramLabels)
 	}
 }
 

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -187,6 +187,22 @@ func imagePlaceholder(relMap map[string]string, images map[string]*EmbeddedImage
 	return fmt.Sprintf("[Figure: %s (%s, use get_image to retrieve)]", alt, img.Name)
 }
 
+// diagramPlaceholder returns a markdown placeholder for a grouped vector
+// diagram that had no embeddable raster image (see paragraphInfo.
+// SkippedDiagramLabels). Unlike imagePlaceholder, get_image can't retrieve
+// this figure since there is no extracted image file for it — the
+// placeholder says so, and lists any text-box labels found so the
+// information isn't lost entirely, in document order (not necessarily the
+// diagram's visual reading order).
+func diagramPlaceholder(labels []string) string {
+	if len(labels) == 0 {
+		return "[Figure: diagram not extracted — this converter cannot render grouped vector shapes/text boxes; see the original document for this figure]"
+	}
+	return fmt.Sprintf(
+		"[Figure: diagram not extracted (vector shapes/arrows not rendered); extracted text labels, order not guaranteed: %s]",
+		strings.Join(labels, "; "))
+}
+
 // parseSections walks the body elements and creates a section hierarchy.
 func parseSections(elements []bodyElement, styleMap map[string]string, relMap map[string]string, images map[string]*EmbeddedImage) []*Section {
 	var sections []*Section
@@ -319,6 +335,12 @@ func parseSections(elements []bodyElement, styleMap map[string]string, relMap ma
 								currentSection.Content = append(currentSection.Content, ph)
 							}
 						}
+					}
+					// Surface any grouped vector diagram this converter
+					// couldn't render as an image (see issue #25), instead
+					// of silently dropping it.
+					if currentSection != nil && info.SkippedDiagramLabels != nil {
+						currentSection.Content = append(currentSection.Content, diagramPlaceholder(info.SkippedDiagramLabels))
 					}
 				}
 			}

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -237,7 +237,7 @@ func writeCellContent(b *strings.Builder, c tableCell, ctx imageContext) {
 
 func writeParagraphInline(b *strings.Builder, p paragraphInfo, ctx imageContext) {
 	if len(p.Runs) > 0 {
-		for _, r := range p.Runs {
+		for _, r := range mergeAdjacentRuns(p.Runs) {
 			if r.Text == "" {
 				continue
 			}

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -126,6 +126,27 @@ func TestTableToHTML_VertAlignRunInCell(t *testing.T) {
 	}
 }
 
+func TestTableToHTML_CoalesceAdjacentVertAlignRuns(t *testing.T) {
+	// Two adjacent subscript runs (as Word commonly splits at a spell-check
+	// boundary) must merge into a single <sub> tag instead of fragmenting
+	// into <sub>edge,high</sub><sub> </sub> (issue #25).
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+		<w:tr><w:tc><w:p>
+			<w:r><w:t>F</w:t></w:r>
+			<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>edge,high</w:t></w:r>
+			<w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t xml:space="preserve"> </w:t></w:r>
+		</w:p></w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	html := tableToHTML(info, imageContext{})
+	if !strings.Contains(html, "F<sub>edge,high </sub>") {
+		t.Errorf("expected adjacent subscript runs merged into one <sub> tag: %s", html)
+	}
+	if strings.Contains(html, "<sub>edge,high</sub><sub>") {
+		t.Errorf("expected no fragmented adjacent <sub> tags: %s", html)
+	}
+}
+
 func TestTableToHTML_HTMLEscape(t *testing.T) {
 	// Cell text containing HTML special characters must be escaped.
 	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">


### PR DESCRIPTION
## Summary

- Grouped vector diagrams (VML `v:group` / DrawingML `wpg:wgp` reached through `mc:AlternateContent`, e.g. Figure 5.3A.3-1 in TS 38.101-1) with no embedded raster image were flattened into the surrounding paragraph as jumbled text-box labels in raw XML order. These are now detected and replaced with a `[Figure: diagram not extracted ...]` placeholder listing the extracted labels, instead of garbled prose.
- A leading `<w:tab/>` (used by 3GPP's `EQ` paragraph style to center display equations via tab stops) was emitted as a literal tab character at the start of the markdown line, which CommonMark parses as an indented code block — so `<sub>`/`<sup>` tags inside it rendered as literal unrendered text. The paragraph's markdown output is now trimmed of leading/trailing whitespace.
- Adjacent runs sharing identical formatting (e.g. two separate `w:r` elements both marked subscript, as Word commonly splits at a spell-check boundary) were each wrapped in their own `<sub>`/`<sup>` tag, producing fragments like `<sub>edge,high</sub><sub> </sub>`. Adjacent same-formatted runs are now merged before wrapping.

Verified against the real TS 38.101-1 (v19.5.0) document: clause 5.3A.3 now renders a clean diagram placeholder and correctly formatted equations instead of garbled text and literal `<sub>` tags.

Closes #25

---
_Generated by [Claude Code](https://claude.ai/code/session_016LuWxuRRjDKSn9jsYjQTTp)_