### PR TITLE
fix(db): make leading-hyphen exclusion in FTS5 search actually work

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -665,9 +665,32 @@ func needsFTS5Quoting(s string) bool {
 	return strings.ContainsRune(s, '-') || strings.ContainsRune(s, '.')
 }
 
+// classifyToken quotes a bareword or "col:val" column-filter token if it
+// contains a character FTS5 cannot parse in an unquoted bareword.
+func classifyToken(token string) string {
+	if colIdx := strings.IndexByte(token, ':'); colIdx > 0 {
+		col := token[:colIdx]
+		val := token[colIdx+1:]
+		if fts5Columns[col] {
+			if needsFTS5Quoting(val) && !strings.HasPrefix(val, "\"") {
+				return col + ":\"" + val + "\""
+			}
+			return token
+		}
+	}
+	if needsFTS5Quoting(token) {
+		return "\"" + token + "\""
+	}
+	return token
+}
+
 // sanitizeFTS5Query wraps bare hyphenated or dotted tokens in double quotes
 // so FTS5 does not misinterpret the hyphen as a column-filter separator or
-// reject the period as invalid bareword syntax.
+// reject the period as invalid bareword syntax. It also rewrites a leading
+// "-term" into a real "NOT term": FTS5 has no unary "-" exclusion operator
+// (a lone "-x" is a hard syntax error, and "-col:x" parses but silently
+// means something other than exclusion), so passing the hyphen through
+// unchanged never actually excludes anything.
 func sanitizeFTS5Query(query string) string {
 	var result []string
 	i := 0
@@ -721,36 +744,25 @@ func sanitizeFTS5Query(query string) string {
 			continue
 		}
 
-		if colIdx := strings.IndexByte(token, ':'); colIdx > 0 {
-			col := token[:colIdx]
-			val := token[colIdx+1:]
-			if fts5Columns[col] {
-				if needsFTS5Quoting(val) && !strings.HasPrefix(val, "\"") {
-					result = append(result, col+":\""+val+"\"")
-				} else {
-					result = append(result, token)
-				}
-				continue
-			}
-		}
-
-		// A leading hyphen is FTS5 NOT shorthand — leave it alone unless
-		// there are additional hyphens or a period in the rest of the token.
-		if needsFTS5Quoting(token) {
-			if token[0] == '-' {
-				rest := token[1:]
-				if needsFTS5Quoting(rest) {
-					result = append(result, "\""+token+"\"")
-				} else {
-					result = append(result, token)
-				}
+		if len(token) > 1 && token[0] == '-' {
+			// A real NOT needs a preceding phrase as its left operand, and
+			// that phrase can't itself be a bare operator keyword (FTS5
+			// rejects e.g. "AND NOT" as adjacent operators). When neither
+			// holds, there is no valid way to express the exclusion, so
+			// fall back to quoting the token literally: it matches
+			// nothing, but at least stays valid, non-erroring FTS5 syntax
+			// (an unquoted leading hyphen is invalid FTS5 syntax on its own,
+			// even without any other special character in the token).
+			canNegate := len(result) > 0 && !fts5Operators[result[len(result)-1]]
+			if canNegate {
+				result = append(result, "NOT", classifyToken(token[1:]))
 			} else {
 				result = append(result, "\""+token+"\"")
 			}
 			continue
 		}
 
-		result = append(result, token)
+		result = append(result, classifyToken(token))
 	}
 
 	return strings.Join(result, " ")

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -317,7 +318,7 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"valid column filter title", "title:authentication", "title:authentication"},
 		{"column filter with hyphen value", "title:IMS-AKA", `title:"IMS-AKA"`},
 		{"NEAR preserved", "NEAR(AMF UE, 5)", "NEAR(AMF UE, 5)"},
-		{"leading hyphen NOT shorthand", "-excluded", "-excluded"},
+		{"leading hyphen NOT shorthand", "-excluded", `"-excluded"`},
 		{"leading hyphen with more hyphens", "-one-two", `"-one-two"`},
 		{"mixed query", `IMS-AKA AND "core network"`, `"IMS-AKA" AND "core network"`},
 		{"hyphen with operator", "sec-agree OR authentication", `"sec-agree" OR authentication`},
@@ -329,6 +330,13 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"column filter with dotted value", "title:38.101", `title:"38.101"`},
 		{"spec number with AND operator", "38.101 AND UE", `"38.101" AND UE`},
 		{"multi-part spec number", "38.101-1", `"38.101-1"`},
