### PR TITLE
fix(docx): keep whitespace outside emphasis delimiters

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // paragraphInfo holds extracted information from a w:p element.
@@ -431,6 +432,23 @@ func mergeAdjacentRuns(runs []runInfo) []runInfo {
 	return merged
 }
 
+// wrapEmphasis wraps text in the given markdown emphasis delimiter (e.g.
+// "*", "**", "***"), moving any leading/trailing whitespace outside the
+// delimiters. CommonMark requires emphasis delimiters to hug their content
+// (no whitespace immediately inside), so a run like "word " wrapped naively
+// as "*word *" fails to parse as emphasis and the asterisks show up as
+// literal text; a run that is only whitespace has no content to emphasize
+// at all and is returned unchanged (see issue #33).
+func wrapEmphasis(text, delim string) string {
+	mid := strings.TrimFunc(text, unicode.IsSpace)
+	if mid == "" {
+		return text
+	}
+	i := strings.Index(text, mid)
+	lead, trail := text[:i], text[i+len(mid):]
+	return lead + delim + mid + delim + trail
+}
+
 // paragraphToMarkdown converts a paragraph to markdown text.
 func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 	text := strings.TrimSpace(info.Text)
@@ -455,11 +473,11 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 		for _, run := range mergeAdjacentRuns(info.Runs) {
 			runText := run.Text
 			if run.Bold && run.Italic {
-				runText = "***" + runText + "***"
+				runText = wrapEmphasis(runText, "***")
 			} else if run.Bold {
-				runText = "**" + runText + "**"
+				runText = wrapEmphasis(runText, "**")
 			} else if run.Italic {
-				runText = "*" + runText + "*"
+				runText = wrapEmphasis(runText, "*")
 			}
 			switch run.VertAlign {
 			case "superscript":

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -339,6 +339,55 @@ func TestParagraphToMarkdown(t *testing.T) {
 			styleName: "Normal",
 			want:      "<sup>a</sup><sub>b</sub>",
 		},
+		{
+			name: "italic run with trailing space keeps space outside the delimiter",
+			info: paragraphInfo{
+				Text: "term [15]",
+				Runs: []runInfo{
+					{Text: "term ", Italic: true},
+					{Text: "[15]"},
+				},
+			},
+			styleName: "Normal",
+			want:      "*term* [15]",
+		},
+		{
+			name: "italic run with leading space keeps space outside the delimiter",
+			info: paragraphInfo{
+				Text: " term",
+				Runs: []runInfo{
+					{Text: "pre"},
+					{Text: " term", Italic: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "pre *term*",
+		},
+		{
+			name: "whitespace-only italic run is left unwrapped",
+			info: paragraphInfo{
+				Text: "a b",
+				Runs: []runInfo{
+					{Text: "a"},
+					{Text: " ", Italic: true},
+					{Text: "b"},
+				},
+			},
+			styleName: "Normal",
+			want:      "a b",
+		},
+		{
+			name: "bold run with trailing space keeps space outside the delimiter",
+			info: paragraphInfo{
+				Text: "label: value",
+				Runs: []runInfo{
+					{Text: "label: ", Bold: true},
+					{Text: "value"},
+				},
+			},
+			styleName: "Normal",
+			want:      "**label:** value",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -388,6 +388,43 @@ func TestParagraphToMarkdown(t *testing.T) {
 			styleName: "Normal",
 			want:      "**label:** value",
 		},
+		{
+			name: "bold run with leading space keeps space outside the delimiter",
+			info: paragraphInfo{
+				Text: "pre label",
+				Runs: []runInfo{
+					{Text: "pre"},
+					{Text: " label", Bold: true},
+				},
+			},
+			styleName: "Normal",
+			want:      "pre **label**",
+		},
+		{
+			name: "bold-italic run with trailing space keeps space outside the delimiter",
+			info: paragraphInfo{
+				Text: "term [1]",
+				Runs: []runInfo{
+					{Text: "term ", Bold: true, Italic: true},
+					{Text: "[1]"},
+				},
+			},
+			styleName: "Normal",
+			want:      "***term*** [1]",
+		},
+		{
+			name: "bold-italic run with leading and trailing space keeps spaces outside the delimiter",
+			info: paragraphInfo{
+				Text: "pre term post",
+				Runs: []runInfo{
+					{Text: "pre"},
+					{Text: " term ", Bold: true, Italic: true},
+					{Text: "post"},
+				},
+			},
+			styleName: "Normal",
+			want:      "pre ***term*** post",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #33: residual `*` marks still appearing in converted specs (e.g. TS 38.101-1)
- DOCX runs with leading/trailing whitespace (or whitespace-only runs) were wrapped directly in markdown emphasis delimiters, producing invalid CommonMark emphasis (e.g. `*word *`) that renders as literal asterisks instead of italics
- Added `wrapEmphasis` to move whitespace outside the delimiters, and to skip wrapping whitespace-only runs entirely

## Changes

- `converter/docx/paragraph.go`: introduce `wrapEmphasis` helper, use it for bold/italic/bold-italic wrapping
- `converter/docx/paragraph_test.go`: add test cases for leading/trailing whitespace and whitespace-only runs