### PR TITLE
fix(docx): render inline images at their position in paragraph text

### DIFF
--- a/converter/docx/image_position_test.go
+++ b/converter/docx/image_position_test.go
@@ -1,0 +1,121 @@
+package docx
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+// TestParseDocx_InlineImagesInterleavedWithText reproduces the issue #40
+// scenario reported against TS 38.212: a paragraph whose text and inline
+// images alternate in the document (e.g. "see sub-figure (a) [image] and
+// sub-figure (b) [image] below") must render with each image placeholder
+// next to the text describing it, not with every image bunched up after all
+// of the paragraph's text.
+func TestParseDocx_InlineImagesInterleavedWithText(t *testing.T) {
+	const contentTypes = `<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="xml" ContentType="application/xml"/>
+<Default Extension="png" ContentType="image/png"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+
+	const rels = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+	const docRels = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+<Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image2.png"/>
+</Relationships>`
+
+	img := func(rid string) string {
+		return `<w:r><w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
+			`<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData>` +
+			`<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:blipFill>` +
+			`<a:blip r:embed="` + rid + `"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`
+	}
+
+	// One paragraph: text, image (a), text, image (b), text — the exact
+	// interleaving pattern from a multi-part figure caption.
+	para := `<w:p><w:r><w:t xml:space="preserve">See sub-figure (a) </w:t></w:r>` +
+		img("rId5") +
+		`<w:r><w:t xml:space="preserve"> and sub-figure (b) </w:t></w:r>` +
+		img("rId6") +
+		`<w:r><w:t xml:space="preserve"> below.</w:t></w:r></w:p>`
+
+	doc := `<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<w:body>
+<w:p><w:pPr><w:pStyle w:val="Heading 1"/></w:pPr><w:r><w:t>5 Test</w:t></w:r></w:p>
+` + para + `
+</w:body>
+</w:document>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range map[string]string{
+		"[Content_Types].xml":          contentTypes,
+		"_rels/.rels":                  rels,
+		"word/document.xml":            doc,
+		"word/_rels/document.xml.rels": docRels,
+		"word/media/image1.png":        "png-bytes-1",
+		"word/media/image2.png":        "png-bytes-2",
+	} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ParseDocxFromBytes(buf.Bytes(), "38212-test.docx")
+	if err != nil {
+		t.Fatalf("ParseDocxFromBytes: %v", err)
+	}
+	if len(result.Sections) == 0 {
+		t.Fatal("no sections parsed")
+	}
+
+	content := result.Sections[0].Content
+	t.Logf("section content blocks: %#v", content)
+
+	if len(content) != 5 {
+		t.Fatalf("expected 5 content blocks (text, image, text, image, text), got %d: %#v", len(content), content)
+	}
+
+	wantContains := []string{"See sub-figure (a)", "image1.png", "sub-figure (b)", "image2.png", "below."}
+	for i, want := range wantContains {
+		if !bytes.Contains([]byte(content[i]), []byte(want)) {
+			t.Errorf("block %d = %q, want it to contain %q", i, content[i], want)
+		}
+	}
+
+	// The core regression check: image1 must appear before the "sub-figure
+	// (b)" text, and image2 must appear after it — i.e. the images are
+	// interleaved with their surrounding text, not both stacked at the end.
+	imgAIdx, imgBIdx, subBIdx := -1, -1, -1
+	for i, block := range content {
+		switch {
+		case bytes.Contains([]byte(block), []byte("image1.png")):
+			imgAIdx = i
+		case bytes.Contains([]byte(block), []byte("image2.png")):
+			imgBIdx = i
+		case bytes.Contains([]byte(block), []byte("sub-figure (b)")):
+			subBIdx = i
+		}
+	}
+	if imgAIdx == -1 || imgBIdx == -1 || subBIdx == -1 {
+		t.Fatalf("expected to find both image placeholders and the sub-figure (b) text block: %#v", content)
+	}
+	if !(imgAIdx < subBIdx && subBIdx < imgBIdx) {
+		t.Errorf("images stacked instead of interleaved: image1 at %d, sub-figure (b) text at %d, image2 at %d; want image1 < text < image2", imgAIdx, subBIdx, imgBIdx)
+	}
+}

--- a/converter/docx/image_position_test.go
+++ b/converter/docx/image_position_test.go
@@ -115,7 +115,7 @@ func TestParseDocx_InlineImagesInterleavedWithText(t *testing.T) {
 	if imgAIdx == -1 || imgBIdx == -1 || subBIdx == -1 {
 		t.Fatalf("expected to find both image placeholders and the sub-figure (b) text block: %#v", content)
 	}
-	if !(imgAIdx < subBIdx && subBIdx < imgBIdx) {
+	if imgAIdx >= subBIdx || subBIdx >= imgBIdx {
 		t.Errorf("images stacked instead of interleaved: image1 at %d, sub-figure (b) text at %d, image2 at %d; want image1 < text < image2", imgAIdx, subBIdx, imgBIdx)
 	}
 }

--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -36,6 +36,13 @@ type runInfo struct {
 	// VertAlign holds the vertical alignment of the run, either
 	// "superscript", "subscript", or "" (baseline).
 	VertAlign string
+	// Image marks this entry as an inline image found at this position in
+	// the paragraph's reading flow, rather than a text run. When non-nil,
+	// all other fields are zero. Recording the image's position among the
+	// runs (instead of only collecting it separately in paragraphInfo.
+	// Images) lets the markdown renderer emit the image where it actually
+	// occurs instead of after all of the paragraph's text (see issue #40).
+	Image *imageRef
 }
 
 // parseParagraph parses a w:p XML element from raw bytes into paragraphInfo.
@@ -104,6 +111,9 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 					hasGroup = true
 				}
 				info.Images = append(info.Images, imgs...)
+				for i := range imgs {
+					info.Runs = append(info.Runs, runInfo{Image: &imgs[i]})
+				}
 				if hasGroup && !hasRaster {
 					info.SkippedDiagramLabels = append(info.SkippedDiagramLabels, labels...)
 				} else {
@@ -210,6 +220,7 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 						HeightPx: pendingHeightPx,
 					}
 					info.Images = append(info.Images, ref)
+					info.Runs = append(info.Runs, runInfo{Image: &ref})
 					pendingWidthPx, pendingHeightPx = 0, 0
 				}
 			case "blip":
