### PR TITLE
fix(docx): preserve nested list indent levels in markdown conversion

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -449,6 +449,25 @@ func wrapEmphasis(text, delim string) string {
 	return lead + delim + mid + delim + trail
 }
 
+// listStyleLevelRE matches a list style name's trailing nesting-level digits,
+// e.g. "2" in "List Bullet 2" or "ListBullet2".
+var listStyleLevelRE = regexp.MustCompile(`\s*(\d+)$`)
+
+// listStyleLevel returns the nesting level encoded in a list style name's
+// trailing digits (e.g. "List Bullet 2" -> 2, "List Number 3" -> 3). A style
+// name with no trailing digits (e.g. "List Bullet") is level 1.
+func listStyleLevel(styleName string) int {
+	m := listStyleLevelRE.FindStringSubmatch(styleName)
+	if m == nil {
+		return 1
+	}
+	level, err := strconv.Atoi(m[1])
+	if err != nil || level < 1 {
+		return 1
+	}
+	return level
+}
+
 // paragraphToMarkdown converts a paragraph to markdown text.
 func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 	text := strings.TrimSpace(info.Text)
@@ -458,13 +477,19 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 
 	// Handle list items
 	if strings.HasPrefix(styleName, "List") {
+		// 3GPP DOCX templates encode list nesting depth in the style name's
+		// trailing number ("List Bullet 2", "List Number 3", ...); a bare
+		// "List Bullet"/"List Number" is depth 1. Indent by 4 spaces per
+		// level, which CommonMark/GFM recognizes as nested under both "- "
+		// and "1. " parent markers.
+		indent := strings.Repeat("    ", listStyleLevel(styleName)-1)
 		if strings.Contains(styleName, "Bullet") {
-			return "- " + text
+			return indent + "- " + text
 		}
 		if strings.Contains(styleName, "Number") {
-			return "1. " + text
+			return indent + "1. " + text
 		}
-		return "- " + text // default to bullet for unknown list styles
+		return indent + "- " + text // default to bullet for unknown list styles
 	}
 
 	// Handle bold/italic at run level

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -481,15 +481,17 @@ func TestIsMonospaceFont(t *testing.T) {
 
 func TestListStyleLevel(t *testing.T) {
 	cases := map[string]int{
-		"List Bullet":   1,
-		"List Bullet 2": 2,
-		"List Bullet 3": 3,
-		"List Number":   1,
-		"List Number 2": 2,
-		"ListBullet":    1,
-		"ListBullet2":   2,
-		"ListNumber3":   3,
-		"List":          1,
+		"List Bullet":                      1,
+		"List Bullet 2":                    2,
+		"List Bullet 3":                    3,
+		"List Number":                      1,
+		"List Number 2":                    2,
+		"ListBullet":                       1,
+		"ListBullet2":                      2,
+		"ListNumber3":                      3,
+		"List":                             1,
+		"List Bullet 0":                    1,
+		"List Bullet 99999999999999999999": 1,
 	}
 	for styleName, want := range cases {
 		if got := listStyleLevel(styleName); got != want {

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -259,6 +259,30 @@ func TestParagraphToMarkdown(t *testing.T) {
 			want:      "- x",
 		},
 		{
+			name:      "nested list bullet level 2 style is indented",
+			info:      paragraphInfo{Text: "item", Runs: []runInfo{{Text: "item"}}},
+			styleName: "List Bullet 2",
+			want:      "    - item",
+		},
+		{
+			name:      "nested list bullet level 3 style is indented",
+			info:      paragraphInfo{Text: "item", Runs: []runInfo{{Text: "item"}}},
+			styleName: "List Bullet 3",
+			want:      "        - item",
+		},
+		{
+			name:      "nested list number level 2 style is indented",
+			info:      paragraphInfo{Text: "first", Runs: []runInfo{{Text: "first"}}},
+			styleName: "List Number 2",
+			want:      "    1. first",
+		},
+		{
+			name:      "nested list style without space before level digit is indented",
+			info:      paragraphInfo{Text: "item", Runs: []runInfo{{Text: "item"}}},
+			styleName: "ListBullet2",
+			want:      "    - item",
+		},
+		{
 			name:      "empty runs falls back to plain text",
 			info:      paragraphInfo{Text: "fallback"},
 			styleName: "Normal",
@@ -451,6 +475,25 @@ func TestIsMonospaceFont(t *testing.T) {
 	for font, want := range cases {
 		if got := isMonospaceFont(font); got != want {
 			t.Errorf("isMonospaceFont(%q) = %v, want %v", font, got, want)
+		}
+	}
+}
+
+func TestListStyleLevel(t *testing.T) {
+	cases := map[string]int{
+		"List Bullet":   1,
+		"List Bullet 2": 2,
+		"List Bullet 3": 3,
+		"List Number":   1,
+		"List Number 2": 2,
+		"ListBullet":    1,
+		"ListBullet2":   2,
+		"ListNumber3":   3,
+		"List":          1,
+	}
+	for styleName, want := range cases {
+		if got := listStyleLevel(styleName); got != want {
+			t.Errorf("listStyleLevel(%q) = %d, want %d", styleName, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Preserve nested list indent levels when converting 3GPP DOCX specs to Markdown. The nesting level is derived from the trailing number in the list style name (e.g. "List Bullet 2"), and Markdown output is indented 4 spaces per level accordingly.

Fixes #41