### PR TITLE
feat(web): add previous/next chapter navigation to spec viewer

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -47,6 +47,8 @@ type specData struct {
 	Current    string
 	References []db.Reference
 	OpenAPIs   []db.OpenAPISpec
+	Prev       *db.Section
+	Next       *db.Section
 }
 
 type sectionRendered struct {
@@ -201,6 +203,7 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
 	rendered := renderSections(sections, specID, bracketMap)
 	openAPIs, _ := h.db.ListOpenAPI(specID)
 	refs, _ := h.db.GetReferences(specID, number, db.DirectionOutgoing, false)
+	prev, next := adjacentSections(toc, number)
 
 	data := specData{
 		Spec:       &db.Spec{ID: specID},
@@ -209,11 +212,33 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
 		Current:    number,
 		References: refs,
 		OpenAPIs:   openAPIs,
+		Prev:       prev,
+		Next:       next,
 	}
 
 	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "spec", Data: data, NavSpecID: specID}); err != nil {
 		log.Printf("template error: %v", err)
 	}
+}
+
+// adjacentSections returns the sections immediately before and after number
+// in toc's document order (see db.GetTOC), for "previous/next chapter"
+// navigation. Either return value is nil when number is the first/last
+// section in the TOC.
+func adjacentSections(toc []db.Section, number string) (prev, next *db.Section) {
+	for i := range toc {
+		if toc[i].Number != number {
+			continue
+		}
+		if i > 0 {
+			prev = &toc[i-1]
+		}
+		if i < len(toc)-1 {
+			next = &toc[i+1]
+		}
+		return prev, next
+	}
+	return nil, nil
 }
 
 func (h *handler) handleImage(w http.ResponseWriter, r *http.Request) {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -47,6 +47,28 @@
         }
     }
 
+    // Prev/Next chapter keyboard navigation (Left/Right arrow keys). Ignored
+    // while the user is typing (inputs, textareas, contenteditable) or
+    // holding a modifier key, so it doesn't clash with text editing or
+    // browser/OS shortcuts.
+    document.addEventListener('keydown', function (e) {
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+            return;
+        }
+        var active = document.activeElement;
+        if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+            return;
+        }
+        var selector = e.key === 'ArrowLeft' ? '.section-nav-prev' : e.key === 'ArrowRight' ? '.section-nav-next' : null;
+        if (!selector) {
+            return;
+        }
+        var link = document.querySelector(selector);
+        if (link) {
+            window.location.href = link.getAttribute('href');
+        }
+    });
+
     // Render LaTeX math emitted by the DOCX converter. The server wraps each
     // equation in a <span class="math-inline|math-display"> whose text content
     // is the raw LaTeX; KaTeX renders it in place.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -48,15 +48,16 @@
     }
 
     // Prev/Next chapter keyboard navigation (Left/Right arrow keys). Ignored
