### PR TITLE
fix(docx): parse base-36 version tokens in spec filenames

### DIFF
--- a/converter/docx/metadata.go
+++ b/converter/docx/metadata.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})(?:-(\d{1,2}))?-?([a-z])(\d+)`)
+	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})(?:-(\d{1,2}))?-?([a-z][0-9a-z]+)`)
 	specPatternRE = regexp.MustCompile(`(?i)(?:TS|TR)\s*(\d+)\.(\d+)`)
 	versionRE     = regexp.MustCompile(`V(\d+\.\d+\.\d+)`)
 	releaseRE     = regexp.MustCompile(`Release\s+(\d+)`)
@@ -93,12 +93,12 @@ func extractMetadata(filename string, props coreProperties, bodyElements []bodyE
 
 	// Parse from filename
 	if match := filenameRE.FindStringSubmatch(stem); match != nil {
-		series, num, part, verLetter, verNum := match[1], match[2], match[3], match[4], match[5]
+		series, num, part, ver := match[1], match[2], match[3], match[4]
 		specID = "TS " + series + "." + num
 		if part != "" {
 			specID += "-" + part
 		}
-		version = verLetter + verNum
+		version = ver
 	} else if match := specPatternRE.FindStringSubmatch(stem); match != nil {
 		specID = "TS " + match[1] + "." + match[2]
 	} else {

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -99,6 +99,24 @@ func TestExtractMetadata_FilenameVariants(t *testing.T) {
 			wantSpecID:  "TS 38.101-1",
 			wantVersion: "k00",
 		},
+		{
+			name:        "base-36 version token with letter in second position",
+			filename:    "23222-ja0.docx",
+			wantSpecID:  "TS 23.222",
+			wantVersion: "ja0",
+		},
+		{
+			name:        "base-36 version token, minor version b",
+			filename:    "23280-ja1.docx",
+			wantSpecID:  "TS 23.280",
+			wantVersion: "ja1",
+		},
+		{
+			name:        "base-36 version token, different minor letter",
+			filename:    "23379-jb0.docx",
+			wantSpecID:  "TS 23.379",
+			wantVersion: "jb0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -263,5 +281,15 @@ func TestSpecMetadata_Series(t *testing.T) {
 		if got := m.Series(); got != want {
 			t.Errorf("Series for %q = %q, want %q", specID, got, want)
 		}
+	}
+}
+
+func TestExtractMetadata_SeriesFromBase36VersionFilename(t *testing.T) {
+	meta := extractMetadata("23222-ja0.docx", coreProperties{}, nil, nil)
+	if meta.SpecID != "TS 23.222" {
+		t.Fatalf("SpecID = %q, want %q", meta.SpecID, "TS 23.222")
+	}
+	if got := meta.Series(); got != "23" {
+		t.Errorf("Series() = %q, want %q", got, "23")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #38. Some specs (e.g. `23222-ja0`, `23280-ja1`, `23379-jb0`) were showing up in the web viewer with the raw filename as their ID and an empty Series column, instead of a normal `TS 23.222`-style ID with Series `23`.

`filenameRE` in `converter/docx/metadata.go` only accepted version tokens shaped like one letter followed by digits (e.g. `i30`, `h50`). 3GPP version tokens are actually base-36 strings where any character after the first can also be a letter (e.g. `ja0`, `jb0`), so those filenames failed to parse and fell back to using the raw filename stem as the spec ID, which has no dot for `Series()` to extract from.

Same base-36 issue was already fixed elsewhere (`converter/pipeline/speclist.go`, `converter/pipeline/pipeline.go`) but was missed in `converter/docx/metadata.go`.

## Changes

- Widen `filenameRE`'s version group to accept base-36 tokens (`[a-z][0-9a-z]+`)
- Simplify `extractMetadata` to use the single version capture
- Add test cases for the filenames from the issue in `metadata_test.go`