### PR TITLE
fix(docx): avoid duplicated title for unnumbered dash-marker headings

### DIFF
--- a/converter/docx/markdown.go
+++ b/converter/docx/markdown.go
@@ -1,14 +1,17 @@
 package docx
 
 import (
-	"fmt"
 	"strings"
 )
 
 // SectionToMarkdown converts a single section's content to a markdown string.
 func SectionToMarkdown(section *Section) string {
 	headingPrefix := strings.Repeat("#", section.Level)
-	lines := []string{fmt.Sprintf("%s %s %s", headingPrefix, section.Number, section.Title)}
+	heading := section.Title
+	if section.Number != "" && section.Number != section.Title {
+		heading = section.Number + " " + section.Title
+	}
+	lines := []string{headingPrefix + " " + heading}
 	lines = append(lines, section.Content...)
 	return strings.Join(lines, "\n\n")
 }

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	sectionNumberRE = regexp.MustCompile(`^([A-Z](?:\.\d+[A-Za-z]?)+|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)[\t ]+(.+)$`)
-	annexRE         = regexp.MustCompile(`(?is)^Annex[\s\xa0]+([A-Z])[\s\xa0]*(?:\((?:normative|informative)\))?[\s\xa0]*[:\s\xa0]*(.*)$`)
-	headingNumRE    = regexp.MustCompile(`(?i)^[Hh]eading\s+(\d+)`)
-	annexSubRE      = regexp.MustCompile(`^[A-Z]\.`)
+	sectionNumberRE     = regexp.MustCompile(`^([A-Z](?:\.\d+[A-Za-z]?)+|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)[\t ]+(.+)$`)
+	annexRE             = regexp.MustCompile(`(?is)^Annex[\s\xa0]+([A-Z])[\s\xa0]*(?:\((?:normative|informative)\))?[\s\xa0]*[:\s\xa0]*(.*)$`)
+	headingNumRE        = regexp.MustCompile(`(?i)^[Hh]eading\s+(\d+)`)
+	annexSubRE          = regexp.MustCompile(`^[A-Z]\.`)
+	unnumberedHeadingRE = regexp.MustCompile(`^\p{Pd}[\t ]+(.+)$`)
 )
 
 // bodyElement represents a top-level element in the document body.