-    // while the user is typing (inputs, textareas, contenteditable) or
-    // holding a modifier key, so it doesn't clash with text editing or
-    // browser/OS shortcuts.
+    // while the user is operating a focused interactive control (text
+    // inputs, the series <select>, buttons, ARIA widgets) or holding a
+    // modifier key, so it doesn't clash with that control's own Left/Right
+    // behavior or browser/OS shortcuts.
     document.addEventListener('keydown', function (e) {
         if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
             return;
         }
         var active = document.activeElement;
-        if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+        if (active && (active.isContentEditable || active.matches('input, textarea, select, button, [contenteditable], [role="button"], [role="textbox"], [role="combobox"], [role="listbox"]'))) {
             return;
         }
         var selector = e.key === 'ArrowLeft' ? '.section-nav-prev' : e.key === 'ArrowRight' ? '.section-nav-next' : null;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -550,6 +550,76 @@ mark {
     margin-left: 0.5rem;
 }
 
+/* === Chapter navigation (prev/next) === */
+.section-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 1rem 0;
+    padding: 0.75rem 0;
+}
+
+.section-nav:first-child {
+    border-bottom: 1px solid var(--border);
+}
+
+.section-nav:last-child {
+    border-top: 1px solid var(--border);
+    margin-top: 2rem;
+}
+
+.section-nav-spacer {
+    flex: 1;
+}
+
+.section-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    text-decoration: none;
+    transition: background-color var(--transition), border-color var(--transition);
+}
+
+.section-nav-link:hover {
+    background: var(--bg-secondary);
+    border-color: var(--link);
+    text-decoration: none;
+}
+
+.section-nav-next {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.section-nav-arrow {
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.section-nav-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.section-nav-hint {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.section-nav-label {
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* === Search === */
 .search-page {
     max-width: 800px;
@@ -692,11 +762,19 @@ mark {
     .navbar-search-specid {
         width: 100%;
     }
+
+    .section-nav {
+        flex-direction: column;
+    }
+
+    .section-nav-next {
+        text-align: left;
+    }
 }
 
 /* === Print === */
 @media print {
-    .navbar, .toc-sidebar, .toc-toggle, .theme-toggle, .pagination, .filter-form {
+    .navbar, .toc-sidebar, .toc-toggle, .theme-toggle, .pagination, .filter-form, .section-nav {
         display: none;
     }
 

--- a/web/templates/spec.html
+++ b/web/templates/spec.html
@@ -31,6 +31,8 @@
     </aside>
 
     <div class="section-content">
+        {{template "section-nav" .}}
+
         {{range .Sections}}
         <article class="section">
             <h{{add .Level 1}} id="section-{{.Number}}">
@@ -57,6 +59,33 @@
             </ul>
         </div>
         {{end}}
+
+        {{template "section-nav" .}}
     </div>
 </div>
+{{end}}
+
+{{define "section-nav"}}
+{{if or .Prev .Next}}
+<nav class="section-nav" aria-label="Chapter navigation">
+    {{if .Prev}}
+    <a class="section-nav-link section-nav-prev" href="{{sectionURL .Spec.ID .Prev.Number}}">
+        <span class="section-nav-arrow">&larr;</span>
+        <span class="section-nav-text">
+            <span class="section-nav-hint">Previous</span>
+            <span class="section-nav-label">{{if ne .Prev.Number .Prev.Title}}{{.Prev.Number}} {{end}}{{.Prev.Title}}</span>
+        </span>
+    </a>
+    {{else}}<span class="section-nav-spacer"></span>{{end}}
+    {{if .Next}}
+    <a class="section-nav-link section-nav-next" href="{{sectionURL .Spec.ID .Next.Number}}">
+        <span class="section-nav-text">
+            <span class="section-nav-hint">Next</span>
+            <span class="section-nav-label">{{if ne .Next.Number .Next.Title}}{{.Next.Number}} {{end}}{{.Next.Title}}</span>
+        </span>
+        <span class="section-nav-arrow">&rarr;</span>
+    </a>
+    {{end}}
+</nav>
+{{end}}
 {{end}}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -277,6 +277,99 @@ func TestHandleSection(t *testing.T) {
 	}
 }
 
+func TestHandleSection_PrevNext(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	// TS 23.501 seed TOC in document order: 1 (Scope), 5 (Architecture),
+	// 5.1 (General), 5.1.1 (Overview).
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/sections/5.1")
+	if err != nil {
+		t.Fatalf("GET section error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if !strings.Contains(body, `href="/specs/TS%2023.501/sections/5"`) {
+		t.Errorf("expected prev link to section 5, got:\n%s", body)
+	}
+	if !strings.Contains(body, `href="/specs/TS%2023.501/sections/5.1.1"`) {
+		t.Errorf("expected next link to section 5.1.1, got:\n%s", body)
+	}
+	if !strings.Contains(body, "section-nav-prev") || !strings.Contains(body, "section-nav-next") {
+		t.Errorf("expected both prev and next nav links, got:\n%s", body)
+	}
+}
+
+func TestHandleSection_PrevNextAtBoundaries(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	// First section: no previous link.
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/sections/1")
+	if err != nil {
+		t.Fatalf("GET section error: %v", err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp)
+	if strings.Contains(body, "section-nav-prev") {
+		t.Errorf("first section should have no prev link, got:\n%s", body)
+	}
+	if !strings.Contains(body, "section-nav-next") {
+		t.Errorf("first section should have a next link, got:\n%s", body)
+	}
+
+	// Last section: no next link.
+	resp2, err := http.Get(ts.URL + "/specs/TS 23.501/sections/5.1.1")
+	if err != nil {
+		t.Fatalf("GET section error: %v", err)
+	}
+	defer resp2.Body.Close()
+	body2 := readBody(t, resp2)
+	if strings.Contains(body2, "section-nav-next") {
+		t.Errorf("last section should have no next link, got:\n%s", body2)
+	}
+	if !strings.Contains(body2, "section-nav-prev") {
+		t.Errorf("last section should have a prev link, got:\n%s", body2)
+	}
+}
+
+func TestAdjacentSections(t *testing.T) {
+	toc := []db.Section{
+		{Number: "1", Title: "Scope"},
+		{Number: "5", Title: "Architecture"},
+		{Number: "5.1", Title: "General"},
+		{Number: "5.1.1", Title: "Overview"},
+	}
+
+	prev, next := adjacentSections(toc, "5.1")
+	if prev == nil || prev.Number != "5" {
+		t.Errorf("prev = %v, want section 5", prev)
+	}
+	if next == nil || next.Number != "5.1.1" {
+		t.Errorf("next = %v, want section 5.1.1", next)
+	}
+
+	prev, next = adjacentSections(toc, "1")
+	if prev != nil {
+		t.Errorf("prev = %v, want nil at first section", prev)
+	}
+	if next == nil || next.Number != "5" {
+		t.Errorf("next = %v, want section 5", next)
+	}
+
+	prev, next = adjacentSections(toc, "5.1.1")
+	if next != nil {
+		t.Errorf("next = %v, want nil at last section", next)
+	}
+	if prev == nil || prev.Number != "5.1" {
+		t.Errorf("prev = %v, want section 5.1", prev)
+	}
+
+	prev, next = adjacentSections(toc, "nonexistent")
+	if prev != nil || next != nil {
+		t.Errorf("prev, next = %v, %v, want nil, nil for unknown number", prev, next)
+	}
+}
+
 func TestHandleSpecNotFound(t *testing.T) {
 	ts, _ := setupTestServer(t)
 


### PR DESCRIPTION
## Summary
- Add previous/next chapter links (document TOC order) at the top and bottom of each section on the spec viewer page
- Support Left/Right arrow key shortcuts to navigate between adjacent sections (ignored while typing in an input/textarea)
- Numberless sections (e.g. Foreword) show title only, matching the existing TOC label convention

Closes #50

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpqG5tvwAysyE2ETrBGR1V)_