### PR TITLE
fix: normalize canonical ids for split multi-file specs

### DIFF
--- a/converter/docx/metadata.go
+++ b/converter/docx/metadata.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})-?([a-z])(\d+)`)
+	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})(?:-(\d{1,2}))?-?([a-z])(\d+)`)
 	specPatternRE = regexp.MustCompile(`(?i)(?:TS|TR)\s*(\d+)\.(\d+)`)
 	versionRE     = regexp.MustCompile(`V(\d+\.\d+\.\d+)`)
 	releaseRE     = regexp.MustCompile(`Release\s+(\d+)`)
@@ -93,8 +93,11 @@ func extractMetadata(filename string, props coreProperties, bodyElements []bodyE
 
 	// Parse from filename
 	if match := filenameRE.FindStringSubmatch(stem); match != nil {
-		series, num, verLetter, verNum := match[1], match[2], match[3], match[4]
+		series, num, part, verLetter, verNum := match[1], match[2], match[3], match[4], match[5]
 		specID = "TS " + series + "." + num
+		if part != "" {
+			specID += "-" + part
+		}
 		version = verLetter + verNum
 	} else if match := specPatternRE.FindStringSubmatch(stem); match != nil {
 		specID = "TS " + match[1] + "." + match[2]

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -87,6 +87,18 @@ func TestExtractMetadata_FilenameVariants(t *testing.T) {
 			wantSpecID:  "weirdname",
 			wantVersion: "",
 		},
+		{
+			name:        "split multi-file spec body chunk",
+			filename:    "38101-1-k00_s00-05.docx",
+			wantSpecID:  "TS 38.101-1",
+			wantVersion: "k00",
+		},
+		{
+			name:        "split multi-file spec annex chunk",
+			filename:    "38101-1-k00_sAnnexes.docx",
+			wantSpecID:  "TS 38.101-1",
+			wantVersion: "k00",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/db/db.go
+++ b/db/db.go
@@ -477,6 +477,34 @@ func (d *DB) GetTOC(specID string) ([]Section, error) {
 	return sections, nil
 }
 
+// FindSpecIDsByFamily returns the split multi-file part IDs belonging to a
+// family spec ID (e.g. "TS 38.101" -> ["TS 38.101-1", "TS 38.101-2", ...]).
+// Used to give a helpful error when a lookup tool is queried with a family
+// ID instead of a specific part.
+func (d *DB) FindSpecIDsByFamily(familyID string) ([]string, error) {
+	rows, err := d.conn.Query(
+		"SELECT id FROM specs WHERE id LIKE ? || '-%' ORDER BY id",
+		familyID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find spec ids by family: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan spec id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("find spec ids by family: iterate: %w", err)
+	}
+	return ids, nil
+}
+
 func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Section, error) {
 	var rows *sql.Rows
 	var err error
@@ -709,15 +737,16 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 	sqlQuery := "SELECT spec_id, number, title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32) FROM sections_fts WHERE sections_fts MATCH ?"
 	args := []any{query}
 
-	if len(specIDs) == 1 {
-		sqlQuery += " AND spec_id = ?"
-		args = append(args, specIDs[0])
-	} else if len(specIDs) > 1 {
-		placeholders := strings.Repeat("?,", len(specIDs))
-		sqlQuery += " AND spec_id IN (" + placeholders[:len(placeholders)-1] + ")"
-		for _, id := range specIDs {
-			args = append(args, id)
+	if len(specIDs) > 0 {
+		// Each spec ID also matches its split multi-file parts (e.g. "TS 38.101"
+		// matches "TS 38.101-1", "TS 38.101-2", ...). Spec IDs are always in the
+		// "TS dd.ddd(-d)?" form, so this can't false-positive-match unrelated specs.
+		conds := make([]string, len(specIDs))
+		for i, id := range specIDs {
+			conds[i] = "spec_id = ? OR spec_id LIKE ?"
+			args = append(args, id, id+"-%")
 		}
+		sqlQuery += " AND (" + strings.Join(conds, " OR ") + ")"
 	}
 	sqlQuery += " ORDER BY rank LIMIT ?"
 	args = append(args, limit)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -357,6 +357,74 @@ This document covers IMS-AKA and sec-agree mechanisms.');`)
 			t.Error("expected at least 1 result for IMS-AKA")
 		}
 	})
+
+	t.Run("family spec id matches split parts", func(t *testing.T) {
+		err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
+    ('TS 38.101-1', 'User Equipment radio transmission and reception; Part 1', '18.6.0', 'Rel-18', '38');
+INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
+    ('TS 38.101-1', '5.3A.3', 'Guardband', 2, '5', '## 5.3A.3 Guardband
+The guardband requirements are specified here.');`)
+		if err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		results, err := d.Search("guardband", []string{"TS 38.101"}, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if results[0].SpecID != "TS 38.101-1" {
+			t.Errorf("expected spec_id 'TS 38.101-1', got %q", results[0].SpecID)
+		}
+
+		// An unrelated spec sharing the family's numeric prefix must not match.
+		results, err = d.Search("guardband", []string{"TS 38.10"}, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Fatalf("expected 0 results for unrelated prefix, got %d", len(results))
+		}
+	})
+}
+
+func TestFindSpecIDsByFamily(t *testing.T) {
+	d := setupTestDB(t)
+
+	if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
+    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
+    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38'),
+    ('TS 38.101-5', 'Part 5', '18.6.0', 'Rel-18', '38');`); err != nil {
+		t.Fatalf("failed to insert test data: %v", err)
+	}
+
+	t.Run("family with multiple parts", func(t *testing.T) {
+		ids, err := d.FindSpecIDsByFamily("TS 38.101")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"TS 38.101-1", "TS 38.101-2", "TS 38.101-5"}
+		if len(ids) != len(want) {
+			t.Fatalf("expected %v, got %v", want, ids)
+		}
+		for i, id := range ids {
+			if id != want[i] {
+				t.Errorf("ids[%d] = %q, want %q", i, id, want[i])
+			}
+		}
+	})
+
+	t.Run("family with no parts", func(t *testing.T) {
+		ids, err := d.FindSpecIDsByFamily("TS 23.501")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("expected 0 ids, got %v", ids)
+		}
+	})
 }
 
 func TestListOpenAPI(t *testing.T) {

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -38,6 +38,9 @@ func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 		}
 
 		if len(sections) == 0 {
+			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+			}
 			return errorResult(fmt.Sprintf("section %s not found in %s", input.SectionNumber, input.SpecID)), nil, nil
 		}
 

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -30,6 +30,9 @@ func HandleGetTOC(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 		}
 
 		if len(sections) == 0 {
+			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+			}
 			return errorResult(fmt.Sprintf("no sections found for %s", input.SpecID)), nil, nil
 		}
 

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -100,6 +100,23 @@ func TestHandleListImages(t *testing.T) {
 			t.Errorf("expected 'No images found' message, got: %s", text)
 		}
 	})
+
+	t.Run("family spec id with multiple parts", func(t *testing.T) {
+		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
+    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
+    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 38.101"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "TS 38.101-1") || !strings.Contains(text, "TS 38.101-2") {
+			t.Errorf("expected both parts listed, got: %s", text)
+		}
+	})
 }
 
 func TestHandleGetImage(t *testing.T) {

--- a/tools/list_images.go
+++ b/tools/list_images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,6 +31,9 @@ func HandleListImages(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 		}
 
 		if len(images) == 0 {
+			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+				return textResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+			}
 			return textResult(fmt.Sprintf("No images found for %s", input.SpecID)), nil, nil
 		}
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -85,6 +85,23 @@ func TestHandleGetTOC(t *testing.T) {
 			t.Error("expected error result for empty spec_id")
 		}
 	})
+
+	t.Run("family spec id with multiple parts", func(t *testing.T) {
+		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
+    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
+    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		result, _, err := handler(context.Background(), nil, GetTOCInput{SpecID: "TS 38.101"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "TS 38.101-1") || !strings.Contains(text, "TS 38.101-2") {
+			t.Errorf("expected both parts listed, got: %s", text)
+		}
+	})
 }
 
 func TestHandleGetSection(t *testing.T) {
@@ -146,6 +163,26 @@ func TestHandleGetSection(t *testing.T) {
 		}
 		if !result.IsError {
 			t.Error("expected error result for nonexistent section")
+		}
+	})
+
+	t.Run("family spec id with multiple parts", func(t *testing.T) {
+		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
+    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
+    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID:        "TS 38.101",
+			SectionNumber: "1",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "TS 38.101-1") || !strings.Contains(text, "TS 38.101-2") {
+			t.Errorf("expected both parts listed, got: %s", text)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Fix filename regex so split multi-file specs (e.g. TS 38.101-1/-2/-3/-5) get a canonical `TS NN.xxx-P` spec ID instead of a raw filename-derived one
- Expand `search`'s `spec_id`/`spec_ids` filter to also match all parts of a family ID (e.g. `TS 38.101` matches `TS 38.101-1`, `TS 38.101-2`, ...)
- `get_toc`/`get_section`/`list_images` now return a helpful error listing available parts when queried with a family ID that has multiple parts

## Notes
- Existing databases need a rebuild (`make build-db`) or reimport of the affected specs to pick up corrected IDs; already-imported rows keep their old IDs until reimported
- Closes #30
- Partially related to #31 (its "series filter doesn't work" complaint is fixed here; left a comment there about the remaining keyword-filter feature as a follow-up)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvEdL99HkQUoQKgDLYZdpi)_