@@ -284,6 +285,13 @@ func parseSections(elements []bodyElement, styleMap map[string]string, relMap ma
 					if inAnnex && annexSubRE.MatchString(number) {
 						headingLevel = strings.Count(number, ".") + 1
 					}
+				} else if match := unnumberedHeadingRE.FindStringSubmatch(text); match != nil {
+					// Some specs (e.g. TS 38.331's IE/message annex) mark
+					// clauses with a bare dash instead of a decimal number.
+					// There's no real section number here, so reuse the
+					// title as the storage key (see Section.Number docs).
+					title = strings.TrimSpace(match[1])
+					number = title
 				} else {
 					number = text
 					title = text

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -290,6 +290,12 @@ func parseSections(elements []bodyElement, styleMap map[string]string, relMap ma
 					// clauses with a bare dash instead of a decimal number.
 					// There's no real section number here, so reuse the
 					// title as the storage key (see Section.Number docs).
+					// Known limitation: two such headings in the same spec
+					// with an identical title collide on this key, and the
+					// second one silently overwrites the first in the DB
+					// (pre-existing risk, shared with the raw-text fallback
+					// below; not expected in practice since these headings
+					// name distinct IEs/messages).
 					title = strings.TrimSpace(match[1])
 					number = title
 				} else {

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -375,6 +375,27 @@ func TestSectionToMarkdown(t *testing.T) {
 	}
 }
 
+// TestSectionToMarkdown_NoRealNumber covers GitHub issue #42: when a section
+// has no real clause number (Number == Title, e.g. a TS 38.331 IE heading
+// marked with a bare dash), the rendered heading must show the title once,
+// not "Title Title".
+func TestSectionToMarkdown_NoRealNumber(t *testing.T) {
+	section := &Section{
+		Number:  "MRB-Identity",
+		Title:   "MRB-Identity",
+		Level:   3,
+		Content: []string{"IE definition body."},
+	}
+
+	md := SectionToMarkdown(section)
+	if !strings.HasPrefix(md, "### MRB-Identity\n") {
+		t.Errorf("expected heading to show the title once, got %q", md[:min(len(md), 40)])
+	}
+	if strings.Count(md, "MRB-Identity") != 1 {
+		t.Errorf("expected title to appear exactly once, got:\n%s", md)
+	}
+}
+
 func TestSectionToMarkdown_ConsecutiveTables(t *testing.T) {
 	section := &Section{
 		Number: "7.2.1",
@@ -600,6 +621,56 @@ func TestParseSections_LetteredSectionNumbers(t *testing.T) {
 
 	if s, ok := sectionMap["A.1a"]; ok && s.Level != 2 {
 		t.Errorf("section A.1a level = %d, want 2", s.Level)
+	}
+}
+
+// TestParseSections_UnnumberedDashHeadings guards against a regression
+// (GitHub issue #42) where specs like TS 38.331 mark IE/message definitions
+// with a bare dash instead of a decimal clause number (e.g. "-\tMRB-Identity").
+// Neither sectionNumberRE nor annexRE matches a heading starting with a dash,
+// so it used to fall into the final fallback that sets both Number and Title
+// to the full raw heading text (including the dash and tab), duplicating the
+// title in every rendered output. Number == Title is the intentional result
+// here (there's no real section number); renderers must special-case that
+// rather than show the same text twice.
+func TestParseSections_UnnumberedDashHeadings(t *testing.T) {
+	elements := []bodyElement{
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: "6.3\tMessage and information element definitions",
+			Runs: []runInfo{{Text: "6.3\tMessage and information element definitions"}},
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading2", Text: "-\tMRB-Identity",
+			Runs: []runInfo{{Text: "-\tMRB-Identity"}},
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading2", Text: "–\tMeasSequence",
+			Runs: []runInfo{{Text: "–\tMeasSequence"}},
+		}},
+	}
+	styleMap := map[string]string{"Heading1": "Heading 1", "Heading2": "Heading 2"}
+	sections := parseSections(elements, styleMap, nil, nil)
+
+	want := []string{"MRB-Identity", "MeasSequence"}
+	sectionMap := make(map[string]*Section)
+	for _, s := range sections {
+		sectionMap[s.Title] = s
+	}
+	for _, title := range want {
+		s, ok := sectionMap[title]
+		if !ok {
+			t.Errorf("missing section %q", title)
+			continue
+		}
+		if s.Title != title {
+			t.Errorf("section title = %q, want %q", s.Title, title)
+		}
+		if s.Number != s.Title {
+			t.Errorf("section %q: Number = %q, want equal to Title (no real section number)", title, s.Number)
+		}
+		if strings.HasPrefix(s.Title, "-") || strings.HasPrefix(s.Title, "–") || strings.Contains(s.Title, "\t") {
+			t.Errorf("section %q: title still contains the leading dash/tab marker", s.Title)
+		}
 	}
 }
 

--- a/converter/docx/types.go
+++ b/converter/docx/types.go
@@ -23,6 +23,10 @@ var seriesRE = regexp.MustCompile(`(\d+)\.\d+`)
 
 // Section represents a parsed section from the specification document.
 type Section struct {
+	// Number is the clause number (e.g. "5.1.2"). For headings with no real
+	// section number — such as the bare-dash IE/message entries in some
+	// specs' annexes — it equals Title; renderers should treat that as "no
+	// number" and print Title only, rather than showing it twice.
 	Number       string
 	Title        string
 	Level        int

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -40,7 +40,11 @@ func HandleGetTOC(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", input.SpecID)
 		for _, s := range sections {
 			indent := strings.Repeat("  ", s.Level-1)
-			fmt.Fprintf(&sb, "%s- %s %s\n", indent, s.Number, s.Title)
+			if s.Number != "" && s.Number != s.Title {
+				fmt.Fprintf(&sb, "%s- %s %s\n", indent, s.Number, s.Title)
+			} else {
+				fmt.Fprintf(&sb, "%s- %s\n", indent, s.Title)
+			}
 		}
 
 		return textResult(sb.String()), nil, nil

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -116,6 +116,25 @@ func TestHandleGetTOC(t *testing.T) {
 			t.Errorf("expected both parts listed, got: %s", text)
 		}
 	})
+
+	t.Run("section with no real number is not duplicated", func(t *testing.T) {
+		if err := d.ExecScript(`INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', 'MRB-Identity', 'MRB-Identity', 2, '5', 'IE body.');`); err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		result, _, err := handler(context.Background(), nil, GetTOCInput{SpecID: "TS 23.501"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "MRB-Identity") {
+			t.Errorf("expected MRB-Identity in output, got: %s", text)
+		}
+		if strings.Contains(text, "MRB-Identity MRB-Identity") {
+			t.Errorf("title should not be duplicated, got: %s", text)
+		}
+	})
 }
 
 func TestHandleGetSection(t *testing.T) {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -218,6 +218,31 @@ func TestHandleGetSection(t *testing.T) {
 			t.Errorf("expected both parts listed, got: %s", text)
 		}
 	})
