### PR TITLE
fix(db): quote dotted terms in FTS5 search queries

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -657,8 +657,17 @@ var fts5Operators = map[string]bool{
 	"AND": true, "OR": true, "NOT": true,
 }
 
-// sanitizeFTS5Query wraps bare hyphenated tokens in double quotes so FTS5
-// does not misinterpret the hyphen as a column-filter separator.
+// needsFTS5Quoting reports whether a bare token contains a character FTS5
+// cannot parse as part of an unquoted bareword: a hyphen (misread as the
+// column-filter/NOT operator) or a period (e.g. spec numbers like "38.101",
+// which FTS5 otherwise rejects with "syntax error near \".\"").
+func needsFTS5Quoting(s string) bool {
+	return strings.ContainsRune(s, '-') || strings.ContainsRune(s, '.')
+}
+
+// sanitizeFTS5Query wraps bare hyphenated or dotted tokens in double quotes
+// so FTS5 does not misinterpret the hyphen as a column-filter separator or
+// reject the period as invalid bareword syntax.
 func sanitizeFTS5Query(query string) string {
 	var result []string
 	i := 0
@@ -716,7 +725,7 @@ func sanitizeFTS5Query(query string) string {
 			col := token[:colIdx]
 			val := token[colIdx+1:]
 			if fts5Columns[col] {
-				if strings.ContainsRune(val, '-') && !strings.HasPrefix(val, "\"") {
+				if needsFTS5Quoting(val) && !strings.HasPrefix(val, "\"") {
 					result = append(result, col+":\""+val+"\"")
 				} else {
 					result = append(result, token)
@@ -726,11 +735,11 @@ func sanitizeFTS5Query(query string) string {
 		}
 
 		// A leading hyphen is FTS5 NOT shorthand — leave it alone unless
-		// there are additional hyphens in the rest of the token.
-		if strings.ContainsRune(token, '-') {
+		// there are additional hyphens or a period in the rest of the token.
+		if needsFTS5Quoting(token) {
 			if token[0] == '-' {
 				rest := token[1:]
-				if strings.ContainsRune(rest, '-') {
+				if needsFTS5Quoting(rest) {
 					result = append(result, "\""+token+"\"")
 				} else {
 					result = append(result, token)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -323,6 +323,12 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"hyphen with operator", "sec-agree OR authentication", `"sec-agree" OR authentication`},
 		{"invalid column is hyphenated", "IMS-AKA", `"IMS-AKA"`},
 		{"empty query", "", ""},
+		{"bare spec number", "38.101", `"38.101"`},
+		{"another bare spec number", "23.501", `"23.501"`},
+		{"dotted version string", "18.6.0", `"18.6.0"`},
+		{"column filter with dotted value", "title:38.101", `title:"38.101"`},
+		{"spec number with AND operator", "38.101 AND UE", `"38.101" AND UE`},
+		{"multi-part spec number", "38.101-1", `"38.101-1"`},
 	}
 
 	for _, tt := range tests {

--- a/tools/search.go
+++ b/tools/search.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SearchInput struct {
-	Query string `json:"query" jsonschema:"required,FTS5 query string. Hyphenated terms like IMS-AKA are auto-quoted. Use AND/OR/NOT operators and double-quoted phrases for exact matches (e.g. '\"core network\" AND AMF')."`
+	Query string `json:"query" jsonschema:"required,FTS5 query string. Hyphenated or dotted terms like IMS-AKA and 38.101 are auto-quoted. Use AND/OR/NOT operators and double-quoted phrases for exact matches (e.g. '\"core network\" AND AMF')."`
 	// Deprecated: use SpecIDs instead. Ignored when SpecIDs is non-empty.
 	SpecID  string   `json:"spec_id,omitempty" jsonschema:"Limit search to a single specification (e.g. TS 23.501). Ignored when spec_ids is provided."`
 	SpecIDs []string `json:"spec_ids,omitempty" jsonschema:"Limit search to one or more specifications (e.g. [\"TS 23.501\", \"TS 23.502\"]). Takes precedence over spec_id."`
@@ -27,7 +27,7 @@ Query syntax:
 - Prefix:        handov*
 - Column filter: title:authentication  or  content:handover
 - Proximity:     NEAR(AMF UE, 5)
-- Hyphenated terms (e.g. IMS-AKA, sec-agree) are auto-quoted to avoid FTS5 syntax errors.
+- Hyphenated or dotted terms (e.g. IMS-AKA, sec-agree, 38.101) are auto-quoted to avoid FTS5 syntax errors.
 
 Tips:
 - Use exact 3GPP terms (AMF, SMF, gNB, UE, NRF, PCF, etc.)


### PR DESCRIPTION
## Summary
- Spec numbers like "38.101" contain a period, which SQLite FTS5 rejects as a bareword token, causing the search feature to silently return zero results for the most natural query a user would type.
- `sanitizeFTS5Query` already auto-quotes hyphenated terms for the same reason; extend it to do the same for dotted terms.

Fixes #37

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcaUD4GyUwfMxmD8kuMw6J)_