### PR TITLE
feat: add version/release provenance to get_section, search, and get_toc

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,8 @@ type Spec struct {
 
 type Section struct {
 	SpecID       string `json:"spec_id"`
+	Version      string `json:"version,omitempty"`
+	Release      string `json:"release,omitempty"`
 	Number       string `json:"number"`
 	Title        string `json:"title"`
 	Level        int    `json:"level"`
@@ -29,6 +31,8 @@ type Section struct {
 
 type SearchResult struct {
 	SpecID  string `json:"spec_id"`
+	Version string `json:"version,omitempty"`
+	Release string `json:"release,omitempty"`
 	Number  string `json:"number"`
 	Title   string `json:"title"`
 	Snippet string `json:"snippet"`
@@ -470,7 +474,7 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 
 func (d *DB) GetTOC(specID string) ([]Section, error) {
 	rows, err := d.conn.Query(
-		"SELECT spec_id, number, title, level, COALESCE(parent_number, '') FROM sections WHERE spec_id = ? ORDER BY id",
+		"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? ORDER BY s.id",
 		specID,
 	)
 	if err != nil {
@@ -481,7 +485,7 @@ func (d *DB) GetTOC(specID string) ([]Section, error) {
 	var sections []Section
 	for rows.Next() {
 		var s Section
-		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber); err != nil {
+		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Version, &s.Release); err != nil {
 			return nil, fmt.Errorf("scan section: %w", err)
 		}
 		sections = append(sections, s)
@@ -534,12 +538,12 @@ func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Secti
 
 	if includeSubsections {
 		rows, err = d.conn.Query(
-			"SELECT spec_id, number, title, level, COALESCE(parent_number, ''), content FROM sections WHERE spec_id = ? AND (number = ? OR number LIKE ? || '.%') ORDER BY id",
+			"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
 			specID, number, number,
 		)
 	} else {
 		rows, err = d.conn.Query(
-			"SELECT spec_id, number, title, level, COALESCE(parent_number, ''), content FROM sections WHERE spec_id = ? AND number = ?",
+			"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? AND s.number = ?",
 			specID, number,
 		)
 	}
@@ -551,7 +555,7 @@ func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Secti
 	var sections []Section
 	for rows.Next() {
 		var s Section
-		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Content); err != nil {
+		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Content, &s.Version, &s.Release); err != nil {
 			return nil, fmt.Errorf("scan section: %w", err)
 		}
 		sections = append(sections, s)
@@ -778,7 +782,7 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 
 	query = sanitizeFTS5Query(query)
 
-	sqlQuery := "SELECT spec_id, number, title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32) FROM sections_fts WHERE sections_fts MATCH ?"
+	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), COALESCE(specs.version, ''), COALESCE(specs.release, '') FROM sections_fts LEFT JOIN specs ON specs.id = sections_fts.spec_id WHERE sections_fts MATCH ?"
 	args := []any{query}
 
 	if len(specIDs) > 0 {
@@ -787,12 +791,12 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 		// "TS dd.ddd(-d)?" form, so this can't false-positive-match unrelated specs.
 		conds := make([]string, len(specIDs))
 		for i, id := range specIDs {
-			conds[i] = "spec_id = ? OR spec_id LIKE ? ESCAPE '\\'"
+			conds[i] = "sections_fts.spec_id = ? OR sections_fts.spec_id LIKE ? ESCAPE '\\'"
 			args = append(args, id, escapeLikePattern(id)+"-%")
 		}
 		sqlQuery += " AND (" + strings.Join(conds, " OR ") + ")"
 	}
-	sqlQuery += " ORDER BY rank LIMIT ?"
+	sqlQuery += " ORDER BY sections_fts.rank LIMIT ?"
 	args = append(args, limit)
 
 	rows, err := d.conn.Query(sqlQuery, args...)
@@ -804,7 +808,7 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 	var results []SearchResult
 	for rows.Next() {
 		var r SearchResult
-		if err := rows.Scan(&r.SpecID, &r.Number, &r.Title, &r.Snippet); err != nil {
+		if err := rows.Scan(&r.SpecID, &r.Number, &r.Title, &r.Snippet, &r.Version, &r.Release); err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
 		}
 		results = append(results, r)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -239,6 +239,9 @@ func TestGetTOC(t *testing.T) {
 		if sections[0].Number != "1" || sections[0].Title != "Scope" {
 			t.Errorf("unexpected first section: %+v", sections[0])
 		}
+		if sections[0].Version != "18.6.0" || sections[0].Release != "Rel-18" {
+			t.Errorf("expected version 18.6.0 / release Rel-18, got %+v", sections[0])
+		}
 	})
 
 	t.Run("nonexistent spec", func(t *testing.T) {
@@ -265,6 +268,9 @@ func TestGetSection(t *testing.T) {
 		}
 		if sections[0].Content == "" {
 			t.Error("expected non-empty content")
+		}
+		if sections[0].Version != "18.6.0" || sections[0].Release != "Rel-18" {
+			t.Errorf("expected version 18.6.0 / release Rel-18, got %+v", sections[0])
 		}
 	})
 
@@ -418,6 +424,9 @@ func TestSearch(t *testing.T) {
 		if results[0].SpecID != "TS 29.510" {
 			t.Errorf("expected spec_id 'TS 29.510', got %q", results[0].SpecID)
 		}
+		if results[0].Version != "18.5.0" || results[0].Release != "Rel-18" {
+			t.Errorf("expected version 18.5.0 / release Rel-18, got %+v", results[0])
+		}
 	})
 
 	t.Run("search with multiple spec filter", func(t *testing.T) {
@@ -455,6 +464,10 @@ This document covers IMS-AKA and sec-agree mechanisms.');`)
 		}
 		if len(results) == 0 {
 			t.Error("expected at least 1 result for IMS-AKA")
+		}
+		// TS 33.203 was inserted without version/release: NULL must scan as "".
+		if results[0].Version != "" || results[0].Release != "" {
+			t.Errorf("expected empty version/release for spec without them, got %+v", results[0])
 		}
 	})
 

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -51,6 +51,24 @@ func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			full.WriteString("\n\n")
 		}
 
-		return paginateText(full.String(), input.Offset, input.MaxLines, input.MaxChars), nil, nil
+		res := paginateText(full.String(), input.Offset, input.MaxLines, input.MaxChars)
+		return prependLine(sourceHeader(sections[0], input.IncludeSubsections && len(sections) > 1), res), nil, nil
 	}
+}
+
+// sourceHeader builds the provenance line prepended to every get_section page,
+// e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]".
+func sourceHeader(s db.Section, withSubsections bool) string {
+	src := s.SpecID
+	if s.Version != "" {
+		src += " v" + s.Version
+	}
+	if s.Release != "" {
+		src += " (" + s.Release + ")"
+	}
+	h := fmt.Sprintf("[Source: %s — Section %s", src, s.Number)
+	if withSubsections {
+		h += " (+subsections)"
+	}
+	return h + "]"
 }

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -59,14 +59,7 @@ func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 // sourceHeader builds the provenance line prepended to every get_section page,
 // e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]".
 func sourceHeader(s db.Section, withSubsections bool) string {
-	src := s.SpecID
-	if s.Version != "" {
-		src += " v" + s.Version
-	}
-	if s.Release != "" {
-		src += " (" + s.Release + ")"
-	}
-	h := fmt.Sprintf("[Source: %s — Section %s", src, s.Number)
+	h := fmt.Sprintf("[Source: %s — Section %s", specLabel(s), s.Number)
 	if withSubsections {
 		h += " (+subsections)"
 	}

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -36,16 +36,8 @@ func HandleGetTOC(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 			return errorResult(fmt.Sprintf("no sections found for %s", input.SpecID)), nil, nil
 		}
 
-		header := sections[0].SpecID
-		if sections[0].Version != "" {
-			header += " v" + sections[0].Version
-		}
-		if sections[0].Release != "" {
-			header += " (" + sections[0].Release + ")"
-		}
-
 		var sb strings.Builder
-		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", header)
+		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", specLabel(sections[0]))
 		for _, s := range sections {
 			indent := strings.Repeat("  ", s.Level-1)
 			if s.Number != "" && s.Number != s.Title {

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -36,8 +36,16 @@ func HandleGetTOC(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 			return errorResult(fmt.Sprintf("no sections found for %s", input.SpecID)), nil, nil
 		}
 
+		header := sections[0].SpecID
+		if sections[0].Version != "" {
+			header += " v" + sections[0].Version
+		}
+		if sections[0].Release != "" {
+			header += " (" + sections[0].Release + ")"
+		}
+
 		var sb strings.Builder
-		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", input.SpecID)
+		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", header)
 		for _, s := range sections {
 			indent := strings.Repeat("  ", s.Level-1)
 			if s.Number != "" && s.Number != s.Title {

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -22,6 +22,16 @@ func errorResult(text string) *mcp.CallToolResult {
 	}
 }
 
+// prependLine prefixes the text content of a single-TextContent result with a
+// header line, outside of pagination: line offsets and the [Lines a-b of N]
+// markers are unaffected, so the header survives on every page.
+func prependLine(header string, res *mcp.CallToolResult) *mcp.CallToolResult {
+	if tc, ok := res.Content[0].(*mcp.TextContent); ok && header != "" {
+		tc.Text = header + "\n" + tc.Text
+	}
+	return res
+}
+
 func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolResult {
 	lines := strings.Split(content, "\n")
 	totalLines := len(lines)

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -26,10 +27,26 @@ func errorResult(text string) *mcp.CallToolResult {
 // header line, outside of pagination: line offsets and the [Lines a-b of N]
 // markers are unaffected, so the header survives on every page.
 func prependLine(header string, res *mcp.CallToolResult) *mcp.CallToolResult {
-	if tc, ok := res.Content[0].(*mcp.TextContent); ok && header != "" {
+	if header == "" || len(res.Content) == 0 {
+		return res
+	}
+	if tc, ok := res.Content[0].(*mcp.TextContent); ok {
 		tc.Text = header + "\n" + tc.Text
 	}
 	return res
+}
+
+// specLabel formats a section's spec ID with its version/release,
+// e.g. "TS 23.501 v18.6.0 (Rel-18)". Empty fields are omitted.
+func specLabel(s db.Section) string {
+	label := s.SpecID
+	if s.Version != "" {
+		label += " v" + s.Version
+	}
+	if s.Release != "" {
+		label += " (" + s.Release + ")"
+	}
+	return label
 }
 
 func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolResult {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -411,6 +411,29 @@ func TestHandleGetOpenAPI(t *testing.T) {
 	})
 }
 
+func TestPrependLine(t *testing.T) {
+	t.Run("prepends header", func(t *testing.T) {
+		res := prependLine("[Source: TS 23.501]", textResult("body"))
+		if text := getTextContent(res); text != "[Source: TS 23.501]\nbody" {
+			t.Errorf("unexpected text: %q", text)
+		}
+	})
+
+	t.Run("empty header leaves result unchanged", func(t *testing.T) {
+		res := prependLine("", textResult("body"))
+		if text := getTextContent(res); text != "body" {
+			t.Errorf("unexpected text: %q", text)
+		}
+	})
+
+	t.Run("empty content does not panic", func(t *testing.T) {
+		res := prependLine("[Source]", &mcp.CallToolResult{})
+		if len(res.Content) != 0 {
+			t.Errorf("expected content to stay empty, got %v", res.Content)
+		}
+	})
+}
+
 func TestPaginateText(t *testing.T) {
 	content := "line1\nline2\nline3\nline4\nline5"
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -85,6 +85,9 @@ func TestHandleGetTOC(t *testing.T) {
 		if !strings.Contains(text, "Table of Contents") {
 			t.Errorf("expected TOC header, got: %s", text)
 		}
+		if !strings.Contains(text, "# TS 23.501 v18.6.0 (Rel-18) - Table of Contents") {
+			t.Errorf("expected version/release in TOC header, got: %s", text)
+		}
 		if !strings.Contains(text, "5.1 General") {
 			t.Errorf("expected section 5.1, got: %s", text)
 		}
@@ -156,6 +159,9 @@ func TestHandleGetSection(t *testing.T) {
 		if !strings.Contains(text, "system architecture") {
 			t.Errorf("expected section content, got: %s", text)
 		}
+		if !strings.HasPrefix(text, "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 1]") {
+			t.Errorf("expected source header on first line, got: %s", text)
+		}
 	})
 
 	t.Run("pagination", func(t *testing.T) {
@@ -170,6 +176,58 @@ func TestHandleGetSection(t *testing.T) {
 		text := getTextContent(result)
 		if !strings.Contains(text, "Truncated") {
 			t.Errorf("expected truncation notice, got: %s", text)
+		}
+	})
+
+	t.Run("source header survives on later pages", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID:        "TS 23.501",
+			SectionNumber: "5",
+			Offset:        1,
+			MaxLines:      1,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.HasPrefix(text, "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5]") {
+			t.Errorf("expected source header on page 2, got: %s", text)
+		}
+		if !strings.Contains(text, "[Lines 2-") {
+			t.Errorf("expected pagination to start at line 2, got: %s", text)
+		}
+	})
+
+	t.Run("source header survives past end of content", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID:        "TS 23.501",
+			SectionNumber: "5",
+			Offset:        10000,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.HasPrefix(text, "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5]") {
+			t.Errorf("expected source header before no-content notice, got: %s", text)
+		}
+		if !strings.Contains(text, "No content at offset") {
+			t.Errorf("expected no-content notice, got: %s", text)
+		}
+	})
+
+	t.Run("subsections are flagged in source header", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetSectionInput{
+			SpecID:             "TS 23.501",
+			SectionNumber:      "5",
+			IncludeSubsections: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.HasPrefix(text, "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5 (+subsections)]") {
+			t.Errorf("expected subsections marker in source header, got: %s", text)
 		}
 	})
 
@@ -239,8 +297,9 @@ func TestHandleGetSection(t *testing.T) {
 		if !strings.Contains(text, "IE body.") {
 			t.Errorf("expected section content, got: %s", text)
 		}
-		if strings.Count(text, "MRB-Identity") != 1 {
-			t.Errorf("expected title to appear exactly once, got: %s", text)
+		// Once in the source header, once in the content heading.
+		if strings.Count(text, "MRB-Identity") != 2 {
+			t.Errorf("expected title in source header and content only, got: %s", text)
 		}
 	})
 }
@@ -270,6 +329,9 @@ func TestHandleSearch(t *testing.T) {
 		text := getTextContent(result)
 		if !strings.Contains(text, "TS 23.501") {
 			t.Errorf("expected search result for TS 23.501, got: %s", text)
+		}
+		if !strings.Contains(text, `"version": "18.6.0"`) || !strings.Contains(text, `"release": "Rel-18"`) {
+			t.Errorf("expected version/release in search results, got: %s", text)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Add version/release fields to `db.Section` and `db.SearchResult` so that the output of `get_section`, `search`, and `get_toc` always shows which version of which spec a section belongs to.

- `db.Section` / `db.SearchResult`: add `Version` / `Release` fields, populated via `LEFT JOIN specs` with `COALESCE` (NULL-safe). In `Search`, `sections_fts` stays unaliased on the left side of the join so `MATCH` and `snippet()` keep working.
- `get_section`: prepend a source header line to every page, e.g. `[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]`. The header is added outside `paginateText`, so line offsets are unchanged and the header survives on offset > 0 pages and past-end offsets.
- `get_toc`: include version/release in the heading: `# TS 23.501 v18.6.0 (Rel-18) - Table of Contents`.
- `search`: version/release keys appear in the JSON output automatically (omitted when empty).

No changes to the web viewer, `get_openapi`, or pagination semantics.

## Testing

- `go test -race ./...` passes
- `gofmt -l .` / `go vet ./...` clean
- New tests: source header on first/second/past-end pages and with subsections, TOC heading with version, version/release in search JSON, and empty version/release for specs without them (COALESCE regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6AbqGc4ZEgMhFMaL9PMS6)_