@@ -225,6 +236,7 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 						HeightPx: pendingHeightPx,
 					}
 					info.Images = append(info.Images, ref)
+					info.Runs = append(info.Runs, runInfo{Image: &ref})
 					pendingWidthPx, pendingHeightPx = 0, 0
 				}
 			}
@@ -416,15 +428,17 @@ func getAttrVal(elem xml.StartElement, localName string) string {
 func mergeAdjacentRuns(runs []runInfo) []runInfo {
 	var merged []runInfo
 	for _, run := range runs {
-		if run.Text == "" {
+		if run.Image == nil && run.Text == "" {
 			continue
 		}
-		if n := len(merged); n > 0 {
-			last := &merged[n-1]
-			if last.Bold == run.Bold && last.Italic == run.Italic &&
-				last.VertAlign == run.VertAlign && last.IsCode == run.IsCode {
-				last.Text += run.Text
-				continue
+		if run.Image == nil {
+			if n := len(merged); n > 0 {
+				last := &merged[n-1]
+				if last.Image == nil && last.Bold == run.Bold && last.Italic == run.Italic &&
+					last.VertAlign == run.VertAlign && last.IsCode == run.IsCode {
+					last.Text += run.Text
+					continue
+				}
 			}
 		}
 		merged = append(merged, run)
@@ -469,35 +483,105 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 
 	// Handle bold/italic at run level
 	if len(info.Runs) > 0 {
-		var parts []string
-		for _, run := range mergeAdjacentRuns(info.Runs) {
-			runText := run.Text
-			if run.Bold && run.Italic {
-				runText = wrapEmphasis(runText, "***")
-			} else if run.Bold {
-				runText = wrapEmphasis(runText, "**")
-			} else if run.Italic {
-				runText = wrapEmphasis(runText, "*")
-			}
-			switch run.VertAlign {
-			case "superscript":
-				runText = "<sup>" + runText + "</sup>"
-			case "subscript":
-				runText = "<sub>" + runText + "</sub>"
-			}
-			parts = append(parts, runText)
-		}
-		if len(parts) > 0 {
-			// Trim leading/trailing whitespace (e.g. a leading <w:tab/> used
-			// to center an equation via tab stops): a line that starts with
-			// a tab or 4+ spaces is parsed as an indented code block by
-			// CommonMark, inside which HTML tags like <sub> are never
-			// interpreted and show up as literal text (see issue #25).
-			return strings.TrimSpace(strings.Join(parts, ""))
+		if md := runsToMarkdown(info.Runs); md != "" {
+			return md
 		}
 	}
 
 	return text
+}
+
+// runsToMarkdown renders a sequence of text runs (no images) to a single
+// markdown string, applying bold/italic/vertical-alignment formatting at the
+// run level. Any runInfo with a non-nil Image is skipped.
+func runsToMarkdown(runs []runInfo) string {
+	var parts []string
+	for _, run := range mergeAdjacentRuns(runs) {
+		if run.Image != nil {
+			continue
+		}
+		runText := run.Text
+		if run.Bold && run.Italic {
+			runText = wrapEmphasis(runText, "***")
+		} else if run.Bold {
+			runText = wrapEmphasis(runText, "**")
+		} else if run.Italic {
+			runText = wrapEmphasis(runText, "*")
+		}
+		switch run.VertAlign {
+		case "superscript":
+			runText = "<sup>" + runText + "</sup>"
+		case "subscript":
+			runText = "<sub>" + runText + "</sub>"
+		}
+		parts = append(parts, runText)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	// Trim leading/trailing whitespace (e.g. a leading <w:tab/> used to
+	// center an equation via tab stops): a line that starts with a tab or
+	// 4+ spaces is parsed as an indented code block by CommonMark, inside
+	// which HTML tags like <sub> are never interpreted and show up as
+	// literal text (see issue #25).
+	return strings.TrimSpace(strings.Join(parts, ""))
+}
+
+// paragraphToMarkdownBlocks converts a paragraph into one or more ordered
+// markdown blocks, splitting the paragraph's runs at each inline image so
+// that renderImage's placeholder is emitted at the image's actual position
+// in the reading flow. Previously every image in a paragraph was collected
+// and appended after all of the paragraph's text, so a paragraph with
+// interleaved text and figures rendered with every figure bunched up at the
+// end instead of next to the text describing it (see issue #40).
+//
+// List-style paragraphs keep paragraphToMarkdown's existing single-block
+// text handling (the list marker only makes sense once per paragraph, and
+// list items containing inline images are rare in 3GPP specs); any images
+// they contain are still emitted, just after the list-item text.
+func paragraphToMarkdownBlocks(info paragraphInfo, styleName string, renderImage func(imageRef) string) []string {
+	if strings.HasPrefix(styleName, "List") {
+		var blocks []string
+		if md := paragraphToMarkdown(info, styleName); md != "" {
+			blocks = append(blocks, md)
+		}
+		for _, r := range info.Runs {
+			if r.Image == nil {
+				continue
+			}
+			if ph := renderImage(*r.Image); ph != "" {
+				blocks = append(blocks, ph)
+			}
+		}
+		return blocks
+	}
+
+	var blocks []string
+	var segment []runInfo
+	flush := func() {
+		if md := runsToMarkdown(segment); md != "" {
+			blocks = append(blocks, md)
+		}
+		segment = nil
+	}
+	for _, r := range info.Runs {
+		if r.Image != nil {
+			flush()
+			if ph := renderImage(*r.Image); ph != "" {
+				blocks = append(blocks, ph)
+			}
+			continue
+		}
+		segment = append(segment, r)
+	}
+	flush()
+
+	if len(blocks) == 0 {
+		if text := strings.TrimSpace(info.Text); text != "" {
+			blocks = append(blocks, text)
+		}
+	}
+	return blocks
 }
 
 // emuToPx converts an EMU (English Metric Unit) string value to CSS pixels.

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -323,18 +323,14 @@ func parseSections(elements []bodyElement, styleMap map[string]string, relMap ma
 					codeBuffer = append(codeBuffer, "")
 				default:
 					flushCodeBlock()
-					md := paragraphToMarkdown(info, styleName)
-					if md != "" && currentSection != nil {
-						currentSection.Content = append(currentSection.Content, md)
-					}
-					// Insert image placeholders if the paragraph references images
-					if currentSection != nil && len(info.Images) > 0 && relMap != nil {
-						for _, ref := range info.Images {
-							ph := imagePlaceholder(relMap, images, ref)
-							if ph != "" {
-								currentSection.Content = append(currentSection.Content, ph)
+					if currentSection != nil {
+						blocks := paragraphToMarkdownBlocks(info, styleName, func(ref imageRef) string {
+							if relMap == nil {
+								return ""
 							}
-						}
+							return imagePlaceholder(relMap, images, ref)
+						})
+						currentSection.Content = append(currentSection.Content, blocks...)
 					}
 					// Surface any grouped vector diagram this converter
 					// couldn't render as an image (see issue #25), instead

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -238,6 +238,15 @@ func writeCellContent(b *strings.Builder, c tableCell, ctx imageContext) {
 func writeParagraphInline(b *strings.Builder, p paragraphInfo, ctx imageContext) {
 	if len(p.Runs) > 0 {
 		for _, r := range mergeAdjacentRuns(p.Runs) {
+			if r.Image != nil {
+				// Render the image where it actually occurs in the run
+				// sequence rather than after all of the cell's text (see
+				// issue #40).
+				if html := imageHTML(ctx, *r.Image); html != "" {
+					b.WriteString(html)
+				}
+				continue
+			}
 			if r.Text == "" {
 				continue
 			}
@@ -260,10 +269,12 @@ func writeParagraphInline(b *strings.Builder, p paragraphInfo, ctx imageContext)
 			}
 			b.WriteString(esc)
 		}
-	} else if p.Text != "" {
-		b.WriteString(htmlpkg.EscapeString(p.Text))
+		return
 	}
 
+	if p.Text != "" {
+		b.WriteString(htmlpkg.EscapeString(p.Text))
+	}
 	for _, ref := range p.Images {
 		if html := imageHTML(ctx, ref); html != "" {
 			b.WriteString(html)


### PR DESCRIPTION
## Summary

Fixes #40. Previously every image in a paragraph was collected separately from its text and appended after all of the paragraph's text, so a paragraph with interleaved text and figures (e.g. TS 38.212 clauses with multi-part figures) rendered with every figure bunched up at the end instead of next to the text describing it.

## Changes

- Track each image's position among a paragraph's runs (`runInfo.Image`) instead of only collecting it in a separate slice.
- Split paragraph markdown generation (`paragraphToMarkdownBlocks`) at each image position so the placeholder renders where the image actually occurs in the reading flow.
- Apply the same fix to table cell HTML rendering (`writeParagraphInline`), which had the same underlying issue.
- Add a regression test (`converter/docx/image_position_test.go`) covering a paragraph with text/image/text/image/text interleaving.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZDbAkyY5v2Z4zTNjbfAps)_