+
+	t.Run("unnumbered heading looked up by title as section_number", func(t *testing.T) {
+		if err := d.ExecScript(`INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', 'MRB-Identity', 'MRB-Identity', 2, '5', '### MRB-Identity` + "\n\n" + `IE body.');`); err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID:        "TS 23.501",
+			SectionNumber: "MRB-Identity",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected error result: %s", getTextContent(result))
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "IE body.") {
+			t.Errorf("expected section content, got: %s", text)
+		}
+		if strings.Count(text, "MRB-Identity") != 1 {
+			t.Errorf("expected title to appear exactly once, got: %s", text)
+		}
+	})
 }
 
 func TestHandleSearch(t *testing.T) {

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -9,7 +9,7 @@
         {{range .Results}}
         <div class="search-result">
             <h3>
-                <a href="{{sectionURL .SpecID .Number}}">{{.SpecID}} &sect;{{.Number}}</a>
+                <a href="{{sectionURL .SpecID .Number}}">{{.SpecID}}{{if ne .Number .Title}} &sect;{{.Number}}{{end}}</a>
                 <span class="result-title">{{.Title}}</span>
             </h3>
             <p class="result-snippet">{{safeHTML .Snippet}}</p>

--- a/web/templates/spec.html
+++ b/web/templates/spec.html
@@ -10,8 +10,8 @@
             <ul class="toc-list">
                 {{range .TOC}}
                 <li class="toc-item {{if isActive $.Current .Number}}active{{end}}" style="padding-left: {{indent .Level}}px">
-                    <a href="{{sectionURL $.Spec.ID .Number}}" title="{{.Number}} {{.Title}}">
-                        <span class="toc-number">{{.Number}}</span>
+                    <a href="{{sectionURL $.Spec.ID .Number}}" title="{{if ne .Number .Title}}{{.Number}} {{end}}{{.Title}}">
+                        {{if ne .Number .Title}}<span class="toc-number">{{.Number}}</span>{{end}}
                         <span class="toc-title">{{.Title}}</span>
                     </a>
                 </li>
@@ -34,7 +34,7 @@
         {{range .Sections}}
         <article class="section">
             <h{{add .Level 1}} id="section-{{.Number}}">
-                <span class="section-number">{{.Number}}</span> {{.Title}}
+                {{if ne .Number .Title}}<span class="section-number">{{.Number}}</span> {{end}}{{.Title}}
             </h{{add .Level 1}}>
             <div class="section-body">
                 {{.Content}}


### PR DESCRIPTION
Some specs (e.g. TS 38.331's IE/message definition annex) mark clauses with a bare dash instead of a real decimal section number (e.g. a heading paragraph reading `"-\tMRB-Identity"`). The docx parser's heading-splitting logic didn't recognize this style, so it fell into a fallback that set both `Number` and `Title` to the same raw heading text. Every place that renders `Number` and `Title` side by side (TOC sidebar, section headers, search results, `get_toc`/`get_section` output) then showed the title twice.

This adds a `\p{Pd}`-based regex to `converter/docx/parser.go` to recognize bare-dash headings and extract a clean title, and updates `markdown.go`, `get_toc.go`, and the web templates to skip the redundant number whenever it equals the title.

Closes #42.

Note: specs already imported into an existing database need a re-import (`make build-db`) to pick up the corrected parsing.

---
_Generated by [Claude Code](https://claude.ai/code/session_013u7iviUnuaQB1oWBM6MJuh)_