+		{"leading hyphen with preceding term becomes NOT", "AMF -excluded", "AMF NOT excluded"},
+		{"leading hyphen with dotted rest becomes NOT", "AMF -38.101", `AMF NOT "38.101"`},
+		{"leading hyphen with hyphenated rest becomes NOT", "AMF -IMS-AKA", `AMF NOT "IMS-AKA"`},
+		{"leading hyphen column filter becomes NOT", "AMF -title:band", "AMF NOT title:band"},
+		{"leading hyphen column filter with dotted value becomes NOT", "AMF -title:38.101", `AMF NOT title:"38.101"`},
+		{"leading hyphen after AND operator falls back", "AMF AND -excluded", `AMF AND "-excluded"`},
+		{"leading hyphen after OR operator falls back", "AMF OR -excluded", `AMF OR "-excluded"`},
 	}
 
 	for _, tt := range tests {
@@ -338,6 +346,51 @@ func TestSanitizeFTS5Query(t *testing.T) {
 				t.Errorf("sanitizeFTS5Query(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestSanitizeFTS5Query_ExecutesWithoutError runs sanitizeFTS5Query's output
+// through a real FTS5 MATCH to catch the class of bug where the sanitizer
+// produces a string that is well-formed by inspection but invalid (or
+// silently wrong) FTS5 syntax — see issue #47, where a lone leading hyphen
+// was assumed to be FTS5's NOT shorthand but FTS5 has no such operator.
+func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
+	dbConn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbConn.Close()
+	// An in-memory SQLite database is per-connection; without this, the
+	// connection pool could hand out a second, empty in-memory database for
+	// a later query and "no such table" would mask the real assertion.
+	dbConn.SetMaxOpenConns(1)
+
+	if _, err := dbConn.Exec(`CREATE VIRTUAL TABLE t USING fts5(spec_id, number, title, content)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbConn.Exec(
+		`INSERT INTO t(spec_id, number, title, content) VALUES (?, ?, ?, ?)`,
+		"TS 38.101-1", "5.1", "Band requirements", "radio transmission band requirements AMF",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	queries := []string{
+		"38.101", "23.501", "18.6.0", "title:38.101",
+		"38.101 AND UE", "IMS-AKA", "title:IMS-AKA",
+		"AMF -excluded", "AMF -38.101", "AMF -IMS-AKA",
+		"AMF -title:band", "AMF -title:38.101",
+		"AMF AND -excluded", "AMF OR -excluded",
+		"-excluded", "-one-two",
+	}
+	for _, q := range queries {
+		sanitized := sanitizeFTS5Query(q)
+		rows, err := dbConn.Query(`SELECT spec_id FROM t WHERE t MATCH ?`, sanitized)
+		if err != nil {
+			t.Errorf("query %q sanitized to %q, which FTS5 rejected: %v", q, sanitized, err)
+			continue
+		}
+		rows.Close()
 	}
 }
 

--- a/tools/search.go
+++ b/tools/search.go
@@ -28,6 +28,7 @@ Query syntax:
 - Column filter: title:authentication  or  content:handover
 - Proximity:     NEAR(AMF UE, 5)
 - Hyphenated or dotted terms (e.g. IMS-AKA, sec-agree, 38.101) are auto-quoted to avoid FTS5 syntax errors.
+- A leading "-" excludes a term (e.g. AMF -SMF), same as NOT.
 
 Tips:
 - Use exact 3GPP terms (AMF, SMF, gNB, UE, NRF, PCF, etc.)

--- a/tools/search.go
+++ b/tools/search.go
@@ -28,7 +28,7 @@ Query syntax:
 - Column filter: title:authentication  or  content:handover
 - Proximity:     NEAR(AMF UE, 5)
 - Hyphenated or dotted terms (e.g. IMS-AKA, sec-agree, 38.101) are auto-quoted to avoid FTS5 syntax errors.
-- A leading "-" excludes a term (e.g. AMF -SMF), same as NOT.
+- After a positive term, "-term" excludes that term (e.g. AMF -SMF), same as NOT. An exclusion cannot begin a query or immediately follow AND/OR.
 
 Tips:
 - Use exact 3GPP terms (AMF, SMF, gNB, UE, NRF, PCF, etc.)


### PR DESCRIPTION
## Summary
- FTS5 has no unary "-" operator for excluding a bare term; `sanitizeFTS5Query` assumed one existed and passed `-term` through unchanged, which either raised a hard syntax error or (for `-col:val`) silently matched the wrong rows.
- Rewrite a leading `-term` into a real `NOT term` when a preceding phrase is present to serve as its left operand; otherwise fall back to quoting the token literally so it stays valid, non-erroring syntax.
- Verified against a real FTS5 `MATCH` (`modernc.org/sqlite`), and added a test that runs sanitized queries through an in-memory FTS5 table to catch this class of bug going forward.

Fixes #47

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcaUD4GyUwfMxmD8kuMw6J)_