### PR TITLE
fix(docx): separate stacked equations in oMathPara

### DIFF
--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -142,6 +142,8 @@ func renderOMML(n *ommlNode) string {
 	switch n.Local {
 	case "t":
 		return escapeMathText(n.Text)
+	case "oMathPara":
+		return renderMathPara(n)
 	case "f":
 		return renderFraction(n)
 	case "d":
@@ -262,6 +264,24 @@ func renderNary(n *ommlNode) string {
 	}
 	b.WriteString(renderOMML(child(n, "e")))
 	return b.String()
+}
+
+// renderMathPara renders an m:oMathPara, which groups one or more m:oMath
+// siblings that each represent a separate equation stacked in the same math
+// paragraph (e.g. a set of related formulas listed together). A single child
+// renders as-is; multiple children are wrapped in a "gathered" environment so
+// each equation lands on its own line instead of concatenating into one run
+// of LaTeX (see issue #53).
+func renderMathPara(n *ommlNode) string {
+	lines := children(n, "oMath")
+	if len(lines) <= 1 {
+		return renderChildren(n)
+	}
+	parts := make([]string, len(lines))
+	for i, c := range lines {
+		parts[i] = renderOMML(c)
+	}
+	return "\\begin{gathered} " + strings.Join(parts, " \\\\ ") + " \\end{gathered}"
 }
 
 func renderMatrix(n *ommlNode) string {

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -168,9 +168,9 @@ func renderOMML(n *ommlNode) string {
 	case "acc":
 		return renderAccent(n)
 	default:
-		// Transparent containers (oMath, oMathPara, e, num, den, deg, sub, sup,
-		// r, ...) and unrecognized elements: recurse into children so their
-		// text still surfaces.
+		// Transparent containers (oMath, e, num, den, deg, sub, sup, r, ...)
+		// and unrecognized elements: recurse into children so their text
+		// still surfaces.
 		return renderChildren(n)
 	}
 }

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -189,6 +189,21 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "oMathPara with single equation renders unwrapped",
+			xml: `<m:oMathPara ` + mXMLNS + `><m:oMath>` + mrun("x=1") +
+				`</m:oMath></m:oMathPara>`,
+			want: "x=1",
+		},
+		{
+			name: "oMathPara with multiple equations separates each line",
+			xml: `<m:oMathPara ` + mXMLNS + `>` +
+				`<m:oMath>` + mrun("a=1") + `</m:oMath>` +
+				`<m:oMath>` + mrun("b=2") + `</m:oMath>` +
+				`<m:oMath>` + mrun("c=3") + `</m:oMath>` +
+				`</m:oMathPara>`,
+			want: "\\begin{gathered} a=1 \\\\ b=2 \\\\ c=3 \\end{gathered}",
+		},
+		{
 			name: "greek and relation symbols",
 			xml:  `<m:oMath ` + mXMLNS + `>` + mrun("α≤β") + `</m:oMath>`,
 			want: "\\alpha \\leq \\beta",


### PR DESCRIPTION
## Summary
- `m:oMathPara` groups multiple sibling `m:oMath` equations meant to be stacked as separate lines, but `renderOMML` had no explicit case for it, so it fell through to plain child concatenation with no separator between equations.
- Added an explicit `oMathPara` case: a single equation renders unchanged, but multiple equations are now joined with `\\` inside a `gathered` environment so each renders on its own line.

Closes #53

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `go test -race ./...`
- [x] Added unit tests for single- and multi-equation `oMathPara` cases in `converter/docx/omml_test.go`


---
_Generated by [Claude Code](https://claude.ai/code/session_0183Byfs8fYTeAsEXuyJnFDi)_