### PR TITLE
feat(web): add persistent search bar and spec list keyword filter

### DIFF
--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -445,7 +445,7 @@ func cmdUpdate(args []string) {
 	if err != nil {
 		log.Fatalf("Failed to open database: %v", err)
 	}
-	currentResult, err := src.ListSpecs("", -1, 0)
+	currentResult, err := src.ListSpecs("", "", -1, 0)
 	if err != nil || len(currentResult.Specs) == 0 {
 		_ = src.Close()
 		fmt.Println("No specs in database. Use 'build' command first.")

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -266,7 +266,7 @@ func TestCmdConvert_HappyPath(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	defer d.Close()
-	result, err := d.ListSpecs("", -1, 0)
+	result, err := d.ListSpecs("", "", -1, 0)
 	if err != nil {
 		t.Fatalf("list specs: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestCmdConvertDir_HappyPath(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	defer d.Close()
-	result, err := d.ListSpecs("", -1, 0)
+	result, err := d.ListSpecs("", "", -1, 0)
 	if err != nil {
 		t.Fatalf("list specs: %v", err)
 	}

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -91,7 +91,7 @@ func TestConvertDir_Race(t *testing.T) {
 	}
 
 	// Verify at least one spec was inserted.
-	result, err := d.ListSpecs("", -1, 0)
+	result, err := d.ListSpecs("", "", -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestConvertSingleFile(t *testing.T) {
 		t.Error("expected sections for TS 23.274 after ConvertSingleFile")
 	}
 
-	specs, err := d.ListSpecs("", -1, 0)
+	specs, err := d.ListSpecs("", "", -1, 0)
 	if err != nil {
 		t.Fatalf("ListSpecs: %v", err)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -415,6 +415,9 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 		filterArgs = append(filterArgs, series)
 	}
 	if query != "" {
+		// Match three ways a user might type the prefix: the bare number
+		// (e.g. "23.501"), or with an explicit "TS "/"TR " document-type
+		// prefix already included (e.g. "TS 23.501").
 		pattern := escapeLikePattern(query) + "%"
 		conditions = append(conditions, "(id LIKE ? ESCAPE '\\' OR id LIKE 'TS ' || ? ESCAPE '\\' OR id LIKE 'TR ' || ? ESCAPE '\\')")
 		filterArgs = append(filterArgs, pattern, pattern, pattern)

--- a/db/db.go
+++ b/db/db.go
@@ -401,15 +401,27 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	return tx.Commit()
 }
 
-func (d *DB) ListSpecs(series string, limit, offset int) (*ListSpecsResult, error) {
+// ListSpecs lists specs, optionally filtered by series and/or an ID prefix.
+// query matches spec IDs that start with the given text, ignoring a leading
+// "TS "/"TR " document-type prefix (e.g. query "38.21" matches "TS 38.211").
+func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResult, error) {
 	if offset < 0 {
 		offset = 0
 	}
-	where := ""
+	var conditions []string
 	var filterArgs []any
 	if series != "" {
-		where = " WHERE series = ?"
+		conditions = append(conditions, "series = ?")
 		filterArgs = append(filterArgs, series)
+	}
+	if query != "" {
+		pattern := escapeLikePattern(query) + "%"
+		conditions = append(conditions, "(id LIKE ? ESCAPE '\\' OR id LIKE 'TS ' || ? ESCAPE '\\' OR id LIKE 'TR ' || ? ESCAPE '\\')")
+		filterArgs = append(filterArgs, pattern, pattern, pattern)
+	}
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
 	}
 
 	// Get total count.
@@ -418,7 +430,7 @@ func (d *DB) ListSpecs(series string, limit, offset int) (*ListSpecsResult, erro
 		return nil, fmt.Errorf("count specs: %w", err)
 	}
 
-	query := "SELECT id, title, COALESCE(version, ''), COALESCE(release, ''), COALESCE(series, '') FROM specs" + where + " ORDER BY id"
+	sqlQuery := "SELECT id, title, COALESCE(version, ''), COALESCE(release, ''), COALESCE(series, '') FROM specs" + where + " ORDER BY id"
 	args := append([]any{}, filterArgs...)
 
 	// limit == 0: use default; limit < 0: no limit (return all rows, internal use only).
@@ -429,11 +441,11 @@ func (d *DB) ListSpecs(series string, limit, offset int) (*ListSpecsResult, erro
 		limit = MaxListSpecsLimit
 	}
 	if limit > 0 {
-		query += " LIMIT ? OFFSET ?"
+		sqlQuery += " LIMIT ? OFFSET ?"
 		args = append(args, limit, offset)
 	}
 
-	rows, err := d.conn.Query(query, args...)
+	rows, err := d.conn.Query(sqlQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list specs: %w", err)
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -86,7 +86,7 @@ func TestListSpecs(t *testing.T) {
 	d := setupTestDB(t)
 
 	t.Run("all", func(t *testing.T) {
-		result, err := d.ListSpecs("", 0, 0)
+		result, err := d.ListSpecs("", "", 0, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -102,7 +102,7 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("filter by series", func(t *testing.T) {
-		result, err := d.ListSpecs("29", 0, 0)
+		result, err := d.ListSpecs("29", "", 0, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -118,7 +118,7 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("no match", func(t *testing.T) {
-		result, err := d.ListSpecs("99", 0, 0)
+		result, err := d.ListSpecs("99", "", 0, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -131,7 +131,7 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("with limit", func(t *testing.T) {
-		result, err := d.ListSpecs("", 1, 0)
+		result, err := d.ListSpecs("", "", 1, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -147,7 +147,7 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("with offset", func(t *testing.T) {
-		result, err := d.ListSpecs("", 1, 1)
+		result, err := d.ListSpecs("", "", 1, 1)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("offset beyond end", func(t *testing.T) {
-		result, err := d.ListSpecs("", 10, 100)
+		result, err := d.ListSpecs("", "", 10, 100)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -173,12 +173,53 @@ func TestListSpecs(t *testing.T) {
 	})
 
 	t.Run("no limit", func(t *testing.T) {
-		result, err := d.ListSpecs("", -1, 0)
+		result, err := d.ListSpecs("", "", -1, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(result.Specs) != 3 {
 			t.Fatalf("expected 3 specs, got %d", len(result.Specs))
+		}
+	})
+
+	t.Run("filter by query prefix ignoring TS/TR prefix", func(t *testing.T) {
+		result, err := d.ListSpecs("", "23.5", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(result.Specs))
+		}
+		if result.Specs[0].ID != "TS 23.501" {
+			t.Errorf("expected spec ID 'TS 23.501', got %q", result.Specs[0].ID)
+		}
+	})
+
+	t.Run("filter by query prefix no match", func(t *testing.T) {
+		result, err := d.ListSpecs("", "99.9", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Specs) != 0 {
+			t.Fatalf("expected 0 specs, got %d", len(result.Specs))
+		}
+	})
+
+	t.Run("filter by series and query prefix combined", func(t *testing.T) {
+		result, err := d.ListSpecs("23", "23.5", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Specs) != 1 || result.Specs[0].ID != "TS 23.501" {
+			t.Fatalf("expected only TS 23.501, got %+v", result.Specs)
+		}
+
+		result, err = d.ListSpecs("29", "23.5", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Specs) != 0 {
+			t.Fatalf("expected 0 specs for mismatched series/query, got %d", len(result.Specs))
 		}
 	})
 }
@@ -966,7 +1007,7 @@ func TestOpen_ReadOnly(t *testing.T) {
 	}
 	defer ro.Close()
 
-	result, err := ro.ListSpecs("", 0, 0)
+	result, err := ro.ListSpecs("", "", 0, 0)
 	if err != nil {
 		t.Fatalf("ListSpecs: %v", err)
 	}
@@ -1013,7 +1054,7 @@ func TestExec_DirectSQL(t *testing.T) {
 		t.Fatalf("Exec insert: %v", err)
 	}
 
-	result, err := d.ListSpecs("99", 0, 0)
+	result, err := d.ListSpecs("99", "", 0, 0)
 	if err != nil {
 		t.Fatalf("ListSpecs: %v", err)
 	}
@@ -1039,7 +1080,7 @@ func TestUpsertSpec_Replaces(t *testing.T) {
 		t.Fatalf("UpsertSpec: %v", err)
 	}
 
-	result, err := d.ListSpecs("", 0, 0)
+	result, err := d.ListSpecs("", "", 0, 0)
 	if err != nil {
 		t.Fatalf("ListSpecs: %v", err)
 	}

--- a/tools/list_specs.go
+++ b/tools/list_specs.go
@@ -11,18 +11,19 @@ import (
 
 type ListSpecsInput struct {
 	Series string `json:"series,omitempty" jsonschema:"Filter by series number (e.g. 23 for TS 23.xxx)"`
+	Query  string `json:"query,omitempty" jsonschema:"Filter specs whose ID starts with this text (e.g. '38.21' matches 38.211, 38.212, 38.213)"`
 	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of results to return (default: 20)"`
 	Offset int    `json:"offset,omitempty" jsonschema:"Number of results to skip for pagination (default: 0)"`
 }
 
 var ListSpecsTool = &mcp.Tool{
 	Name:        "list_specs",
-	Description: "List available 3GPP specifications. Optionally filter by series number. Results are paginated (default 20 per page); use limit and offset to navigate.",
+	Description: "List available 3GPP specifications. Optionally filter by series number and/or by an ID prefix (query). Results are paginated (default 20 per page); use limit and offset to navigate.",
 }
 
 func HandleListSpecs(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input ListSpecsInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ListSpecsInput) (*mcp.CallToolResult, any, error) {
-		result, err := d.ListSpecs(input.Series, input.Limit, input.Offset)
+		result, err := d.ListSpecs(input.Series, input.Query, input.Limit, input.Offset)
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to list specs: %v", err)), nil, nil
 		}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -56,6 +56,20 @@ func TestHandleListSpecs(t *testing.T) {
 			t.Errorf("expected only one spec in output, got: %s", text)
 		}
 	})
+
+	t.Run("with query prefix", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, ListSpecsInput{Query: "23.5"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "TS 23.501") {
+			t.Errorf("expected TS 23.501 in output, got: %s", text)
+		}
+		if strings.Contains(text, "TS 29.510") || strings.Contains(text, "TS 24.229") {
+			t.Errorf("expected only TS 23.501 in output, got: %s", text)
+		}
+	})
 }
 
 func TestHandleGetTOC(t *testing.T) {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -19,10 +19,20 @@ type handler struct {
 
 // Template data types
 
+// layoutData wraps the page-specific data with fields the shared layout
+// (navbar search bar) needs regardless of which page is being rendered.
+type layoutData struct {
+	Page      string
+	Data      any
+	NavQuery  string // pre-fills the navbar search query input (only set on /search)
+	NavSpecID string // pre-fills the navbar spec ID input with the current spec scope
+}
+
 type indexData struct {
 	Specs      []db.Spec
 	TotalCount int
 	Series     string
+	Query      string
 	Page       int
 	Limit      int
 	TotalPages int
@@ -114,16 +124,14 @@ func (h *handler) initTemplates() {
 func (h *handler) renderError(w http.ResponseWriter, code int, message string) {
 	w.WriteHeader(code)
 	data := errorData{Code: code, Message: message}
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data errorData
-	}{Page: "error", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "error", Data: data}); err != nil {
 		http.Error(w, message, code)
 	}
 }
 
 func (h *handler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	series := r.URL.Query().Get("series")
+	query := r.URL.Query().Get("q")
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	if page < 1 {
 		page = 1
@@ -131,7 +139,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	limit := 50
 	offset := (page - 1) * limit
 
-	result, err := h.db.ListSpecs(series, limit, offset)
+	result, err := h.db.ListSpecs(series, query, limit, offset)
 	if err != nil {
 		h.renderError(w, http.StatusInternalServerError, "Failed to load specifications")
 		log.Printf("ListSpecs error: %v", err)
@@ -147,6 +155,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, r *http.Request) {
 		Specs:      result.Specs,
 		TotalCount: result.TotalCount,
 		Series:     series,
+		Query:      query,
 		Page:       page,
 		Limit:      limit,
 		TotalPages: totalPages,
@@ -154,10 +163,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, r *http.Request) {
 		HasNext:    page < totalPages,
 	}
 
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data indexData
-	}{Page: "index", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "index", Data: data}); err != nil {
 		log.Printf("template error: %v", err)
 	}
 }
@@ -205,10 +211,7 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
 		OpenAPIs:   openAPIs,
 	}
 
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data specData
-	}{Page: "spec", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "spec", Data: data, NavSpecID: specID}); err != nil {
 		log.Printf("template error: %v", err)
 	}
 }
@@ -250,10 +253,7 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data searchData
-	}{Page: "search", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "search", Data: data, NavQuery: query, NavSpecID: specID}); err != nil {
 		log.Printf("template error: %v", err)
 	}
 }
@@ -272,10 +272,7 @@ func (h *handler) handleOpenAPIList(w http.ResponseWriter, r *http.Request) {
 		APIs:   apis,
 	}
 
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data openAPIListData
-	}{Page: "openapi_list", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "openapi_list", Data: data, NavSpecID: specID}); err != nil {
 		log.Printf("template error: %v", err)
 	}
 }
@@ -296,10 +293,7 @@ func (h *handler) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
 		Content: template.HTML(highlightYAML(content)), //nolint:gosec
 	}
 
-	if err := h.tmpls.ExecuteTemplate(w, "layout.html", struct {
-		Page string
-		Data openAPIData
-	}{Page: "openapi", Data: data}); err != nil {
+	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "openapi", Data: data, NavSpecID: specID}); err != nil {
 		log.Printf("template error: %v", err)
 	}
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -126,6 +126,50 @@ mark {
     text-decoration: none;
 }
 
+.navbar-search {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.navbar-search-input,
+.navbar-search-specid {
+    padding: 5px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: var(--radius);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--nav-text);
+    font-size: 0.85rem;
+}
+
+.navbar-search-input::placeholder,
+.navbar-search-specid::placeholder {
+    color: var(--nav-text);
+    opacity: 0.6;
+}
+
+.navbar-search-input {
+    width: 220px;
+}
+
+.navbar-search-specid {
+    width: 140px;
+}
+
+.navbar-search-btn {
+    padding: 5px 12px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--nav-text);
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.navbar-search-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
 .theme-toggle {
     background: none;
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -179,13 +223,29 @@ mark {
     color: var(--text-secondary);
 }
 
-.filter-form select {
+.filter-form select,
+.filter-form input[type="text"] {
     padding: 6px 12px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: var(--bg);
     color: var(--text);
     font-size: 0.9rem;
+}
+
+.filter-btn {
+    padding: 6px 14px;
+    background: var(--link);
+    color: white;
+    border: none;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.filter-btn:hover {
+    background: var(--link-hover);
 }
 
 /* === Tables === */
@@ -500,52 +560,6 @@ mark {
     margin-bottom: 1rem;
 }
 
-.search-form {
-    margin-bottom: 1.5rem;
-}
-
-.search-input-group {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-
-.search-input {
-    flex: 1;
-    min-width: 200px;
-    padding: 10px 14px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 1rem;
-    background: var(--bg);
-    color: var(--text);
-}
-
-.search-filter {
-    width: 200px;
-    padding: 10px 14px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 0.9rem;
-    background: var(--bg);
-    color: var(--text);
-}
-
-.search-btn {
-    padding: 10px 20px;
-    background: var(--link);
-    color: white;
-    border: none;
-    border-radius: var(--radius);
-    cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 500;
-}
-
-.search-btn:hover {
-    background: var(--link-hover);
-}
-
 .results-count {
     color: var(--text-secondary);
     font-size: 0.9rem;
@@ -655,11 +669,21 @@ mark {
         max-width: 200px;
     }
 
-    .search-input-group {
-        flex-direction: column;
+    .navbar-inner {
+        height: auto;
+        flex-wrap: wrap;
+        padding: 0.5rem 1rem;
+        gap: 0.5rem;
     }
 
-    .search-filter {
+    .navbar-search {
+        flex-direction: column;
+        width: 100%;
+        order: 3;
+    }
+
+    .navbar-search-input,
+    .navbar-search-specid {
         width: 100%;
     }
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -595,6 +595,12 @@ mark {
     text-align: center;
 }
 
+.search-hint {
+    color: var(--text-secondary);
+    padding: 2rem;
+    text-align: center;
+}
+
 /* === OpenAPI === */
 .openapi-page {
     max-width: 1000px;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,6 +13,9 @@
         <option value="{{$s}}" {{if eq (printf "%d" $s) $currentSeries}}selected{{end}}>{{$s}}</option>
         {{end}}
     </select>
+    <label for="q">Filter by keyword:</label>
+    <input type="text" name="q" id="q" value="{{.Query}}" placeholder="e.g. 38.21">
+    <button type="submit" class="filter-btn">Filter</button>
 </form>
 
 <div class="table-responsive">
@@ -45,7 +48,7 @@
 {{if gt .TotalPages 1}}
 <nav class="pagination" aria-label="Pagination">
     {{if .HasPrev}}
-        <a href="/?page={{sub .Page 1}}{{if .Series}}&series={{.Series}}{{end}}" class="page-link">&laquo; Previous</a>
+        <a href="/?page={{sub .Page 1}}{{if .Series}}&series={{.Series}}{{end}}{{if .Query}}&q={{.Query}}{{end}}" class="page-link">&laquo; Previous</a>
     {{else}}
         <span class="page-link disabled">&laquo; Previous</span>
     {{end}}
@@ -53,7 +56,7 @@
     <span class="page-info">Page {{.Page}} of {{.TotalPages}}</span>
 
     {{if .HasNext}}
-        <a href="/?page={{add .Page 1}}{{if .Series}}&series={{.Series}}{{end}}" class="page-link">Next &raquo;</a>
+        <a href="/?page={{add .Page 1}}{{if .Series}}&series={{.Series}}{{end}}{{if .Query}}&q={{.Query}}{{end}}" class="page-link">Next &raquo;</a>
     {{else}}
         <span class="page-link disabled">Next &raquo;</span>
     {{end}}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -13,7 +13,11 @@
             <a href="/" class="navbar-brand">3GPP Spec Viewer</a>
             <nav class="navbar-nav">
                 <a href="/" class="nav-link">Specs</a>
-                <a href="/search" class="nav-link">Search</a>
+                <form class="navbar-search" method="get" action="/search">
+                    <input type="text" name="q" value="{{.NavQuery}}" placeholder="Search specs..." class="navbar-search-input">
+                    <input type="text" name="spec_id" value="{{.NavSpecID}}" placeholder="Spec ID (optional)" class="navbar-search-specid">
+                    <button type="submit" class="navbar-search-btn">Search</button>
+                </form>
                 <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
                     <span class="theme-icon-light">&#9788;</span>
                     <span class="theme-icon-dark">&#9789;</span>

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -2,17 +2,9 @@
 <div class="search-page">
     <h1>Search Specifications</h1>
 
-    <form class="search-form" method="get" action="/search">
-        <div class="search-input-group">
-            <input type="text" name="q" value="{{.Query}}" placeholder="Search across all specifications..." class="search-input" autofocus>
-            <input type="text" name="spec_id" value="{{.SpecID}}" placeholder="Filter by spec ID (optional)" class="search-filter">
-            <button type="submit" class="search-btn">Search</button>
-        </div>
-    </form>
-
     {{if .Query}}
     <div class="search-results">
-        <p class="results-count">{{len .Results}} result{{if ne (len .Results) 1}}s{{end}} for "{{.Query}}"</p>
+        <p class="results-count">{{len .Results}} result{{if ne (len .Results) 1}}s{{end}} for "{{.Query}}"{{if .SpecID}} in {{.SpecID}}{{end}}</p>
 
         {{range .Results}}
         <div class="search-result">

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -18,6 +18,8 @@
         <p class="no-results">No results found. Try a different search term.</p>
         {{end}}
     </div>
+    {{else}}
+    <p class="search-hint">Use the search bar above to find specifications.</p>
     {{end}}
 </div>
 {{end}}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -190,6 +190,52 @@ func TestHandleIndexWithSeriesFilter(t *testing.T) {
 	}
 }
 
+func TestHandleIndexWithQueryFilter(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	t.Run("query prefix alone", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/?q=23.5")
+		if err != nil {
+			t.Fatalf("GET /?q=23.5 error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		body := readBody(t, resp)
+		if !strings.Contains(body, "TS 23.501") {
+			t.Error("should contain TS 23.501")
+		}
+		if strings.Contains(body, "TS 29.510") || strings.Contains(body, "TS 24.229") {
+			t.Error("should not contain non-matching specs")
+		}
+	})
+
+	t.Run("query prefix combined with series", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/?series=23&q=23.5")
+		if err != nil {
+			t.Fatalf("GET /?series=23&q=23.5 error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		body := readBody(t, resp)
+		if !strings.Contains(body, "TS 23.501") {
+			t.Error("should contain TS 23.501")
+		}
+	})
+
+	t.Run("index navbar search has no spec scope", func(t *testing.T) {
+		resp, err := http.Get(ts.URL + "/")
+		if err != nil {
+			t.Fatalf("GET / error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		body := readBody(t, resp)
+		if !strings.Contains(body, `name="spec_id" value=""`) {
+			t.Errorf("expected empty navbar spec_id field, got:\n%s", body)
+		}
+	})
+}
+
 func TestHandleSpec(t *testing.T) {
 	ts, _ := setupTestServer(t)
 
@@ -206,6 +252,9 @@ func TestHandleSpec(t *testing.T) {
 	body := readBody(t, resp)
 	if !strings.Contains(body, "Scope") {
 		t.Error("should contain TOC entry 'Scope'")
+	}
+	if !strings.Contains(body, `name="spec_id" value="TS 23.501"`) {
+		t.Errorf("expected navbar search to be pre-filled with the current spec ID, got:\n%s", body)
 	}
 }
 
@@ -266,6 +315,21 @@ func TestHandleSearch(t *testing.T) {
 	body := readBody(t, resp2)
 	if !strings.Contains(body, "TS 23.501") {
 		t.Error("search for 'architecture' should return TS 23.501")
+	}
+	if !strings.Contains(body, `name="q" value="architecture"`) {
+		t.Errorf("expected navbar search to retain the submitted query, got:\n%s", body)
+	}
+
+	// Search scoped to a spec
+	resp3, err := http.Get(ts.URL + "/search?q=architecture&spec_id=TS+23.501")
+	if err != nil {
+		t.Fatalf("GET /search?q=architecture&spec_id=TS+23.501 error: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	body3 := readBody(t, resp3)
+	if !strings.Contains(body3, `name="spec_id" value="TS 23.501"`) {
+		t.Errorf("expected navbar search to retain the submitted spec_id, got:\n%s", body3)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a persistent navbar search bar (query + editable spec ID field) shown on every page, pre-filled with the current spec while browsing it
- Remove the now-duplicate search form from the /search results page
- Add an ID-prefix keyword filter to the spec list page and the list_specs tool (e.g. "38.21" matches 38.211/38.212/38.213)

Closes #23
Closes #31