### PR TITLE
feat: support reading past spec versions on demand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ converter/
   docx/              # DOCX → Markdown parser (zip/XML processing, EMF/WMF image support)
   pipeline/          # Streaming download + conversion pipeline with worker pool
 db/                  # SQLite schema, queries, FTS5 full-text search
-tools/               # MCP tool handlers (list_specs, get_toc, get_section, search, openapi, references, images)
+versionstore/        # On-demand cache of spec versions not in the prebuilt database
+tools/               # MCP tool handlers (list_specs, list_versions, get_toc, get_section, search, openapi, references, images)
 web/                 # Web viewer UI (HTTP handlers, HTML templates, static assets)
+internal/specver/    # Version notation conversion (base-36 archive token <-> dotted)
 internal/testutil/   # Shared test helpers (SetupTestDB, DownloadTestZip)
 data/                # Database files (gitignored except .gitkeep)
 examples/systemd/    # Deployment examples (service + timer)
@@ -80,15 +82,40 @@ Uses a worker pool (`runtime.NumCPU()` workers by default) for parallel processi
 
 The pipeline caches the spec list to avoid repeated scraping. Cache TTL and location are controlled via environment variables.
 
+### Versions
+
+Specification versions are first-class in the schema: `specs` is keyed by
+`(id, version)` and `sections` by `(spec_id, version, number)`. The canonical
+version is the dotted form (`20.2.0`); the base-36 archive token (`k20`) is
+kept alongside it in `specs.version_token` so archive files stay resolvable.
+`internal/specver` converts between the two — each token digit is one base-36
+digit of release, technical and editorial number.
+
+A build imports **one version per spec**, and `InsertSpecWithSectionsAndImages`
+drops any other version of the same spec to keep that invariant. Search depends
+on it: the FTS index has no version column, so a second version of the same
+spec would double every hit.
+
+Reading a version the build did not import goes through `versionstore`, which
+downloads and converts it via `pipeline.FetchVersion` and stores it in a
+separate SQLite file (`$XDG_CACHE_HOME/3gpp-mcp/versions.db`). That file has no
+FTS tables, so cached versions never reach search. Fetches are deduplicated per
+`(spec, version)`, run on a context detached from the caller so a client timeout
+does not discard minutes of work, and are evicted least-recently-used once the
+size limit is exceeded. The on-demand path deliberately skips images, OpenAPI
+YAML and cross-reference extraction — those are served from the prebuilt
+database for its version only.
+
 ### MCP Tools
 
-Nine tools are exposed via MCP:
+Ten tools are exposed via MCP:
 
 | Tool | Description |
 |------|-------------|
 | `list_specs` | List available specifications |
-| `get_toc` | Get table of contents for a spec |
-| `get_section` | Get section content (paginated) |
+| `list_versions` | List a spec's versions and where each can be read from |
+| `get_toc` | Get table of contents for a spec (optionally a past version) |
+| `get_section` | Get section content (paginated, optionally a past version) |
 | `search` | Full-text search across all specs |
 | `list_openapi` | List OpenAPI definitions |
 | `get_openapi` | Get OpenAPI definition (paginated) |
@@ -142,4 +169,6 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push/PR to `main`:
 | `PORT` | PaaS convention (Cloud Run / Heroku). When set, `serve` defaults to HTTP transport and binds to `:$PORT`. `THREEGPP_MCP_*` and CLI flags take precedence |
 | `THREEGPP_MAX_ZIP_SIZE_MB` | Max ZIP download size (default: 512 MB) |
 | `THREEGPP_CACHE_TTL_HOURS` | Spec list cache TTL in hours |
+| `THREEGPP_VERSION_CACHE_MB` | Size limit of the on-demand version cache in MB (default: 1024; `0` keeps only the newest fetch, `-1` is unlimited) |
+| `THREEGPP_FETCH_BUDGET` | How long a tool call waits for an on-demand fetch before asking the caller to retry (default: `60s`) |
 | `XDG_CACHE_HOME` | Override cache directory (follows XDG Base Directory spec) |

--- a/README.md
+++ b/README.md
@@ -201,8 +201,41 @@ Features: spec list with filtering, section viewer with TOC sidebar, full-text s
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `list_specs` | List available specifications | `series` (optional): filter by series number, e.g. `"23"` |
-| `get_toc` | Get table of contents of a spec | `spec_id` (required): e.g. `"TS 23.501"` |
-| `get_section` | Get section content (paginated) | `spec_id`, `section_number` (required), `include_subsections`, `offset`, `max_lines`, `max_chars` |
+| `list_versions` | List the versions of a spec and where each can be read from | `spec_id` (required): e.g. `"TS 23.501"` |
+| `get_toc` | Get table of contents of a spec | `spec_id` (required), `version` |
+| `get_section` | Get section content (paginated) | `spec_id`, `section_number` (required), `version`, `include_subsections`, `offset`, `max_lines`, `max_chars` |
+
+Every `get_toc`, `get_section` and `search` result names the specification and
+version it came from, on every page of a paginated response.
+
+### Past versions
+
+The database holds one version per specification. To read another version, pass
+`version` to `get_section` or `get_toc`:
+
+```
+list_versions  spec_id="TS 24.301"
+get_section    spec_id="TS 24.301" section_number="5.5.1" version="15.8.0"
+```
+
+`version` accepts the dotted form (`15.8.0`), the archive token (`f80`), a
+release selector (`Rel-15` or `15`, picking the newest version in that release),
+or `latest`.
+
+A version that is not in the database is downloaded from the 3GPP archive and
+converted on first use. This takes up to a few minutes for a large
+specification; if it is still running when the call's budget expires, the tool
+says so and the same call repeated later returns the content. Results are kept
+in a size-bounded cache (see [`serve`](#serve)) that is separate from the main
+database, so:
+
+- `search` covers only the version in the database — cross-release full-text
+  search is not supported
+- `get_image` and `get_references` only have data for the version in the
+  database, so a section read from an archived version returns text alone and
+  says so in its header
+- section numbers move between releases; check `get_toc` for the older version
+  before reading a section of it
 
 ### Searching
 
@@ -302,6 +335,17 @@ Start the MCP server.
 | `--addr` | HTTP listen address (env: `THREEGPP_MCP_ADDR`, or `PORT` interpreted as `:$PORT`) | `:8080` |
 | `--bearer-token` | Bearer token for HTTP auth (env: `THREEGPP_MCP_BEARER_TOKEN`) | |
 | `--web` | Enable web viewer alongside MCP server (HTTP transport only) | `false` |
+| `--no-fetch` | Disable on-demand fetching of spec versions that are not in the database | `false` |
+| `--version-cache` | Path to the on-demand version cache | `$XDG_CACHE_HOME/3gpp-mcp/versions.db` |
+| `--version-cache-mb` | Size limit of the version cache in MB. `0` keeps only the most recently fetched version, `-1` is unlimited (env: `THREEGPP_VERSION_CACHE_MB`) | `1024` |
+| `--fetch-budget` | How long a tool call waits for an on-demand fetch before asking the caller to retry (env: `THREEGPP_FETCH_BUDGET`) | `60s` |
+
+The version cache is a separate SQLite file, so the main database stays
+read-only and is never polluted with extra versions. When the cache cannot be
+created — a read-only or ephemeral filesystem, such as the `scratch`-based
+container image — the server logs a warning and runs with on-demand fetching
+disabled; everything else keeps working. Cached versions are evicted
+least-recently-used once the size limit is exceeded.
 
 When `--web` is enabled with HTTP transport, the MCP endpoint is served at `/mcp/` and the web viewer at `/`.
 

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -11,12 +11,15 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
 	"github.com/higebu/3gpp-mcp/tools"
+	"github.com/higebu/3gpp-mcp/versionstore"
 	"github.com/higebu/3gpp-mcp/web"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -74,6 +77,29 @@ func main() {
 	}
 }
 
+// defaultVersionCacheMB reads the version cache limit from the environment,
+// falling back to the versionstore default.
+func defaultVersionCacheMB() int64 {
+	if v := os.Getenv("THREEGPP_VERSION_CACHE_MB"); v != "" {
+		if mb, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return mb
+		}
+		log.Printf("WARNING: ignoring invalid THREEGPP_VERSION_CACHE_MB=%q", v)
+	}
+	return versionstore.DefaultLimitBytes >> 20
+}
+
+// defaultFetchBudget reads the on-demand fetch budget from the environment.
+func defaultFetchBudget() time.Duration {
+	if v := os.Getenv("THREEGPP_FETCH_BUDGET"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+		log.Printf("WARNING: ignoring invalid THREEGPP_FETCH_BUDGET=%q", v)
+	}
+	return versionstore.DefaultBudget
+}
+
 func cmdServe(args []string) {
 	defaultTransport := "stdio"
 	if v := os.Getenv("THREEGPP_MCP_TRANSPORT"); v != "" {
@@ -96,6 +122,10 @@ func cmdServe(args []string) {
 	addr := fs.String("addr", defaultAddr, "HTTP listen address (env: THREEGPP_MCP_ADDR, or PORT)")
 	bearerToken := fs.String("bearer-token", "", "Bearer token for HTTP auth (env: THREEGPP_MCP_BEARER_TOKEN)")
 	enableWeb := fs.Bool("web", false, "Enable web viewer alongside MCP server (HTTP transport only)")
+	noFetch := fs.Bool("no-fetch", false, "Disable on-demand fetching of spec versions that are not in the database")
+	versionCache := fs.String("version-cache", "", "Path to the on-demand version cache (default: $XDG_CACHE_HOME/3gpp-mcp/versions.db)")
+	versionCacheMB := fs.Int64("version-cache-mb", defaultVersionCacheMB(), "Size limit of the version cache in MB, or -1 for unlimited (env: THREEGPP_VERSION_CACHE_MB)")
+	fetchBudget := fs.Duration("fetch-budget", defaultFetchBudget(), "How long a tool call waits for an on-demand fetch before asking the caller to retry (env: THREEGPP_FETCH_BUDGET)")
 	_ = fs.Parse(args)
 
 	// Environment variable takes precedence if flag is not set
@@ -109,16 +139,36 @@ func cmdServe(args []string) {
 	}
 	defer d.Close()
 
+	src := tools.NewSource(d)
+	src.Budget = *fetchBudget
+	if !*noFetch {
+		// A read-only or ephemeral filesystem — a scratch container image, for
+		// instance — cannot hold the cache. That disables past-version reads but
+		// leaves everything else working, so it is a warning, not a failure.
+		store, err := versionstore.Open(versionstore.Options{
+			Path:       *versionCache,
+			LimitBytes: *versionCacheMB << 20,
+		})
+		if err != nil {
+			log.Printf("WARNING: on-demand version fetching disabled: %v", err)
+		} else {
+			defer store.Close()
+			src.Store = store
+		}
+	}
+
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    "3gpp-mcp",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions.",
+		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions.\n\n" +
+			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then pass version to get_section or get_toc. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. search only covers the version in the database, and get_image and get_references only have data for that version, so an archived version returns text alone.",
 	})
 
 	mcp.AddTool(s, tools.ListSpecsTool, tools.HandleListSpecs(d))
-	mcp.AddTool(s, tools.GetTOCTool, tools.HandleGetTOC(d))
-	mcp.AddTool(s, tools.GetSectionTool, tools.HandleGetSection(d))
+	mcp.AddTool(s, tools.ListVersionsTool, tools.HandleListVersions(src))
+	mcp.AddTool(s, tools.GetTOCTool, tools.HandleGetTOC(src))
+	mcp.AddTool(s, tools.GetSectionTool, tools.HandleGetSection(src))
 	mcp.AddTool(s, tools.SearchTool, tools.HandleSearch(d))
 	mcp.AddTool(s, tools.ListOpenAPITool, tools.HandleListOpenAPI(d))
 	mcp.AddTool(s, tools.GetOpenAPITool, tools.HandleGetOpenAPI(d))
@@ -503,8 +553,13 @@ func cmdUpdate(args []string) {
 		if !ok {
 			continue
 		}
-		newVer := pipeline.SpecVersionString(sv)
-		if pipeline.IsNewerVersion(newVer, oldVer) {
+		// Stored versions are the dotted form, so compare in that form rather
+		// than on the archive token.
+		newVer, ok := specver.TokenToDotted(pipeline.SpecVersionString(sv))
+		if !ok {
+			continue
+		}
+		if specver.Compare(newVer, oldVer) > 0 {
 			fmt.Printf("  %s: %s -> %s\n", sv.SpecID, oldVer, newVer)
 			updates = append(updates, sv)
 		}
@@ -522,6 +577,13 @@ func cmdUpdate(args []string) {
 	if err != nil {
 		_ = os.Remove(newPath)
 		log.Fatalf("Failed to open working copy: %v", err)
+	}
+	// VACUUM INTO copies whatever schema the live database has, which may
+	// predate the current binary.
+	if err := d.InitSchema(); err != nil {
+		_ = d.Close()
+		_ = os.Remove(newPath)
+		log.Fatalf("Failed to initialize working copy schema: %v", err)
 	}
 
 	p := &pipeline.Pipeline{

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -503,19 +503,20 @@ func TestCmdUpdate_AllUpToDate(t *testing.T) {
 		t.Fatalf("init schema: %v", err)
 	}
 	if err := d.UpsertSpec(db.Spec{
-		ID:      "TS 23.501",
-		Title:   "System architecture",
-		Version: "k10",
-		Release: "Rel-20",
-		Series:  "23",
+		ID:           "TS 23.501",
+		Title:        "System architecture",
+		Version:      "20.1.0",
+		VersionToken: "k10",
+		Release:      "20",
+		Series:       "23",
 	}); err != nil {
 		t.Fatalf("upsert spec: %v", err)
 	}
 	d.Close()
 
 	// Provide a spec-list with an OLDER version of the same spec. FilterSpecs
-	// with latestOnly=true picks j60; cmdUpdate then sees j60 < k10 and prints
-	// "All specs are up to date.".
+	// with latestOnly=true picks j60 (v19.6.0); cmdUpdate then sees it is older
+	// than the stored v20.1.0 and prints "All specs are up to date.".
 	listPath := filepath.Join(t.TempDir(), "list.txt")
 	if err := os.WriteFile(listPath, []byte("23_series/23.501/23501-j60.zip\n"), 0o644); err != nil {
 		t.Fatalf("write list: %v", err)

--- a/converter/docx/metadata.go
+++ b/converter/docx/metadata.go
@@ -5,6 +5,8 @@ import (
 	"encoding/xml"
 	"regexp"
 	"strings"
+
+	"github.com/higebu/3gpp-mcp/internal/specver"
 )
 
 const (
@@ -89,16 +91,20 @@ func extractMetadata(filename string, props coreProperties, bodyElements []bodyE
 	// Remove multi-part suffixes like _cover, _s00-11
 	baseStem := stem
 
-	var specID, title, version, release string
+	var specID, title, version, versionToken, release string
 
-	// Parse from filename
+	// Parse from filename. The trailing group is the base-36 archive token
+	// (e.g. "i60"), which is normalized to the dotted form used everywhere else.
 	if match := filenameRE.FindStringSubmatch(stem); match != nil {
 		series, num, part, ver := match[1], match[2], match[3], match[4]
 		specID = "TS " + series + "." + num
 		if part != "" {
 			specID += "-" + part
 		}
-		version = ver
+		versionToken = strings.ToLower(ver)
+		if dotted, ok := specver.TokenToDotted(versionToken); ok {
+			version = dotted
+		}
 	} else if match := specPatternRE.FindStringSubmatch(stem); match != nil {
 		specID = "TS " + match[1] + "." + match[2]
 	} else {
@@ -175,11 +181,26 @@ func extractMetadata(filename string, props coreProperties, bodyElements []bodyE
 		}
 	}
 
+	// Fill in whichever version form is still missing. A legacy filename whose
+	// token does not parse leaves only the body-scanned dotted version, and a
+	// filename token that has no dotted counterpart leaves only the token.
+	if version != "" && versionToken == "" {
+		if token, ok := specver.DottedToToken(version); ok {
+			versionToken = token
+		}
+	}
+	// The first version component is the release, so a document that never
+	// spells out "Release N" still gets one.
+	if release == "" {
+		release = specver.ReleaseOf(version)
+	}
+
 	return &SpecMetadata{
-		SpecID:  specID,
-		Title:   title,
-		Version: version,
-		Release: release,
+		SpecID:       specID,
+		Title:        title,
+		Version:      version,
+		VersionToken: versionToken,
+		Release:      release,
 	}
 }
 

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -56,66 +56,77 @@ func TestExtractMetadata_FilenameVariants(t *testing.T) {
 		filename    string
 		wantSpecID  string
 		wantVersion string
+		wantToken   string
 	}{
 		{
 			name:        "TS series with hyphen and letter version",
 			filename:    "23501-i30.docx",
 			wantSpecID:  "TS 23.501",
-			wantVersion: "i30",
+			wantVersion: "18.3.0",
+			wantToken:   "i30",
 		},
 		{
 			name:        "TR series with hyphen and letter version",
 			filename:    "24229-h50.doc",
 			wantSpecID:  "TS 24.229",
-			wantVersion: "h50",
+			wantVersion: "17.5.0",
+			wantToken:   "h50",
 		},
 		{
 			name:        "high series",
 			filename:    "29510-f60.zip",
 			wantSpecID:  "TS 29.510",
-			wantVersion: "f60",
+			wantVersion: "15.6.0",
+			wantToken:   "f60",
 		},
 		{
 			name:        "no extension",
 			filename:    "33401-i00",
 			wantSpecID:  "TS 33.401",
-			wantVersion: "i00",
+			wantVersion: "18.0.0",
+			wantToken:   "i00",
 		},
 		{
 			name:        "non-standard falls back to stem",
 			filename:    "weirdname.docx",
 			wantSpecID:  "weirdname",
 			wantVersion: "",
+			wantToken:   "",
 		},
 		{
 			name:        "split multi-file spec body chunk",
 			filename:    "38101-1-k00_s00-05.docx",
 			wantSpecID:  "TS 38.101-1",
-			wantVersion: "k00",
+			wantVersion: "20.0.0",
+			wantToken:   "k00",
 		},
 		{
 			name:        "split multi-file spec annex chunk",
 			filename:    "38101-1-k00_sAnnexes.docx",
 			wantSpecID:  "TS 38.101-1",
-			wantVersion: "k00",
+			wantVersion: "20.0.0",
+			wantToken:   "k00",
 		},
 		{
 			name:        "base-36 version token with letter in second position",
 			filename:    "23222-ja0.docx",
 			wantSpecID:  "TS 23.222",
-			wantVersion: "ja0",
+			wantVersion: "19.10.0",
+			wantToken:   "ja0",
 		},
 		{
 			name:        "base-36 version token, minor version b",
 			filename:    "23280-ja1.docx",
 			wantSpecID:  "TS 23.280",
-			wantVersion: "ja1",
+			wantVersion: "19.10.1",
+			wantToken:   "ja1",
 		},
 		{
 			name:        "base-36 version token, different minor letter",
 			filename:    "23379-jb0.docx",
 			wantSpecID:  "TS 23.379",
-			wantVersion: "jb0",
+			wantVersion: "19.11.0",
+			wantToken:   "jb0",
 		},
 	}
 	for _, tt := range tests {
@@ -126,6 +137,9 @@ func TestExtractMetadata_FilenameVariants(t *testing.T) {
 			}
 			if meta.Version != tt.wantVersion {
 				t.Errorf("Version = %q, want %q", meta.Version, tt.wantVersion)
+			}
+			if meta.VersionToken != tt.wantToken {
+				t.Errorf("VersionToken = %q, want %q", meta.VersionToken, tt.wantToken)
 			}
 		})
 	}

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -128,8 +128,8 @@ func TestParseDocx(t *testing.T) {
 		t.Errorf("Series = %q, want %q", metadata.Series(), "23")
 	}
 	// Version comes from filename (i20), matching Python behavior
-	if metadata.Version != "i20" {
-		t.Errorf("Version = %q, want %q", metadata.Version, "i20")
+	if metadata.Version != "18.2.0" {
+		t.Errorf("Version = %q, want %q", metadata.Version, "18.2.0")
 	}
 	if metadata.Release != "18" {
 		t.Errorf("Release = %q, want %q", metadata.Release, "18")
@@ -273,8 +273,8 @@ func TestParseDocx_26274(t *testing.T) {
 	if metadata.Series() != "26" {
 		t.Errorf("Series = %q, want %q", metadata.Series(), "26")
 	}
-	if metadata.Version != "j00" {
-		t.Errorf("Version = %q, want %q", metadata.Version, "j00")
+	if metadata.Version != "19.0.0" {
+		t.Errorf("Version = %q, want %q", metadata.Version, "19.0.0")
 	}
 	if metadata.Release != "19" {
 		t.Errorf("Release = %q, want %q", metadata.Release, "19")
@@ -346,8 +346,8 @@ func TestParseDocx_22839(t *testing.T) {
 	if metadata.SpecID != "TS 22.839" {
 		t.Errorf("SpecID = %q, want %q", metadata.SpecID, "TS 22.839")
 	}
-	if metadata.Version != "i10" {
-		t.Errorf("Version = %q, want %q", metadata.Version, "i10")
+	if metadata.Version != "18.1.0" {
+		t.Errorf("Version = %q, want %q", metadata.Version, "18.1.0")
 	}
 	if metadata.Release != "18" {
 		t.Errorf("Release = %q, want %q", metadata.Release, "18")

--- a/converter/docx/types.go
+++ b/converter/docx/types.go
@@ -4,10 +4,14 @@ import "regexp"
 
 // SpecMetadata holds metadata extracted from a 3GPP specification document.
 type SpecMetadata struct {
-	SpecID  string // e.g., "TS 23.501"
-	Title   string
-	Version string // e.g., "k10" or "18.6.0"
-	Release string // e.g., "19"
+	SpecID string // e.g., "TS 23.501"
+	Title  string
+	// Version is the canonical dotted form, e.g. "18.6.0".
+	Version string
+	// VersionToken is the base-36 archive form, e.g. "i60". It is empty when
+	// the dotted version has a component that no single base-36 digit holds.
+	VersionToken string
+	Release      string // e.g., "19"
 }
 
 // Series extracts the series number from the spec ID (e.g., "23" from "TS 23.501").

--- a/converter/pipeline/cache.go
+++ b/converter/pipeline/cache.go
@@ -37,6 +37,13 @@ func cacheDir() (string, error) {
 	return filepath.Join(base, "3gpp-mcp"), nil
 }
 
+// CacheDir returns the directory holding this tool's caches, following the XDG
+// Base Directory spec. Callers that keep their own cache files, such as the
+// on-demand version store, put them here too.
+func CacheDir() (string, error) {
+	return cacheDir()
+}
+
 // CacheKey generates a cache file name from a prefix and parameters.
 // e.g., CacheKey("speclist", "23", "29") -> "speclist_23_29.txt"
 func CacheKey(prefix string, params ...string) string {

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -1,0 +1,206 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/docx"
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
+)
+
+// LatestVersion asks ResolveVersion for the newest version of a spec.
+const LatestVersion = "latest"
+
+var (
+	// ErrVersionNotFound reports that the archive directory for a spec holds no
+	// file matching the requested version.
+	ErrVersionNotFound = errors.New("version not found in archive")
+	// ErrNoDocx reports that the version exists but ships no .docx file. Old
+	// versions are commonly .doc only, which needs LibreOffice to convert.
+	ErrNoDocx = errors.New("version has no .docx file")
+)
+
+// ListVersions returns every version of a spec present in the archive, newest
+// first. Results come from the per-spec directory listing cache, so repeated
+// calls within the cache TTL do not hit the network.
+func ListVersions(ctx context.Context, client *http.Client, specID string, useCache bool) ([]*SpecVersion, error) {
+	entries, err := FetchSpecZips(ctx, client, specID, useCache)
+	if err != nil {
+		return nil, fmt.Errorf("list archive versions for %s: %w", specID, err)
+	}
+
+	var versions []*SpecVersion
+	for _, entry := range entries {
+		if sv := ParseSpecEntry(entry); sv != nil {
+			versions = append(versions, sv)
+		}
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versionKey(versions[i]) > versionKey(versions[j])
+	})
+	return versions, nil
+}
+
+// ResolveVersion finds the archive file for a requested version of a spec.
+// The request may be the dotted form ("18.6.0"), the archive token ("i60"),
+// a bare release number ("18" or "Rel-18") selecting the newest version in
+// that release, or "latest"/"" for the newest version overall.
+//
+// It returns the matching entry along with every version it saw, so callers can
+// tell the user what does exist when nothing matches.
+func ResolveVersion(ctx context.Context, client *http.Client, specID, version string, useCache bool) (*SpecVersion, []*SpecVersion, error) {
+	available, err := ListVersions(ctx, client, specID, useCache)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(available) == 0 {
+		return nil, nil, fmt.Errorf("%w: no versions listed for %s", ErrVersionNotFound, specID)
+	}
+
+	// available is sorted newest first, so the first match in each branch wins.
+	if version == "" || version == LatestVersion {
+		return available[0], available, nil
+	}
+
+	if release, ok := releaseRequest(version); ok {
+		for _, sv := range available {
+			if sv.Release == release {
+				return sv, available, nil
+			}
+		}
+		return nil, available, fmt.Errorf("%w: %s has no version in Rel-%d", ErrVersionNotFound, specID, release)
+	}
+
+	_, token, err := specver.Normalize(version)
+	if err != nil {
+		return nil, available, fmt.Errorf("invalid version %q: %w", version, err)
+	}
+	if token == "" {
+		return nil, available, fmt.Errorf("%w: %s has no archive file for version %s", ErrVersionNotFound, specID, version)
+	}
+	for _, sv := range available {
+		if sv.Version == token {
+			return sv, available, nil
+		}
+	}
+	return nil, available, fmt.Errorf("%w: %s has no version %s", ErrVersionNotFound, specID, version)
+}
+
+// releaseRequest recognises a bare release selector such as "18" or "Rel-18".
+// A dotted version is never a release selector, so "18.6.0" does not match.
+func releaseRequest(s string) (int, bool) {
+	trimmed := s
+	for _, prefix := range []string{"Rel-", "rel-", "REL-", "R", "r"} {
+		if len(trimmed) > len(prefix) && trimmed[:len(prefix)] == prefix {
+			trimmed = trimmed[len(prefix):]
+			break
+		}
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// FetchVersion downloads one archive entry, converts its documents to Markdown
+// and returns the resulting records without writing them anywhere.
+//
+// Unlike the build pipeline it deliberately skips images, OpenAPI YAML and
+// cross-reference extraction: those are served from the prebuilt database for
+// the current version only, and carrying them for every fetched version would
+// bloat the cache with data no tool reads.
+func FetchVersion(ctx context.Context, client *http.Client, sv *SpecVersion, timeout time.Duration) (db.Spec, []db.Section, error) {
+	tmpDir, err := os.MkdirTemp("", "3gpp-ondemand-"+sv.SpecID+"-")
+	if err != nil {
+		return db.Spec{}, nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	result, err := DownloadAndExtract(ctx, client, sv, tmpDir, timeout)
+	if err != nil {
+		return db.Spec{}, nil, err
+	}
+	switch result.Status {
+	case "OK":
+	case "DOC_ONLY":
+		return db.Spec{}, nil, fmt.Errorf("%w: %s v%s ships only legacy .doc files, which need LibreOffice to convert; build it into the database with `3gpp-mcp build --convert-doc`",
+			ErrNoDocx, sv.SpecID, displayVersion(sv))
+	default:
+		return db.Spec{}, nil, fmt.Errorf("%w: %s v%s (%s)", ErrNoDocx, sv.SpecID, displayVersion(sv), result.Status)
+	}
+
+	// Cover files carry the title and are processed last so their metadata wins.
+	sortCoverLast(result.DocxFiles)
+
+	var spec db.Spec
+	var sections []db.Section
+	// A multi-file spec repeats section numbers across its parts only when a
+	// later part supersedes an earlier one, so last write wins by number.
+	index := map[string]int{}
+
+	for _, docxPath := range result.DocxFiles {
+		if err := ctx.Err(); err != nil {
+			return db.Spec{}, nil, err
+		}
+		parsed, err := docx.ParseDocx(docxPath)
+		if err != nil {
+			log.Printf("  on-demand parse error %s: %v", filepath.Base(docxPath), err)
+			continue
+		}
+		fileSpec, fileSections, _ := convertToDBRecords(parsed)
+		if fileSpec.Title != "" {
+			spec = fileSpec
+		} else if spec.ID == "" {
+			spec = fileSpec
+		}
+		for _, s := range fileSections {
+			if i, ok := index[s.Number]; ok {
+				sections[i] = s
+				continue
+			}
+			index[s.Number] = len(sections)
+			sections = append(sections, s)
+		}
+		// Free the file as soon as it is parsed, as the build pipeline does.
+		if err := os.Remove(docxPath); err != nil {
+			log.Printf("  warning: failed to remove %s: %v", filepath.Base(docxPath), err)
+		}
+	}
+
+	if len(sections) == 0 {
+		return db.Spec{}, nil, fmt.Errorf("%w: %s v%s produced no sections", ErrNoDocx, sv.SpecID, displayVersion(sv))
+	}
+
+	if spec.ID == "" {
+		// The archive path carries the bare number; the database form has a
+		// document-type prefix.
+		spec.ID = "TS " + sv.SpecID
+	}
+	if spec.Title == "" {
+		spec.Title = spec.ID
+	}
+	applyArchiveVersion(&spec, sections, sv)
+	for i := range sections {
+		sections[i].SpecID = spec.ID
+	}
+	return spec, sections, nil
+}
+
+// displayVersion formats an archive entry's version for messages, preferring
+// the dotted form and falling back to the raw token.
+func displayVersion(sv *SpecVersion) string {
+	if dotted, ok := specver.TokenToDotted(sv.Version); ok {
+		return dotted
+	}
+	return sv.Version
+}

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -1,0 +1,147 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeArchive serves a directory listing for TS 23.501 with a spread of
+// versions, so version resolution can be exercised without the network.
+func fakeArchive(t *testing.T) *http.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, _ *http.Request) {
+		for _, name := range []string{"23501-i60.zip", "23501-j50.zip", "23501-k20.zip", "23501-k00.zip"} {
+			fmt.Fprintf(w, `<a href="%s">%s</a>`+"\n", name, name)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+}
+
+func TestListVersions(t *testing.T) {
+	versions, err := ListVersions(context.Background(), fakeArchive(t), "TS 23.501", false)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+	want := []string{"k20", "k00", "j50", "i60"}
+	if len(versions) != len(want) {
+		t.Fatalf("got %d versions, want %d", len(versions), len(want))
+	}
+	for i, w := range want {
+		if versions[i].Version != w {
+			t.Errorf("versions[%d] = %q, want %q (newest first)", i, versions[i].Version, w)
+		}
+	}
+}
+
+func TestResolveVersion(t *testing.T) {
+	client := fakeArchive(t)
+
+	tests := []struct {
+		name    string
+		request string
+		want    string
+		wantErr bool
+	}{
+		{name: "dotted", request: "18.6.0", want: "i60"},
+		{name: "archive token", request: "i60", want: "i60"},
+		{name: "uppercase token", request: "I60", want: "i60"},
+		{name: "v prefix", request: "v19.5.0", want: "j50"},
+		{name: "latest", request: "latest", want: "k20"},
+		{name: "empty means latest", request: "", want: "k20"},
+		{name: "release selector picks newest in release", request: "Rel-20", want: "k20"},
+		{name: "bare release number", request: "18", want: "i60"},
+		{name: "unknown version", request: "17.1.0", wantErr: true},
+		{name: "unknown release", request: "Rel-5", wantErr: true},
+		{name: "malformed", request: "18.6", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv, available, err := ResolveVersion(context.Background(), client, "TS 23.501", tt.request, false)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveVersion(%q) = %v, want error", tt.request, sv)
+				}
+				// Callers show the user what does exist, so the list must survive.
+				if len(available) == 0 {
+					t.Error("expected the available versions alongside the error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveVersion(%q): %v", tt.request, err)
+			}
+			if sv.Version != tt.want {
+				t.Errorf("ResolveVersion(%q) = %q, want %q", tt.request, sv.Version, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveVersionUnknownSpec(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	if _, _, err := ResolveVersion(context.Background(), client, "TS 99.999", "18.6.0", false); err == nil {
+		t.Error("expected an error for a spec that is not in the archive")
+	}
+}
+
+func TestReleaseRequest(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"18", 18, true},
+		{"Rel-18", 18, true},
+		{"rel-18", 18, true},
+		{"R18", 18, true},
+		{"18.6.0", 0, false},
+		{"i60", 0, false},
+		{"", 0, false},
+		{"Rel-", 0, false},
+	}
+	for _, tt := range tests {
+		got, ok := releaseRequest(tt.in)
+		if got != tt.want || ok != tt.ok {
+			t.Errorf("releaseRequest(%q) = %d, %v; want %d, %v", tt.in, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+// TestFetchVersionDocOnly checks the error a legacy .doc-only version gives,
+// since old versions hit this far more often than recent ones.
+func TestFetchVersionDocOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-300.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(makeRawZipEntry(t, "23501-300.doc", []byte("legacy")))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-300.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	_, _, err := FetchVersion(context.Background(), client, sv, 0)
+	if !errors.Is(err, ErrNoDocx) {
+		t.Fatalf("FetchVersion = %v, want ErrNoDocx", err)
+	}
+	if !strings.Contains(err.Error(), "LibreOffice") {
+		t.Errorf("error should explain why a .doc-only version fails, got: %v", err)
+	}
+}

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/higebu/3gpp-mcp/converter/docx"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
 )
 
 // docxVersionRE matches 3GPP docx filenames like "21900-j10.docx" or
@@ -204,9 +205,9 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 		}
 
 		dbSpec, dbSections, dbImages := convertToDBRecords(parseResult)
-		if spec.Release != 0 {
-			dbSpec.Release = strconv.Itoa(spec.Release)
-		}
+		// The archive entry knows the release and version of the file we asked
+		// for, so it wins over anything scraped out of the document.
+		applyArchiveVersion(&dbSpec, dbSections, spec)
 
 		// Store in DB (serialized)
 		if err := p.DB.InsertSpecWithSectionsAndImages(dbSpec, dbSections, dbImages); err != nil {
@@ -255,21 +256,42 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 	return "OK", nil
 }
 
+// applyArchiveVersion overwrites the version and release of records parsed out
+// of a document with what the archive entry says. The entry names the exact
+// file that was downloaded, so it is authoritative; document metadata is a
+// best-effort scrape that legacy specs frequently get wrong or omit.
+func applyArchiveVersion(spec *db.Spec, sections []db.Section, sv *SpecVersion) {
+	if sv.Version != "" {
+		spec.VersionToken = sv.Version
+		if dotted, ok := specver.TokenToDotted(sv.Version); ok {
+			spec.Version = dotted
+		}
+	}
+	if sv.Release != 0 {
+		spec.Release = strconv.Itoa(sv.Release)
+	}
+	for i := range sections {
+		sections[i].Version = spec.Version
+	}
+}
+
 // convertToDBRecords converts parsed docx results into DB records.
 func convertToDBRecords(result *docx.ParseResult) (db.Spec, []db.Section, []db.Image) {
 	metadata := result.Metadata
 	dbSpec := db.Spec{
-		ID:      metadata.SpecID,
-		Title:   metadata.Title,
-		Version: metadata.Version,
-		Release: metadata.Release,
-		Series:  metadata.Series(),
+		ID:           metadata.SpecID,
+		Title:        metadata.Title,
+		Version:      metadata.Version,
+		VersionToken: metadata.VersionToken,
+		Release:      metadata.Release,
+		Series:       metadata.Series(),
 	}
 
 	var dbSections []db.Section
 	for _, s := range result.Sections {
 		dbSections = append(dbSections, db.Section{
 			SpecID:       metadata.SpecID,
+			Version:      metadata.Version,
 			Number:       s.Number,
 			Title:        s.Title,
 			Level:        s.Level,
@@ -282,6 +304,7 @@ func convertToDBRecords(result *docx.ParseResult) (db.Spec, []db.Section, []db.I
 	for _, img := range result.Images {
 		dbImages = append(dbImages, db.Image{
 			SpecID:      metadata.SpecID,
+			Version:     metadata.Version,
 			Name:        img.Name,
 			MIMEType:    img.MIMEType,
 			Data:        img.Data,

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -129,7 +129,7 @@ func TestPipelineRun_MultiFileZip(t *testing.T) {
 		t.Fatalf("Pipeline.Run: %v", err)
 	}
 
-	sections, err := d.GetTOC("TS 36.133")
+	sections, err := d.GetTOC("TS 36.133", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestPipelineRun_OpenAPIYAML(t *testing.T) {
 	t.Logf("Imported %d OpenAPI specs from TS 29.510", len(apis))
 
 	// Verify sections were also parsed.
-	sections, err := d.GetTOC("TS 29.510")
+	sections, err := d.GetTOC("TS 29.510", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestPipelineRun_DocConversion(t *testing.T) {
 		t.Fatalf("Pipeline.Run: %v", err)
 	}
 
-	sections, err := d.GetTOC("TS 24.229")
+	sections, err := d.GetTOC("TS 24.229", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestPipelineRun_Race(t *testing.T) {
 	}
 
 	// Verify spec was inserted.
-	sections, err := d.GetTOC("TS 23.274")
+	sections, err := d.GetTOC("TS 23.274", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestConvertSingleFile(t *testing.T) {
 	}
 
 	// Parser pulls spec ID from metadata; testdata file is TS 23.274.
-	sections, err := d.GetTOC("TS 23.274")
+	sections, err := d.GetTOC("TS 23.274", "")
 	if err != nil {
 		t.Fatalf("GetTOC: %v", err)
 	}

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -164,8 +164,15 @@ func FetchSpecZips(ctx context.Context, client *http.Client, specID string, useC
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 
-	// Normalize: "23.501" -> series "23", spec dir "23.501"
-	normalized := specID
+	// Normalize: "TS 23.501" or "23501" -> series "23", spec dir "23.501".
+	// Callers hand over IDs in either the archive form or the database form.
+	normalized := strings.TrimSpace(specID)
+	for _, prefix := range []string{"TS ", "TR ", "ts ", "tr "} {
+		if rest, ok := strings.CutPrefix(normalized, prefix); ok {
+			normalized = strings.TrimSpace(rest)
+			break
+		}
+	}
 	if !strings.Contains(normalized, ".") && len(normalized) >= 4 {
 		// "23501" -> "23.501"
 		normalized = normalized[:2] + "." + normalized[2:]

--- a/db/db.go
+++ b/db/db.go
@@ -2,20 +2,33 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/higebu/3gpp-mcp/internal/specver"
 	_ "modernc.org/sqlite"
 )
 
+// ErrNoVersion reports that a spec, or a specific version of it, is not in
+// this database. Read methods that return a list translate it into an empty
+// result so callers can fall back to another source.
+var ErrNoVersion = errors.New("spec version not found")
+
 type Spec struct {
-	ID      string `json:"id"`
-	Title   string `json:"title"`
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	// Version is the canonical dotted form, e.g. "20.2.0".
 	Version string `json:"version,omitempty"`
-	Release string `json:"release,omitempty"`
-	Series  string `json:"series,omitempty"`
+	// VersionToken is the base-36 form used in archive filenames, e.g. "k20".
+	// It is kept alongside Version so an archive file stays resolvable even
+	// though the dotted form is what users and documents refer to.
+	VersionToken string `json:"version_token,omitempty"`
+	Release      string `json:"release,omitempty"`
+	Series       string `json:"series,omitempty"`
 }
 
 type Section struct {
@@ -41,6 +54,7 @@ type SearchResult struct {
 // Image holds an embedded image from a specification.
 type Image struct {
 	SpecID      string `json:"spec_id"`
+	Version     string `json:"version,omitempty"`
 	Name        string `json:"name"`
 	MIMEType    string `json:"mime_type"`
 	Data        []byte `json:"-"`
@@ -50,14 +64,18 @@ type Image struct {
 // ImageInfo holds image metadata without the binary data.
 type ImageInfo struct {
 	SpecID      string `json:"spec_id"`
+	Version     string `json:"version,omitempty"`
 	Name        string `json:"name"`
 	MIMEType    string `json:"mime_type"`
 	LLMReadable bool   `json:"llm_readable"`
 }
 
 // Reference represents a cross-reference from one spec section to another spec.
+// Only the source side carries a version: a reference names a target spec, not
+// a particular version of it.
 type Reference struct {
 	SourceSpecID  string `json:"source_spec_id"`
+	SourceVersion string `json:"source_version,omitempty"`
 	SourceSection string `json:"source_section"`
 	TargetSpec    string `json:"target_spec"`
 	TargetSection string `json:"target_section,omitempty"`
@@ -146,29 +164,44 @@ type ListSpecsResult struct {
 	Offset     int    `json:"offset"`
 }
 
-// Schema is the SQL schema for the 3GPP database.
-const Schema = `
+// SpecTablesSchema defines the tables that hold a specification's text, keyed
+// by (spec_id, version). The version cache reuses it verbatim; the main
+// database adds full-text search and the remaining tables on top.
+const SpecTablesSchema = `
 CREATE TABLE IF NOT EXISTS specs (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    version_token TEXT NOT NULL DEFAULT '',
     title TEXT NOT NULL,
-    version TEXT,
     release TEXT,
-    series TEXT
+    series TEXT,
+    PRIMARY KEY (id, version)
 );
+
+CREATE INDEX IF NOT EXISTS idx_specs_id ON specs(id);
 
 CREATE TABLE IF NOT EXISTS sections (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    spec_id TEXT NOT NULL REFERENCES specs(id),
+    spec_id TEXT NOT NULL,
+    version TEXT NOT NULL,
     number TEXT NOT NULL,
     title TEXT NOT NULL,
     level INTEGER NOT NULL,
     parent_number TEXT,
     content TEXT NOT NULL,
-    UNIQUE(spec_id, number)
+    UNIQUE(spec_id, version, number)
 );
 
-CREATE INDEX IF NOT EXISTS idx_sections_spec ON sections(spec_id);
-CREATE INDEX IF NOT EXISTS idx_sections_number ON sections(spec_id, number);
+CREATE INDEX IF NOT EXISTS idx_sections_spec ON sections(spec_id, version);
+CREATE INDEX IF NOT EXISTS idx_sections_number ON sections(spec_id, version, number);
+`
+
+// Schema is the SQL schema for the 3GPP database.
+//
+// A build imports one version per spec, so the FTS index covers exactly that
+// version. Versions fetched on demand are stored in a separate cache database
+// that has no FTS tables, keeping cross-release rows out of search results.
+const Schema = SpecTablesSchema + `
 
 CREATE VIRTUAL TABLE IF NOT EXISTS sections_fts USING fts5(
     spec_id, number, title, content,
@@ -195,16 +228,21 @@ END;
 
 CREATE TABLE IF NOT EXISTS images (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    spec_id TEXT NOT NULL REFERENCES specs(id),
+    spec_id TEXT NOT NULL,
+    version TEXT NOT NULL,
     name TEXT NOT NULL,
     mime_type TEXT NOT NULL,
     data BLOB NOT NULL,
     llm_readable BOOLEAN NOT NULL DEFAULT 0,
-    UNIQUE(spec_id, name)
+    UNIQUE(spec_id, version, name)
 );
 
-CREATE INDEX IF NOT EXISTS idx_images_spec ON images(spec_id);
+CREATE INDEX IF NOT EXISTS idx_images_spec ON images(spec_id, version);
 
+-- OpenAPI definitions are not keyed by spec version. They ship as standalone
+-- YAML files carrying their own api version, and the pipeline imports them
+-- under a spec ID that may have no specs row at all, so a spec version column
+-- here could not be filled reliably.
 CREATE TABLE IF NOT EXISTS openapi_specs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     spec_id TEXT NOT NULL,
@@ -218,14 +256,15 @@ CREATE TABLE IF NOT EXISTS openapi_specs (
 CREATE TABLE IF NOT EXISTS spec_references (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     source_spec_id TEXT NOT NULL,
+    source_version TEXT NOT NULL DEFAULT '',
     source_section TEXT NOT NULL,
     target_spec TEXT NOT NULL,
     target_section TEXT NOT NULL DEFAULT '',
     context TEXT NOT NULL,
-    UNIQUE(source_spec_id, source_section, target_spec, target_section)
+    UNIQUE(source_spec_id, source_version, source_section, target_spec, target_section)
 );
 
-CREATE INDEX IF NOT EXISTS idx_ref_source ON spec_references(source_spec_id, source_section);
+CREATE INDEX IF NOT EXISTS idx_ref_source ON spec_references(source_spec_id, source_version, source_section);
 CREATE INDEX IF NOT EXISTS idx_ref_target ON spec_references(target_spec);
 `
 
@@ -235,11 +274,86 @@ func (d *DB) InitSchema() error {
 	return err
 }
 
+// ResolveVersion returns the version of a spec to read. An empty version means
+// "whatever this database holds": a build imports one version per spec, so the
+// newest row is the only row. It returns ErrNoVersion when the spec is absent
+// or when an explicitly requested version is not stored.
+func (d *DB) ResolveVersion(specID, version string) (string, error) {
+	if version != "" {
+		var found string
+		err := d.conn.QueryRow("SELECT version FROM specs WHERE id = ? AND version = ?", specID, version).Scan(&found)
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNoVersion
+		}
+		if err != nil {
+			return "", fmt.Errorf("resolve version: %w", err)
+		}
+		return found, nil
+	}
+
+	rows, err := d.conn.Query("SELECT version FROM specs WHERE id = ?", specID)
+	if err != nil {
+		return "", fmt.Errorf("resolve version: %w", err)
+	}
+	defer rows.Close()
+
+	// An empty version is a legitimate stored value for a document whose
+	// version could not be determined, so "found nothing" is tracked separately
+	// from "found an empty string".
+	best := ""
+	found := false
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return "", fmt.Errorf("scan version: %w", err)
+		}
+		if !found || specver.Compare(v, best) > 0 {
+			best, found = v, true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("resolve version: iterate: %w", err)
+	}
+	if !found {
+		return "", ErrNoVersion
+	}
+	return best, nil
+}
+
+// ListSpecVersions returns every version of a spec held in this database,
+// newest first.
+func (d *DB) ListSpecVersions(specID string) ([]Spec, error) {
+	rows, err := d.conn.Query(
+		"SELECT id, version, COALESCE(version_token, ''), title, COALESCE(release, ''), COALESCE(series, '') FROM specs WHERE id = ?",
+		specID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list spec versions: %w", err)
+	}
+	defer rows.Close()
+
+	var specs []Spec
+	for rows.Next() {
+		var s Spec
+		if err := rows.Scan(&s.ID, &s.Version, &s.VersionToken, &s.Title, &s.Release, &s.Series); err != nil {
+			return nil, fmt.Errorf("scan spec version: %w", err)
+		}
+		specs = append(specs, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list spec versions: iterate: %w", err)
+	}
+	sort.Slice(specs, func(i, j int) bool {
+		return specver.Compare(specs[i].Version, specs[j].Version) > 0
+	})
+	return specs, nil
+}
+
 // UpsertSpec inserts or replaces a spec record.
 func (d *DB) UpsertSpec(spec Spec) error {
 	_, err := d.conn.Exec(
-		"INSERT OR REPLACE INTO specs (id, title, version, release, series) VALUES (?, ?, ?, ?, ?)",
-		spec.ID, spec.Title, spec.Version, spec.Release, spec.Series,
+		"INSERT OR REPLACE INTO specs (id, version, version_token, title, release, series) VALUES (?, ?, ?, ?, ?, ?)",
+		spec.ID, spec.Version, spec.VersionToken, spec.Title, spec.Release, spec.Series,
 	)
 	return err
 }
@@ -247,15 +361,15 @@ func (d *DB) UpsertSpec(spec Spec) error {
 // UpsertSection deletes then re-inserts a section to trigger FTS update.
 func (d *DB) UpsertSection(section Section) error {
 	_, err := d.conn.Exec(
-		"DELETE FROM sections WHERE spec_id = ? AND number = ?",
-		section.SpecID, section.Number,
+		"DELETE FROM sections WHERE spec_id = ? AND version = ? AND number = ?",
+		section.SpecID, section.Version, section.Number,
 	)
 	if err != nil {
 		return err
 	}
 	_, err = d.conn.Exec(
-		"INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?)",
-		section.SpecID, section.Number, section.Title, section.Level, section.ParentNumber, section.Content,
+		"INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		section.SpecID, section.Version, section.Number, section.Title, section.Level, section.ParentNumber, section.Content,
 	)
 	return err
 }
@@ -263,19 +377,24 @@ func (d *DB) UpsertSection(section Section) error {
 // UpsertImage inserts or replaces an image record.
 func (d *DB) UpsertImage(img Image) error {
 	_, err := d.conn.Exec(
-		"INSERT OR REPLACE INTO images (spec_id, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?)",
-		img.SpecID, img.Name, img.MIMEType, img.Data, img.LLMReadable,
+		"INSERT OR REPLACE INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, ?)",
+		img.SpecID, img.Version, img.Name, img.MIMEType, img.Data, img.LLMReadable,
 	)
 	return err
 }
 
-// GetImage retrieves a single image by spec ID and name.
-func (d *DB) GetImage(specID, name string) (*Image, error) {
+// GetImage retrieves a single image by spec ID, version and name.
+// An empty version resolves to the version this database holds.
+func (d *DB) GetImage(specID, version, name string) (*Image, error) {
+	version, err := d.ResolveVersion(specID, version)
+	if err != nil {
+		return nil, fmt.Errorf("get image: %w", err)
+	}
 	var img Image
-	err := d.conn.QueryRow(
-		"SELECT spec_id, name, mime_type, data, llm_readable FROM images WHERE spec_id = ? AND name = ?",
-		specID, name,
-	).Scan(&img.SpecID, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
+	err = d.conn.QueryRow(
+		"SELECT spec_id, version, name, mime_type, data, llm_readable FROM images WHERE spec_id = ? AND version = ? AND name = ?",
+		specID, version, name,
+	).Scan(&img.SpecID, &img.Version, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
 	if err != nil {
 		return nil, fmt.Errorf("get image: %w", err)
 	}
@@ -283,10 +402,18 @@ func (d *DB) GetImage(specID, name string) (*Image, error) {
 }
 
 // ListImages returns metadata for all images of a spec (without binary data).
-func (d *DB) ListImages(specID string) ([]ImageInfo, error) {
+// An empty version resolves to the version this database holds.
+func (d *DB) ListImages(specID, version string) ([]ImageInfo, error) {
+	version, err := d.ResolveVersion(specID, version)
+	if errors.Is(err, ErrNoVersion) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list images: %w", err)
+	}
 	rows, err := d.conn.Query(
-		"SELECT spec_id, name, mime_type, llm_readable FROM images WHERE spec_id = ? ORDER BY name",
-		specID,
+		"SELECT spec_id, version, name, mime_type, llm_readable FROM images WHERE spec_id = ? AND version = ? ORDER BY name",
+		specID, version,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list images: %w", err)
@@ -296,7 +423,7 @@ func (d *DB) ListImages(specID string) ([]ImageInfo, error) {
 	var infos []ImageInfo
 	for rows.Next() {
 		var info ImageInfo
-		if err := rows.Scan(&info.SpecID, &info.Name, &info.MIMEType, &info.LLMReadable); err != nil {
+		if err := rows.Scan(&info.SpecID, &info.Version, &info.Name, &info.MIMEType, &info.LLMReadable); err != nil {
 			return nil, fmt.Errorf("scan image info: %w", err)
 		}
 		infos = append(infos, info)
@@ -318,8 +445,8 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	defer tx.Rollback() // no-op after Commit per database/sql docs
 
 	_, err = tx.Exec(
-		"INSERT OR REPLACE INTO specs (id, title, version, release, series) VALUES (?, ?, ?, ?, ?)",
-		spec.ID, spec.Title, spec.Version, spec.Release, spec.Series,
+		"INSERT OR REPLACE INTO specs (id, version, version_token, title, release, series) VALUES (?, ?, ?, ?, ?, ?)",
+		spec.ID, spec.Version, spec.VersionToken, spec.Title, spec.Release, spec.Series,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert spec: %w", err)
@@ -332,7 +459,7 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	// for the spec, because multi-file specs (e.g. TS 36.133) call this function
 	// once per DOCX file and a bulk DELETE would erase previously processed sections.
 	delStmt, err := tx.Prepare(
-		"DELETE FROM sections WHERE spec_id = ? AND number = ?",
+		"DELETE FROM sections WHERE spec_id = ? AND version = ? AND number = ?",
 	)
 	if err != nil {
 		return fmt.Errorf("prepare delete: %w", err)
@@ -340,7 +467,7 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	defer delStmt.Close()
 
 	insStmt, err := tx.Prepare(
-		"INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?)",
+		"INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?, ?)",
 	)
 	if err != nil {
 		return fmt.Errorf("prepare insert: %w", err)
@@ -348,7 +475,7 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	defer insStmt.Close()
 
 	refStmt, err := tx.Prepare(
-		"INSERT OR REPLACE INTO spec_references (source_spec_id, source_section, target_spec, target_section, context) VALUES (?, ?, ?, ?, ?)",
+		"INSERT OR REPLACE INTO spec_references (source_spec_id, source_version, source_section, target_spec, target_section, context) VALUES (?, ?, ?, ?, ?, ?)",
 	)
 	if err != nil {
 		return fmt.Errorf("prepare ref insert: %w", err)
@@ -366,18 +493,39 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 		}
 	}
 
+	// A build imports one version per spec, and search depends on that: the FTS
+	// index has no version column, so a second version of the same spec would
+	// double every hit. Superseding a version therefore drops the old one.
+	// Multi-file specs call this once per DOCX with the same version, so this
+	// only fires on the first call.
+	for _, table := range []string{"sections", "images", "spec_references"} {
+		column, versionColumn := "spec_id", "version"
+		if table == "spec_references" {
+			column, versionColumn = "source_spec_id", "source_version"
+		}
+		q := fmt.Sprintf("DELETE FROM %s WHERE %s = ? AND %s <> ?", table, column, versionColumn)
+		if _, err = tx.Exec(q, spec.ID, spec.Version); err != nil {
+			return fmt.Errorf("drop superseded %s: %w", table, err)
+		}
+	}
+	if _, err = tx.Exec("DELETE FROM specs WHERE id = ? AND version <> ?", spec.ID, spec.Version); err != nil {
+		return fmt.Errorf("drop superseded spec versions: %w", err)
+	}
+
+	// The spec row is the authority on the version, so child rows take it from
+	// there rather than from their own field.
 	for _, s := range sections {
-		if _, err = delStmt.Exec(s.SpecID, s.Number); err != nil {
+		if _, err = delStmt.Exec(s.SpecID, spec.Version, s.Number); err != nil {
 			return fmt.Errorf("delete section: %w", err)
 		}
-		_, err = insStmt.Exec(s.SpecID, s.Number, s.Title, s.Level, s.ParentNumber, s.Content)
+		_, err = insStmt.Exec(s.SpecID, spec.Version, s.Number, s.Title, s.Level, s.ParentNumber, s.Content)
 		if err != nil {
 			return fmt.Errorf("insert section: %w", err)
 		}
 
 		refs := ExtractReferences(s.SpecID, s.Number, s.Content, bracketMap)
 		for _, r := range refs {
-			_, err = refStmt.Exec(r.SourceSpecID, r.SourceSection, r.TargetSpec, r.TargetSection, r.Context)
+			_, err = refStmt.Exec(r.SourceSpecID, spec.Version, r.SourceSection, r.TargetSpec, r.TargetSection, r.Context)
 			if err != nil {
 				return fmt.Errorf("insert reference: %w", err)
 			}
@@ -387,7 +535,7 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	// Insert images if provided.
 	if len(images) > 0 {
 		imgStmt, err := tx.Prepare(
-			"INSERT OR REPLACE INTO images (spec_id, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?)",
+			"INSERT OR REPLACE INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, ?)",
 		)
 		if err != nil {
 			return fmt.Errorf("prepare image insert: %w", err)
@@ -395,7 +543,7 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 		defer imgStmt.Close()
 
 		for _, img := range images {
-			_, err = imgStmt.Exec(img.SpecID, img.Name, img.MIMEType, img.Data, img.LLMReadable)
+			_, err = imgStmt.Exec(img.SpecID, spec.Version, img.Name, img.MIMEType, img.Data, img.LLMReadable)
 			if err != nil {
 				return fmt.Errorf("insert image: %w", err)
 			}
@@ -437,7 +585,7 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 		return nil, fmt.Errorf("count specs: %w", err)
 	}
 
-	sqlQuery := "SELECT id, title, COALESCE(version, ''), COALESCE(release, ''), COALESCE(series, '') FROM specs" + where + " ORDER BY id"
+	sqlQuery := "SELECT id, version, COALESCE(version_token, ''), title, COALESCE(release, ''), COALESCE(series, '') FROM specs" + where + " ORDER BY id, version"
 	args := append([]any{}, filterArgs...)
 
 	// limit == 0: use default; limit < 0: no limit (return all rows, internal use only).
@@ -461,7 +609,7 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 	var specs []Spec
 	for rows.Next() {
 		var s Spec
-		if err := rows.Scan(&s.ID, &s.Title, &s.Version, &s.Release, &s.Series); err != nil {
+		if err := rows.Scan(&s.ID, &s.Version, &s.VersionToken, &s.Title, &s.Release, &s.Series); err != nil {
 			return nil, fmt.Errorf("scan spec: %w", err)
 		}
 		specs = append(specs, s)
@@ -472,10 +620,19 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 	return &ListSpecsResult{Specs: specs, TotalCount: totalCount, Limit: limit, Offset: offset}, nil
 }
 
-func (d *DB) GetTOC(specID string) ([]Section, error) {
+// GetTOC returns the section structure of a spec. An empty version resolves to
+// the version this database holds; a version it does not hold yields no rows.
+func (d *DB) GetTOC(specID, version string) ([]Section, error) {
+	version, err := d.ResolveVersion(specID, version)
+	if errors.Is(err, ErrNoVersion) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get toc: %w", err)
+	}
 	rows, err := d.conn.Query(
-		"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? ORDER BY s.id",
-		specID,
+		"SELECT s.spec_id, s.version, s.number, s.title, s.level, COALESCE(s.parent_number, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE s.spec_id = ? AND s.version = ? ORDER BY s.id",
+		specID, version,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get toc: %w", err)
@@ -485,7 +642,7 @@ func (d *DB) GetTOC(specID string) ([]Section, error) {
 	var sections []Section
 	for rows.Next() {
 		var s Section
-		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Version, &s.Release); err != nil {
+		if err := rows.Scan(&s.SpecID, &s.Version, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Release); err != nil {
 			return nil, fmt.Errorf("scan section: %w", err)
 		}
 		sections = append(sections, s)
@@ -510,7 +667,7 @@ func escapeLikePattern(s string) string {
 // ID instead of a specific part.
 func (d *DB) FindSpecIDsByFamily(familyID string) ([]string, error) {
 	rows, err := d.conn.Query(
-		"SELECT id FROM specs WHERE id LIKE ? || '-%' ESCAPE '\\' ORDER BY id",
+		"SELECT DISTINCT id FROM specs WHERE id LIKE ? || '-%' ESCAPE '\\' ORDER BY id",
 		escapeLikePattern(familyID),
 	)
 	if err != nil {
@@ -532,19 +689,31 @@ func (d *DB) FindSpecIDsByFamily(familyID string) ([]string, error) {
 	return ids, nil
 }
 
-func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Section, error) {
-	var rows *sql.Rows
-	var err error
+// GetSection returns a section, optionally with its subsections. An empty
+// version resolves to the version this database holds; a version it does not
+// hold yields no rows.
+func (d *DB) GetSection(specID, version, number string, includeSubsections bool) ([]Section, error) {
+	version, err := d.ResolveVersion(specID, version)
+	if errors.Is(err, ErrNoVersion) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get section: %w", err)
+	}
 
+	const projection = "SELECT s.spec_id, s.version, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.release, '') " +
+		"FROM sections s LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE s.spec_id = ? AND s.version = ?"
+
+	var rows *sql.Rows
 	if includeSubsections {
 		rows, err = d.conn.Query(
-			"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
-			specID, number, number,
+			projection+" AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
+			specID, version, number, number,
 		)
 	} else {
 		rows, err = d.conn.Query(
-			"SELECT s.spec_id, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.version, ''), COALESCE(p.release, '') FROM sections s LEFT JOIN specs p ON p.id = s.spec_id WHERE s.spec_id = ? AND s.number = ?",
-			specID, number,
+			projection+" AND s.number = ?",
+			specID, version, number,
 		)
 	}
 	if err != nil {
@@ -555,7 +724,7 @@ func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Secti
 	var sections []Section
 	for rows.Next() {
 		var s Section
-		if err := rows.Scan(&s.SpecID, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Content, &s.Version, &s.Release); err != nil {
+		if err := rows.Scan(&s.SpecID, &s.Version, &s.Number, &s.Title, &s.Level, &s.ParentNumber, &s.Content, &s.Release); err != nil {
 			return nil, fmt.Errorf("scan section: %w", err)
 		}
 		sections = append(sections, s)
@@ -569,16 +738,23 @@ func (d *DB) GetSection(specID, number string, includeSubsections bool) ([]Secti
 // GetBracketMap returns the bracket reference map for a spec by fetching the
 // References section (number "2" or matching title) and parsing it.
 // Returns nil, nil when no References section is found.
-func (d *DB) GetBracketMap(specID string) (map[string]string, error) {
+func (d *DB) GetBracketMap(specID, version string) (map[string]string, error) {
+	version, err := d.ResolveVersion(specID, version)
+	if errors.Is(err, ErrNoVersion) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get bracket map: %w", err)
+	}
 	rows, err := d.conn.Query(
 		`SELECT content FROM sections
-		 WHERE spec_id = ? AND (
+		 WHERE spec_id = ? AND version = ? AND (
 		   number = '2' OR
 		   LOWER(title) = 'references' OR
 		   LOWER(title) = 'normative references' OR
 		   LOWER(title) = 'informative references'
 		 ) ORDER BY id LIMIT 1`,
-		specID,
+		specID, version,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get bracket map: %w", err)
@@ -782,7 +958,11 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 
 	query = sanitizeFTS5Query(query)
 
-	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), COALESCE(specs.version, ''), COALESCE(specs.release, '') FROM sections_fts LEFT JOIN specs ON specs.id = sections_fts.spec_id WHERE sections_fts MATCH ?"
+	// sections_fts has no version column, so the version comes from the backing
+	// sections row (sections_fts.rowid is sections.id). Joining specs on the
+	// pair keeps one row per hit even when a database holds several versions.
+	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
+		"FROM sections_fts JOIN sections s ON s.id = sections_fts.rowid LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE sections_fts MATCH ?"
 	args := []any{query}
 
 	if len(specIDs) > 0 {
@@ -1120,13 +1300,20 @@ func extractContext(content string, start, end int) string {
 	return b.String()
 }
 
-const refBaseQuery = `SELECT r.source_spec_id, r.source_section, r.target_spec, r.target_section, r.context,
-	COALESCE(s.title, '')
-	FROM spec_references r
-	LEFT JOIN sections s ON r.target_spec = s.spec_id AND r.target_section = s.number`
+// refBaseQuery takes the target title from whichever version of the target
+// spec this database holds; a reference names a spec, not a version of it. The
+// title is a scalar subquery rather than a join so a database holding several
+// versions of the target cannot duplicate the reference row.
+const refBaseQuery = `SELECT r.source_spec_id, r.source_version, r.source_section, r.target_spec, r.target_section, r.context,
+	COALESCE((SELECT s.title FROM sections s
+	          WHERE s.spec_id = r.target_spec AND s.number = r.target_section
+	          ORDER BY s.id LIMIT 1), '')
+	FROM spec_references r`
 
-// GetReferences retrieves cross-references in the given direction.
-func (d *DB) GetReferences(specID, sectionNumber, direction string, includeSubsections bool) ([]Reference, error) {
+// GetReferences retrieves cross-references in the given direction. For the
+// outgoing direction an empty version resolves to the version this database
+// holds; incoming references are not version-scoped on the target side.
+func (d *DB) GetReferences(specID, version, sectionNumber, direction string, includeSubsections bool) ([]Reference, error) {
 	if direction == "" {
 		direction = DirectionOutgoing
 	}
@@ -1135,14 +1322,21 @@ func (d *DB) GetReferences(specID, sectionNumber, direction string, includeSubse
 	var args []any
 	switch direction {
 	case DirectionOutgoing:
+		resolved, err := d.ResolveVersion(specID, version)
+		if errors.Is(err, ErrNoVersion) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get references: %w", err)
+		}
 		if includeSubsections {
-			where = ` WHERE r.source_spec_id = ? AND (r.source_section = ? OR r.source_section LIKE ? || '.%')
+			where = ` WHERE r.source_spec_id = ? AND r.source_version = ? AND (r.source_section = ? OR r.source_section LIKE ? || '.%')
 				ORDER BY r.source_section, r.target_spec, r.target_section`
-			args = []any{specID, sectionNumber, sectionNumber}
+			args = []any{specID, resolved, sectionNumber, sectionNumber}
 		} else {
-			where = ` WHERE r.source_spec_id = ? AND r.source_section = ?
+			where = ` WHERE r.source_spec_id = ? AND r.source_version = ? AND r.source_section = ?
 				ORDER BY r.target_spec, r.target_section`
-			args = []any{specID, sectionNumber}
+			args = []any{specID, resolved, sectionNumber}
 		}
 	case DirectionIncoming:
 		if sectionNumber != "" {
@@ -1171,7 +1365,7 @@ func (d *DB) queryReferences(query string, args []any) ([]Reference, error) {
 	var refs []Reference
 	for rows.Next() {
 		var r Reference
-		if err := rows.Scan(&r.SourceSpecID, &r.SourceSection, &r.TargetSpec, &r.TargetSection, &r.Context, &r.TargetTitle); err != nil {
+		if err := rows.Scan(&r.SourceSpecID, &r.SourceVersion, &r.SourceSection, &r.TargetSpec, &r.TargetSection, &r.Context, &r.TargetTitle); err != nil {
 			return nil, fmt.Errorf("scan reference: %w", err)
 		}
 		refs = append(refs, r)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -8,42 +8,42 @@ import (
 )
 
 const seedData = `
-INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 23.501', 'System architecture for the 5G System (5GS)', '18.6.0', 'Rel-18', '23'),
-    ('TS 29.510', 'Network Function Repository Services', '18.5.0', 'Rel-18', '29');
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 23.501', '18.6.0', 'i60', 'System architecture for the 5G System (5GS)', '18', '23'),
+    ('TS 29.510', '18.5.0', 'i50', 'Network Function Repository Services', '18', '29');
 
-INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 23.501', '1', 'Scope', 1, NULL, '# 1 Scope
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.6.0', '1', 'Scope', 1, NULL, '# 1 Scope
 This document defines the system architecture.'),
-    ('TS 23.501', '5', 'Architecture', 1, NULL, '# 5 Architecture
+    ('TS 23.501', '18.6.0', '5', 'Architecture', 1, NULL, '# 5 Architecture
 The 5G system architecture is defined here.'),
-    ('TS 23.501', '5.1', 'General', 2, '5', '## 5.1 General
+    ('TS 23.501', '18.6.0', '5.1', 'General', 2, '5', '## 5.1 General
 General architecture description for 5G.'),
-    ('TS 23.501', '5.1.1', 'Overview', 3, '5.1', '### 5.1.1 Overview
+    ('TS 23.501', '18.6.0', '5.1.1', 'Overview', 3, '5.1', '### 5.1.1 Overview
 Overview of the architecture components.'),
-    ('TS 29.510', '1', 'Scope', 1, NULL, '# 1 Scope
+    ('TS 29.510', '18.5.0', '1', 'Scope', 1, NULL, '# 1 Scope
 This document defines the NRF services.'),
-    ('TS 29.510', '6', 'API Definitions', 1, NULL, '# 6 API Definitions
+    ('TS 29.510', '18.5.0', '6', 'API Definitions', 1, NULL, '# 6 API Definitions
 API definitions for NRF.');
 
-INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 24.229', 'IP multimedia call control protocol', '18.4.0', 'Rel-18', '24');
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 24.229', '18.4.0', 'i40', 'IP multimedia call control protocol', '18', '24');
 
-INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 24.229', '5', 'Procedures', 1, NULL, '# 5 Procedures
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 24.229', '18.4.0', '5', 'Procedures', 1, NULL, '# 5 Procedures
 The IMS registration procedures.'),
-    ('TS 24.229', '5.1', 'Registration', 2, '5', '## 5.1 Registration
+    ('TS 24.229', '18.4.0', '5.1', 'Registration', 2, '5', '## 5.1 Registration
 The IMS registration procedures are specified in 3GPP TS 23.228 clause 5.2.1.
 The security mechanisms are defined in TS 33.203. See also RFC 3261 section 10.2
 for SIP registration details and IETF RFC 3327 for the Path header.
 The authentication uses IMS-AKA as described in TS 33.203 subclause 6.1.');
 
-INSERT INTO spec_references (source_spec_id, source_section, target_spec, target_section, context) VALUES
-    ('TS 24.229', '5.1', 'TS 23.228', '5.2.1', '...specified in 3GPP TS 23.228 clause 5.2.1...'),
-    ('TS 24.229', '5.1', 'TS 33.203', '', '...security mechanisms are defined in TS 33.203...'),
-    ('TS 24.229', '5.1', 'RFC 3261', '10.2', '...RFC 3261 section 10.2 for SIP registration...'),
-    ('TS 24.229', '5.1', 'RFC 3327', '', '...IETF RFC 3327 for the Path header...'),
-    ('TS 24.229', '5.1', 'TS 33.203', '6.1', '...IMS-AKA as described in TS 33.203 subclause 6.1...');
+INSERT INTO spec_references (source_spec_id, source_version, source_section, target_spec, target_section, context) VALUES
+    ('TS 24.229', '18.4.0', '5.1', 'TS 23.228', '5.2.1', '...specified in 3GPP TS 23.228 clause 5.2.1...'),
+    ('TS 24.229', '18.4.0', '5.1', 'TS 33.203', '', '...security mechanisms are defined in TS 33.203...'),
+    ('TS 24.229', '18.4.0', '5.1', 'RFC 3261', '10.2', '...RFC 3261 section 10.2 for SIP registration...'),
+    ('TS 24.229', '18.4.0', '5.1', 'RFC 3327', '', '...IETF RFC 3327 for the Path header...'),
+    ('TS 24.229', '18.4.0', '5.1', 'TS 33.203', '6.1', '...IMS-AKA as described in TS 33.203 subclause 6.1...');
 
 INSERT INTO openapi_specs (spec_id, api_name, version, filename, content) VALUES
     ('TS 29.510', 'Nnrf_NFManagement', 'v1.3.0', 'TS29510_Nnrf_NFManagement.yaml', 'openapi: 3.0.0
@@ -229,7 +229,7 @@ func TestGetTOC(t *testing.T) {
 	d := setupTestDB(t)
 
 	t.Run("existing spec", func(t *testing.T) {
-		sections, err := d.GetTOC("TS 23.501")
+		sections, err := d.GetTOC("TS 23.501", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,13 +239,13 @@ func TestGetTOC(t *testing.T) {
 		if sections[0].Number != "1" || sections[0].Title != "Scope" {
 			t.Errorf("unexpected first section: %+v", sections[0])
 		}
-		if sections[0].Version != "18.6.0" || sections[0].Release != "Rel-18" {
-			t.Errorf("expected version 18.6.0 / release Rel-18, got %+v", sections[0])
+		if sections[0].Version != "18.6.0" || sections[0].Release != "18" {
+			t.Errorf("expected version 18.6.0 / release 18, got %+v", sections[0])
 		}
 	})
 
 	t.Run("nonexistent spec", func(t *testing.T) {
-		sections, err := d.GetTOC("TS 99.999")
+		sections, err := d.GetTOC("TS 99.999", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -259,7 +259,7 @@ func TestGetSection(t *testing.T) {
 	d := setupTestDB(t)
 
 	t.Run("single section", func(t *testing.T) {
-		sections, err := d.GetSection("TS 23.501", "1", false)
+		sections, err := d.GetSection("TS 23.501", "", "1", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -269,13 +269,13 @@ func TestGetSection(t *testing.T) {
 		if sections[0].Content == "" {
 			t.Error("expected non-empty content")
 		}
-		if sections[0].Version != "18.6.0" || sections[0].Release != "Rel-18" {
-			t.Errorf("expected version 18.6.0 / release Rel-18, got %+v", sections[0])
+		if sections[0].Version != "18.6.0" || sections[0].Release != "18" {
+			t.Errorf("expected version 18.6.0 / release 18, got %+v", sections[0])
 		}
 	})
 
 	t.Run("with subsections", func(t *testing.T) {
-		sections, err := d.GetSection("TS 23.501", "5", true)
+		sections, err := d.GetSection("TS 23.501", "", "5", true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -285,7 +285,7 @@ func TestGetSection(t *testing.T) {
 	})
 
 	t.Run("without subsections", func(t *testing.T) {
-		sections, err := d.GetSection("TS 23.501", "5", false)
+		sections, err := d.GetSection("TS 23.501", "", "5", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -295,7 +295,7 @@ func TestGetSection(t *testing.T) {
 	})
 
 	t.Run("nonexistent section", func(t *testing.T) {
-		sections, err := d.GetSection("TS 23.501", "99", false)
+		sections, err := d.GetSection("TS 23.501", "", "99", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -424,8 +424,8 @@ func TestSearch(t *testing.T) {
 		if results[0].SpecID != "TS 29.510" {
 			t.Errorf("expected spec_id 'TS 29.510', got %q", results[0].SpecID)
 		}
-		if results[0].Version != "18.5.0" || results[0].Release != "Rel-18" {
-			t.Errorf("expected version 18.5.0 / release Rel-18, got %+v", results[0])
+		if results[0].Version != "18.5.0" || results[0].Release != "18" {
+			t.Errorf("expected version 18.5.0 / release 18, got %+v", results[0])
 		}
 	})
 
@@ -451,9 +451,9 @@ func TestSearch(t *testing.T) {
 
 	t.Run("hyphenated term does not error", func(t *testing.T) {
 		// Insert a section with a hyphenated term.
-		err := d.ExecScript(`INSERT INTO specs (id, title) VALUES ('TS 33.203', 'IMS Security') ON CONFLICT DO NOTHING;
-INSERT OR REPLACE INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 33.203', '1', 'Scope', 1, NULL, '# 1 Scope
+		err := d.ExecScript(`INSERT INTO specs (id, version, title) VALUES ('TS 33.203', '', 'IMS Security') ON CONFLICT DO NOTHING;
+INSERT OR REPLACE INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 33.203', '', '1', 'Scope', 1, NULL, '# 1 Scope
 This document covers IMS-AKA and sec-agree mechanisms.');`)
 		if err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
@@ -472,10 +472,10 @@ This document covers IMS-AKA and sec-agree mechanisms.');`)
 	})
 
 	t.Run("family spec id matches split parts", func(t *testing.T) {
-		err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 38.101-1', 'User Equipment radio transmission and reception; Part 1', '18.6.0', 'Rel-18', '38');
-INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 38.101-1', '5.3A.3', 'Guardband', 2, '5', '## 5.3A.3 Guardband
+		err := d.ExecScript(`INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 38.101-1', '18.6.0', 'i60', 'User Equipment radio transmission and reception; Part 1', '18', '38');
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 38.101-1', '18.6.0', '5.3A.3', 'Guardband', 2, '5', '## 5.3A.3 Guardband
 The guardband requirements are specified here.');`)
 		if err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
@@ -780,7 +780,7 @@ func TestGetReferences(t *testing.T) {
 	d := setupTestDB(t)
 
 	t.Run("outgoing", func(t *testing.T) {
-		refs, err := d.GetReferences("TS 24.229", "5.1", "outgoing", false)
+		refs, err := d.GetReferences("TS 24.229", "", "5.1", "outgoing", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -790,7 +790,7 @@ func TestGetReferences(t *testing.T) {
 	})
 
 	t.Run("outgoing with subsections", func(t *testing.T) {
-		refs, err := d.GetReferences("TS 24.229", "5", "outgoing", true)
+		refs, err := d.GetReferences("TS 24.229", "", "5", "outgoing", true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -801,7 +801,7 @@ func TestGetReferences(t *testing.T) {
 	})
 
 	t.Run("incoming", func(t *testing.T) {
-		refs, err := d.GetReferences("TS 33.203", "", "incoming", false)
+		refs, err := d.GetReferences("TS 33.203", "", "", "incoming", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -812,7 +812,7 @@ func TestGetReferences(t *testing.T) {
 	})
 
 	t.Run("incoming with section", func(t *testing.T) {
-		refs, err := d.GetReferences("TS 33.203", "6.1", "incoming", false)
+		refs, err := d.GetReferences("TS 33.203", "", "6.1", "incoming", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -828,7 +828,7 @@ func TestGetReferences(t *testing.T) {
 	})
 
 	t.Run("no results", func(t *testing.T) {
-		refs, err := d.GetReferences("TS 99.999", "", "incoming", false)
+		refs, err := d.GetReferences("TS 99.999", "", "", "incoming", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -838,7 +838,7 @@ func TestGetReferences(t *testing.T) {
 	})
 
 	t.Run("invalid direction", func(t *testing.T) {
-		_, err := d.GetReferences("TS 24.229", "5.1", "sideways", false)
+		_, err := d.GetReferences("TS 24.229", "", "5.1", "sideways", false)
 		if err == nil {
 			t.Fatal("expected error for invalid direction")
 		}
@@ -865,7 +865,7 @@ func TestInsertSpecWithSections_References(t *testing.T) {
 	}
 
 	// Verify references were auto-extracted
-	refs, err := d.GetReferences("TS 99.001", "1", "outgoing", false)
+	refs, err := d.GetReferences("TS 99.001", "", "1", "outgoing", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1035,7 +1035,7 @@ func TestInsertSpecWithSections_BracketedRefs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	refs, err := d.GetReferences("TS 99.002", "5", "outgoing", false)
+	refs, err := d.GetReferences("TS 99.002", "", "5", "outgoing", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1120,8 +1120,8 @@ func TestExec_DirectSQL(t *testing.T) {
 
 	// Insert a new spec via Exec directly.
 	if err := d.Exec(
-		"INSERT INTO specs (id, title, series) VALUES (?, ?, ?)",
-		"TS 99.123", "Exec-inserted", "99",
+		"INSERT INTO specs (id, version, title, series) VALUES (?, ?, ?, ?)",
+		"TS 99.123", "1.0.0", "Exec-inserted", "99",
 	); err != nil {
 		t.Fatalf("Exec insert: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestUpsertSpec_Replaces(t *testing.T) {
 
 	// Existing spec from seed data: TS 23.501 version 18.6.0
 	if err := d.UpsertSpec(Spec{
-		ID: "TS 23.501", Title: "Updated", Version: "k10", Release: "Rel-20", Series: "23",
+		ID: "TS 23.501", Title: "Updated", Version: "18.6.0", VersionToken: "i60", Release: "20", Series: "23",
 	}); err != nil {
 		t.Fatalf("UpsertSpec: %v", err)
 	}
@@ -1166,7 +1166,7 @@ func TestUpsertSpec_Replaces(t *testing.T) {
 	if found == nil {
 		t.Fatal("TS 23.501 missing after upsert")
 	}
-	if found.Title != "Updated" || found.Version != "k10" || found.Release != "Rel-20" {
+	if found.Title != "Updated" || found.Version != "18.6.0" || found.Release != "20" {
 		t.Errorf("upsert did not overwrite fields: %+v", found)
 	}
 }
@@ -1181,6 +1181,7 @@ func TestUpsertSection_ReplacesContent(t *testing.T) {
 	// follows suit.
 	if err := d.UpsertSection(Section{
 		SpecID:  "TS 23.501",
+		Version: "18.6.0",
 		Number:  "1",
 		Title:   "Scope",
 		Level:   1,
@@ -1189,7 +1190,7 @@ func TestUpsertSection_ReplacesContent(t *testing.T) {
 		t.Fatalf("UpsertSection: %v", err)
 	}
 
-	sections, err := d.GetSection("TS 23.501", "1", false)
+	sections, err := d.GetSection("TS 23.501", "", "1", false)
 	if err != nil {
 		t.Fatalf("GetSection: %v", err)
 	}
@@ -1218,6 +1219,7 @@ func TestImageCRUD(t *testing.T) {
 	payload := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad}
 	img := Image{
 		SpecID:      "TS 23.501",
+		Version:     "18.6.0",
 		Name:        "fig1.png",
 		MIMEType:    "image/png",
 		Data:        payload,
@@ -1233,7 +1235,7 @@ func TestImageCRUD(t *testing.T) {
 		t.Fatalf("UpsertImage (replace): %v", err)
 	}
 
-	got, err := d.GetImage("TS 23.501", "fig1.png")
+	got, err := d.GetImage("TS 23.501", "", "fig1.png")
 	if err != nil {
 		t.Fatalf("GetImage: %v", err)
 	}
@@ -1248,12 +1250,12 @@ func TestImageCRUD(t *testing.T) {
 	}
 
 	// Missing image.
-	if _, err := d.GetImage("TS 23.501", "missing.png"); err == nil {
+	if _, err := d.GetImage("TS 23.501", "", "missing.png"); err == nil {
 		t.Error("expected error for missing image")
 	}
 
 	// ListImages returns only the inserted image.
-	infos, err := d.ListImages("TS 23.501")
+	infos, err := d.ListImages("TS 23.501", "")
 	if err != nil {
 		t.Fatalf("ListImages: %v", err)
 	}
@@ -1262,7 +1264,7 @@ func TestImageCRUD(t *testing.T) {
 	}
 
 	// Empty spec → empty result.
-	infos, err = d.ListImages("TS 00.000")
+	infos, err = d.ListImages("TS 00.000", "")
 	if err != nil {
 		t.Fatalf("ListImages empty: %v", err)
 	}
@@ -1278,13 +1280,13 @@ func TestGetBracketMap(t *testing.T) {
 
 	// Insert a References section into TS 23.501.
 	if err := d.UpsertSection(Section{
-		SpecID: "TS 23.501", Number: "2", Title: "References", Level: 1,
+		SpecID: "TS 23.501", Version: "18.6.0", Number: "2", Title: "References", Level: 1,
 		Content: "## 2 References\n\n[1]\t3GPP TS 29.510: \"NRF\"\n[2]\t3GPP TR 23.700: \"Study\"",
 	}); err != nil {
 		t.Fatalf("UpsertSection: %v", err)
 	}
 
-	m, err := d.GetBracketMap("TS 23.501")
+	m, err := d.GetBracketMap("TS 23.501", "")
 	if err != nil {
 		t.Fatalf("GetBracketMap: %v", err)
 	}
@@ -1296,7 +1298,7 @@ func TestGetBracketMap(t *testing.T) {
 	}
 
 	// TS 29.510 has no References section in seed data → expect nil.
-	m2, err := d.GetBracketMap("TS 29.510")
+	m2, err := d.GetBracketMap("TS 29.510", "")
 	if err != nil {
 		t.Fatalf("GetBracketMap empty: %v", err)
 	}
@@ -1324,7 +1326,7 @@ func TestInsertSpecWithSections_MultiSectionRefs(t *testing.T) {
 		t.Fatalf("InsertSpecWithSections: %v", err)
 	}
 
-	refs, err := d.GetReferences("TS 99.003", "5", "outgoing", false)
+	refs, err := d.GetReferences("TS 99.003", "", "5", "outgoing", false)
 	if err != nil {
 		t.Fatalf("GetReferences: %v", err)
 	}

--- a/internal/specver/specver.go
+++ b/internal/specver/specver.go
@@ -1,0 +1,167 @@
+// Package specver converts between the two 3GPP specification version
+// notations: the dotted form used in documents ("18.6.0") and the base-36
+// token used in archive filenames ("i60").
+//
+// An archive token is three base-36 digits holding the release, technical and
+// editorial numbers respectively, so "k20" is v20.2.0 and "fa0" is v15.10.0.
+// Components above 35 do not fit in a single digit and cannot be encoded.
+package specver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// tokenLength is the number of base-36 digits in an archive version token.
+const tokenLength = 3
+
+// maxComponent is the largest version component a single base-36 digit holds.
+const maxComponent = 35
+
+// digitValue returns the numeric value of a base-36 digit, or -1 if c is not one.
+func digitValue(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'z':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'Z':
+		return int(c-'A') + 10
+	default:
+		return -1
+	}
+}
+
+// digitChar returns the lowercase base-36 digit for v, which must be 0..35.
+func digitChar(v int) byte {
+	if v < 10 {
+		return byte('0' + v)
+	}
+	return byte('a' + v - 10)
+}
+
+// TokenToDotted converts an archive version token to the dotted form.
+// It reports false for tokens that are not exactly three base-36 digits.
+func TokenToDotted(token string) (string, bool) {
+	if len(token) != tokenLength {
+		return "", false
+	}
+	parts := make([]string, tokenLength)
+	for i := range tokenLength {
+		v := digitValue(token[i])
+		if v < 0 {
+			return "", false
+		}
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, "."), true
+}
+
+// DottedToToken converts a dotted version to the archive token form.
+// It reports false unless the version has three components, each 0..35.
+func DottedToToken(dotted string) (string, bool) {
+	parts := strings.Split(dotted, ".")
+	if len(parts) != tokenLength {
+		return "", false
+	}
+	token := make([]byte, tokenLength)
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 || v > maxComponent {
+			return "", false
+		}
+		token[i] = digitChar(v)
+	}
+	return string(token), true
+}
+
+// IsDotted reports whether s looks like a dotted version ("18.6.0").
+func IsDotted(s string) bool {
+	return strings.Contains(s, ".")
+}
+
+// Normalize accepts either notation and returns both. When only one of the two
+// can be derived, the other is returned empty rather than guessed: unusual
+// tokens (not three digits) and versions with a component above 35 have no
+// counterpart, and callers display whichever form they have.
+func Normalize(s string) (dotted, token string, err error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	s = strings.TrimPrefix(s, "V")
+	if s == "" {
+		return "", "", fmt.Errorf("empty version")
+	}
+
+	if IsDotted(s) {
+		if t, ok := DottedToToken(s); ok {
+			return s, t, nil
+		}
+		if len(strings.Split(s, ".")) != tokenLength {
+			return "", "", fmt.Errorf("invalid version %q: expected three dot-separated components", s)
+		}
+		return s, "", nil
+	}
+
+	s = strings.ToLower(s)
+	if d, ok := TokenToDotted(s); ok {
+		return d, s, nil
+	}
+	return "", s, nil
+}
+
+// ReleaseOf returns the release number of a dotted version, e.g. "20" for
+// "20.2.0". It returns an empty string when v is not a dotted version.
+func ReleaseOf(v string) string {
+	i := strings.Index(v, ".")
+	if i <= 0 {
+		return ""
+	}
+	if _, err := strconv.Atoi(v[:i]); err != nil {
+		return ""
+	}
+	return v[:i]
+}
+
+// ReleaseLabel formats a release number for display, e.g. "Rel-18". A value
+// that is not a plain number is returned unchanged so odd data still shows.
+func ReleaseLabel(release string) string {
+	if release == "" {
+		return ""
+	}
+	if _, err := strconv.Atoi(release); err != nil {
+		return release
+	}
+	return "Rel-" + release
+}
+
+// Compare orders two dotted versions numerically component by component.
+// Non-numeric or missing components sort below numeric ones, so malformed
+// values never win a "latest version" comparison.
+func Compare(a, b string) int {
+	pa, pb := strings.Split(a, "."), strings.Split(b, ".")
+	n := max(len(pa), len(pb))
+	for i := range n {
+		va, vb := componentAt(pa, i), componentAt(pb, i)
+		if va != vb {
+			if va < vb {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// componentAt returns the numeric value of the i-th component, or -1 when it
+// is absent or not a number.
+func componentAt(parts []string, i int) int {
+	if i >= len(parts) {
+		return -1
+	}
+	v, err := strconv.Atoi(parts[i])
+	if err != nil {
+		return -1
+	}
+	return v
+}

--- a/internal/specver/specver_test.go
+++ b/internal/specver/specver_test.go
@@ -1,0 +1,157 @@
+package specver
+
+import "testing"
+
+func TestTokenToDotted(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+		ok    bool
+	}{
+		{"k20", "20.2.0", true},
+		{"fa0", "15.10.0", true},
+		{"300", "3.0.0", true},
+		{"i60", "18.6.0", true},
+		{"j50", "19.5.0", true},
+		{"a01", "10.0.1", true},
+		{"zzz", "35.35.35", true},
+		{"K20", "20.2.0", true},
+		{"k2", "", false},
+		{"k200", "", false},
+		{"k-0", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := TokenToDotted(tt.token)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("TokenToDotted(%q) = %q, %v; want %q, %v", tt.token, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestDottedToToken(t *testing.T) {
+	tests := []struct {
+		dotted string
+		want   string
+		ok     bool
+	}{
+		{"20.2.0", "k20", true},
+		{"15.10.0", "fa0", true},
+		{"3.0.0", "300", true},
+		{"35.35.35", "zzz", true},
+		{"36.0.0", "", false},  // component above 35 has no single digit
+		{"18.36.0", "", false}, // ditto for the technical component
+		{"18.6", "", false},
+		{"18.6.0.1", "", false},
+		{"x.y.z", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := DottedToToken(tt.dotted)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("DottedToToken(%q) = %q, %v; want %q, %v", tt.dotted, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	for _, token := range []string{"000", "k20", "fa0", "300", "zzz", "9z1"} {
+		dotted, ok := TokenToDotted(token)
+		if !ok {
+			t.Fatalf("TokenToDotted(%q) failed", token)
+		}
+		back, ok := DottedToToken(dotted)
+		if !ok || back != token {
+			t.Errorf("round trip %q -> %q -> %q, ok=%v", token, dotted, back, ok)
+		}
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		in      string
+		dotted  string
+		token   string
+		wantErr bool
+		desc    string
+	}{
+		{in: "20.2.0", dotted: "20.2.0", token: "k20", desc: "dotted input"},
+		{in: "k20", dotted: "20.2.0", token: "k20", desc: "token input"},
+		{in: "K20", dotted: "20.2.0", token: "k20", desc: "uppercase token"},
+		{in: "v18.6.0", dotted: "18.6.0", token: "i60", desc: "v prefix"},
+		{in: " 18.6.0 ", dotted: "18.6.0", token: "i60", desc: "surrounding space"},
+		{in: "36.0.0", dotted: "36.0.0", token: "", desc: "no token counterpart"},
+		{in: "k2", dotted: "", token: "k2", desc: "odd token kept as-is"},
+		{in: "18.6", wantErr: true, desc: "two components"},
+		{in: "", wantErr: true, desc: "empty"},
+	}
+	for _, tt := range tests {
+		dotted, token, err := Normalize(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("Normalize(%q) [%s]: want error, got %q/%q", tt.in, tt.desc, dotted, token)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Normalize(%q) [%s]: unexpected error: %v", tt.in, tt.desc, err)
+			continue
+		}
+		if dotted != tt.dotted || token != tt.token {
+			t.Errorf("Normalize(%q) [%s] = %q, %q; want %q, %q", tt.in, tt.desc, dotted, token, tt.dotted, tt.token)
+		}
+	}
+}
+
+func TestReleaseOf(t *testing.T) {
+	tests := map[string]string{
+		"20.2.0":  "20",
+		"3.0.0":   "3",
+		"18.6.0":  "18",
+		"k20":     "",
+		"":        "",
+		".2.0":    "",
+		"x.2.0":   "",
+		"20.2.0.": "20",
+	}
+	for in, want := range tests {
+		if got := ReleaseOf(in); got != want {
+			t.Errorf("ReleaseOf(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestReleaseLabel(t *testing.T) {
+	tests := map[string]string{
+		"18":     "Rel-18",
+		"20":     "Rel-20",
+		"":       "",
+		"Rel-18": "Rel-18",
+	}
+	for in, want := range tests {
+		if got := ReleaseLabel(in); got != want {
+			t.Errorf("ReleaseLabel(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"18.6.0", "18.6.0", 0},
+		{"18.6.0", "18.7.0", -1},
+		{"18.7.0", "18.6.0", 1},
+		{"9.0.0", "10.0.0", -1}, // numeric, not lexicographic
+		{"20.2.0", "3.0.0", 1},
+		{"18.6.0", "18.6", 1}, // longer beats a missing component
+		{"", "18.6.0", -1},    // malformed sorts below
+		{"junk", "junk", 0},
+	}
+	for _, tt := range tests {
+		if got := Compare(tt.a, tt.b); got != tt.want {
+			t.Errorf("Compare(%q, %q) = %d; want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -13,42 +13,42 @@ import (
 
 // SeedData is the canonical seed SQL used across test packages.
 const SeedData = `
-INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 23.501', 'System architecture for the 5G System (5GS)', '18.6.0', 'Rel-18', '23'),
-    ('TS 29.510', 'Network Function Repository Services', '18.5.0', 'Rel-18', '29');
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 23.501', '18.6.0', 'i60', 'System architecture for the 5G System (5GS)', '18', '23'),
+    ('TS 29.510', '18.5.0', 'i50', 'Network Function Repository Services', '18', '29');
 
-INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 23.501', '1', 'Scope', 1, NULL, '# 1 Scope
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.6.0', '1', 'Scope', 1, NULL, '# 1 Scope
 This document defines the system architecture.'),
-    ('TS 23.501', '5', 'Architecture', 1, NULL, '# 5 Architecture
+    ('TS 23.501', '18.6.0', '5', 'Architecture', 1, NULL, '# 5 Architecture
 The 5G system architecture is defined here.'),
-    ('TS 23.501', '5.1', 'General', 2, '5', '## 5.1 General
+    ('TS 23.501', '18.6.0', '5.1', 'General', 2, '5', '## 5.1 General
 General architecture description for 5G.'),
-    ('TS 23.501', '5.1.1', 'Overview', 3, '5.1', '### 5.1.1 Overview
+    ('TS 23.501', '18.6.0', '5.1.1', 'Overview', 3, '5.1', '### 5.1.1 Overview
 Overview of the architecture components.'),
-    ('TS 29.510', '1', 'Scope', 1, NULL, '# 1 Scope
+    ('TS 29.510', '18.5.0', '1', 'Scope', 1, NULL, '# 1 Scope
 This document defines the NRF services.'),
-    ('TS 29.510', '6', 'API Definitions', 1, NULL, '# 6 API Definitions
+    ('TS 29.510', '18.5.0', '6', 'API Definitions', 1, NULL, '# 6 API Definitions
 API definitions for NRF.');
 
-INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 24.229', 'IP multimedia call control protocol', '18.4.0', 'Rel-18', '24');
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 24.229', '18.4.0', 'i40', 'IP multimedia call control protocol', '18', '24');
 
-INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 24.229', '5', 'Procedures', 1, NULL, '# 5 Procedures
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 24.229', '18.4.0', '5', 'Procedures', 1, NULL, '# 5 Procedures
 The IMS registration procedures.'),
-    ('TS 24.229', '5.1', 'Registration', 2, '5', '## 5.1 Registration
+    ('TS 24.229', '18.4.0', '5.1', 'Registration', 2, '5', '## 5.1 Registration
 The IMS registration procedures are specified in 3GPP TS 23.228 clause 5.2.1.
 The security mechanisms are defined in TS 33.203. See also RFC 3261 section 10.2
 for SIP registration details and IETF RFC 3327 for the Path header.
 The authentication uses IMS-AKA as described in TS 33.203 subclause 6.1.');
 
-INSERT INTO spec_references (source_spec_id, source_section, target_spec, target_section, context) VALUES
-    ('TS 24.229', '5.1', 'TS 23.228', '5.2.1', '...specified in 3GPP TS 23.228 clause 5.2.1...'),
-    ('TS 24.229', '5.1', 'TS 33.203', '', '...security mechanisms are defined in TS 33.203...'),
-    ('TS 24.229', '5.1', 'RFC 3261', '10.2', '...RFC 3261 section 10.2 for SIP registration...'),
-    ('TS 24.229', '5.1', 'RFC 3327', '', '...IETF RFC 3327 for the Path header...'),
-    ('TS 24.229', '5.1', 'TS 33.203', '6.1', '...IMS-AKA as described in TS 33.203 subclause 6.1...');
+INSERT INTO spec_references (source_spec_id, source_version, source_section, target_spec, target_section, context) VALUES
+    ('TS 24.229', '18.4.0', '5.1', 'TS 23.228', '5.2.1', '...specified in 3GPP TS 23.228 clause 5.2.1...'),
+    ('TS 24.229', '18.4.0', '5.1', 'TS 33.203', '', '...security mechanisms are defined in TS 33.203...'),
+    ('TS 24.229', '18.4.0', '5.1', 'RFC 3261', '10.2', '...RFC 3261 section 10.2 for SIP registration...'),
+    ('TS 24.229', '18.4.0', '5.1', 'RFC 3327', '', '...IETF RFC 3327 for the Path header...'),
+    ('TS 24.229', '18.4.0', '5.1', 'TS 33.203', '6.1', '...IMS-AKA as described in TS 33.203 subclause 6.1...');
 
 INSERT INTO openapi_specs (spec_id, api_name, version, filename, content) VALUES
     ('TS 29.510', 'Nnrf_NFManagement', 'v1.3.0', 'TS29510_Nnrf_NFManagement.yaml', 'openapi: 3.0.0

--- a/tools/get_image.go
+++ b/tools/get_image.go
@@ -27,7 +27,9 @@ func HandleGetImage(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest
 			return errorResult("name is required"), nil, nil
 		}
 
-		img, err := d.GetImage(input.SpecID, input.Name)
+		// Images are only imported for the version the database was built with,
+		// so this always answers about that version.
+		img, err := d.GetImage(input.SpecID, "", input.Name)
 		if err != nil {
 			return errorResult(fmt.Sprintf("image not found: %v", err)), nil, nil
 		}

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -12,6 +12,7 @@ import (
 type GetSectionInput struct {
 	SpecID             string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
 	SectionNumber      string `json:"section_number" jsonschema:"required,Section number to retrieve (e.g. 5.1.2)"`
+	Version            string `json:"version,omitempty" jsonschema:"Specification version to read (e.g. 18.6.0). Also accepts an archive token (i60) or a release selector (Rel-18). Defaults to the version in the database. Use list_versions to see what exists."`
 	IncludeSubsections bool   `json:"include_subsections,omitempty" jsonschema:"Include all subsections (default: false)"`
 	Offset             int    `json:"offset,omitempty" jsonschema:"Start line number (0-based, default: 0)"`
 	MaxLines           int    `json:"max_lines,omitempty" jsonschema:"Maximum number of lines to return (default: 200, 0 = all)"`
@@ -20,10 +21,10 @@ type GetSectionInput struct {
 
 var GetSectionTool = &mcp.Tool{
 	Name:        "get_section",
-	Description: "Get the markdown content of a specific section in a 3GPP specification. This tool is for reading specification document text (architecture, procedures, requirements). For API details such as HTTP request/response bodies, paths, and data models of 5G service-based interfaces (TS 29.xxx series), use get_openapi instead. Specify the section number with the `section_number` parameter (e.g. 5.1.2). Large sections are paginated (default 200 lines). Use offset and max_lines to navigate.",
+	Description: "Get the markdown content of a specific section in a 3GPP specification. This tool is for reading specification document text (architecture, procedures, requirements). For API details such as HTTP request/response bodies, paths, and data models of 5G service-based interfaces (TS 29.xxx series), use get_openapi instead. Specify the section number with the `section_number` parameter (e.g. 5.1.2). Pass `version` to read a past version, which is downloaded and converted on first use; call list_versions first to see which versions exist. Large sections are paginated (default 200 lines). Use offset and max_lines to navigate.",
 }
 
-func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionInput) (*mcp.CallToolResult, any, error) {
+func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionInput) (*mcp.CallToolResult, any, error) {
 		if input.SpecID == "" {
 			return errorResult("spec_id is required"), nil, nil
@@ -32,16 +33,16 @@ func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			return errorResult("section_number is required"), nil, nil
 		}
 
-		sections, err := d.GetSection(input.SpecID, input.SectionNumber, input.IncludeSubsections)
+		sections, res, err := src.GetSection(ctx, input.SpecID, input.Version, input.SectionNumber, input.IncludeSubsections)
 		if err != nil {
-			return errorResult(fmt.Sprintf("failed to get section: %v", err)), nil, nil
+			return versionErrorResult(err, "failed to get section"), nil, nil
 		}
 
 		if len(sections) == 0 {
-			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+			if parts, partsErr := src.DB.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
 				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 			}
-			return errorResult(fmt.Sprintf("section %s not found in %s", input.SectionNumber, input.SpecID)), nil, nil
+			return errorResult(fmt.Sprintf("section %s not found in %s%s", input.SectionNumber, input.SpecID, versionSuffix(res))), nil, nil
 		}
 
 		// Combine all section content
@@ -51,17 +52,31 @@ func HandleGetSection(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			full.WriteString("\n\n")
 		}
 
-		res := paginateText(full.String(), input.Offset, input.MaxLines, input.MaxChars)
-		return prependLine(sourceHeader(sections[0], input.IncludeSubsections && len(sections) > 1), res), nil, nil
+		result := paginateText(full.String(), input.Offset, input.MaxLines, input.MaxChars)
+		header := sourceHeader(sections[0], input.IncludeSubsections && len(sections) > 1, res.archived)
+		return prependLine(header, result), nil, nil
 	}
 }
 
 // sourceHeader builds the provenance line prepended to every get_section page,
-// e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]".
-func sourceHeader(s db.Section, withSubsections bool) string {
+// e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]". Archived versions
+// say so, because get_image and get_references only cover the version the
+// database was built with and would silently answer about a different one.
+func sourceHeader(s db.Section, withSubsections, archived bool) string {
 	h := fmt.Sprintf("[Source: %s — Section %s", specLabel(s), s.Number)
 	if withSubsections {
 		h += " (+subsections)"
 	}
+	if archived {
+		h += " (archived version; images and cross-references unavailable)"
+	}
 	return h + "]"
+}
+
+// versionSuffix names the version in a not-found message when one was resolved.
+func versionSuffix(res resolution) string {
+	if res.version == "" {
+		return ""
+	}
+	return " v" + res.version
 }

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -5,35 +5,35 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type GetTOCInput struct {
-	SpecID string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+	SpecID  string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+	Version string `json:"version,omitempty" jsonschema:"Specification version to read (e.g. 18.6.0). Also accepts an archive token (i60) or a release selector (Rel-18). Defaults to the version in the database. Use list_versions to see what exists."`
 }
 
 var GetTOCTool = &mcp.Tool{
 	Name:        "get_toc",
-	Description: "Get the table of contents (section structure) of a 3GPP specification.",
+	Description: "Get the table of contents (section structure) of a 3GPP specification. Pass `version` to see the structure of a past version, which is downloaded and converted on first use; section numbers often move between releases, so check the table of contents before reading a section of an older version.",
 }
 
-func HandleGetTOC(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input GetTOCInput) (*mcp.CallToolResult, any, error) {
+func HandleGetTOC(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input GetTOCInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input GetTOCInput) (*mcp.CallToolResult, any, error) {
 		if input.SpecID == "" {
 			return errorResult("spec_id is required"), nil, nil
 		}
 
-		sections, err := d.GetTOC(input.SpecID)
+		sections, res, err := src.GetTOC(ctx, input.SpecID, input.Version)
 		if err != nil {
-			return errorResult(fmt.Sprintf("failed to get TOC: %v", err)), nil, nil
+			return versionErrorResult(err, "failed to get TOC"), nil, nil
 		}
 
 		if len(sections) == 0 {
-			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+			if parts, partsErr := src.DB.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
 				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 			}
-			return errorResult(fmt.Sprintf("no sections found for %s", input.SpecID)), nil, nil
+			return errorResult(fmt.Sprintf("no sections found for %s%s", input.SpecID, versionSuffix(res))), nil, nil
 		}
 
 		var sb strings.Builder

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -1,10 +1,12 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -21,6 +23,21 @@ func errorResult(text string) *mcp.CallToolResult {
 		Content: []mcp.Content{&mcp.TextContent{Text: text}},
 		IsError: true,
 	}
+}
+
+// versionErrorResult renders an error from version resolution. A fetch that is
+// still running is not a failure — the caller just has to come back — so it is
+// reported as ordinary text rather than as a tool error.
+func versionErrorResult(err error, prefix string) *mcp.CallToolResult {
+	var inProgress *errFetchInProgress
+	if errors.As(err, &inProgress) {
+		return textResult(inProgress.Error())
+	}
+	var unavailable *errVersionUnavailable
+	if errors.As(err, &unavailable) {
+		return errorResult(unavailable.Error())
+	}
+	return errorResult(fmt.Sprintf("%s: %v", prefix, err))
 }
 
 // prependLine prefixes the text content of a single-TextContent result with a
@@ -43,8 +60,8 @@ func specLabel(s db.Section) string {
 	if s.Version != "" {
 		label += " v" + s.Version
 	}
-	if s.Release != "" {
-		label += " (" + s.Release + ")"
+	if rel := specver.ReleaseLabel(s.Release); rel != "" {
+		label += " (" + rel + ")"
 	}
 	return label
 }

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -14,6 +14,7 @@ func seedImages(t *testing.T, d *db.DB) {
 	images := []db.Image{
 		{
 			SpecID:      "TS 23.501",
+			Version:     "18.6.0",
 			Name:        "image1.png",
 			MIMEType:    "image/png",
 			Data:        []byte("\x89PNG\r\n\x1a\nfake-png-data"),
@@ -21,6 +22,7 @@ func seedImages(t *testing.T, d *db.DB) {
 		},
 		{
 			SpecID:      "TS 23.501",
+			Version:     "18.6.0",
 			Name:        "image2.emf",
 			MIMEType:    "image/x-emf",
 			Data:        []byte("fake-emf-data"),
@@ -28,6 +30,7 @@ func seedImages(t *testing.T, d *db.DB) {
 		},
 		{
 			SpecID:      "TS 29.510",
+			Version:     "18.5.0",
 			Name:        "diagram.png",
 			MIMEType:    "image/png",
 			Data:        []byte("\x89PNG\r\n\x1a\nother-spec-data"),
@@ -102,9 +105,9 @@ func TestHandleListImages(t *testing.T) {
 	})
 
 	t.Run("family spec id with multiple parts", func(t *testing.T) {
-		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
-    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+		if err := d.ExecScript(`INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 38.101-1', '18.6.0', 'i60', 'Part 1', '18', '38'),
+    ('TS 38.101-2', '18.6.0', 'i60', 'Part 2', '18', '38');`); err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 

--- a/tools/list_images.go
+++ b/tools/list_images.go
@@ -25,7 +25,7 @@ func HandleListImages(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			return errorResult("spec_id is required"), nil, nil
 		}
 
-		images, err := d.ListImages(input.SpecID)
+		images, err := d.ListImages(input.SpecID, "")
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to list images: %v", err)), nil, nil
 		}

--- a/tools/list_versions.go
+++ b/tools/list_versions.go
@@ -1,0 +1,137 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/internal/specver"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Availability values reported by list_versions.
+const (
+	// availabilityDatabase means the version is in the prebuilt database, with
+	// full-text search, images and cross-references.
+	availabilityDatabase = "database"
+	// availabilityCached means the version was fetched on demand earlier and is
+	// served from the local cache.
+	availabilityCached = "cached"
+	// availabilityArchive means the version exists upstream and will be
+	// downloaded and converted the first time it is read.
+	availabilityArchive = "archive"
+)
+
+type ListVersionsInput struct {
+	SpecID string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+}
+
+// VersionInfo describes one version of a specification.
+type VersionInfo struct {
+	Version      string `json:"version"`
+	Release      string `json:"release,omitempty"`
+	Token        string `json:"token,omitempty"`
+	Availability string `json:"availability"`
+}
+
+// ListVersionsOutput is the JSON payload returned by list_versions.
+type ListVersionsOutput struct {
+	SpecID   string        `json:"spec_id"`
+	Versions []VersionInfo `json:"versions"`
+}
+
+var ListVersionsTool = &mcp.Tool{
+	Name: "list_versions",
+	Description: `List the versions of a 3GPP specification, newest first.
+
+Each entry reports where the version can be read from:
+- database: in the prebuilt database, covered by search, images and cross-references
+- cached:   fetched on demand earlier, available immediately
+- archive:  exists upstream; reading it downloads and converts it first, which takes up to a few minutes for a large specification
+
+Pass a version from this list to get_section or get_toc to read a past version.`,
+}
+
+func HandleListVersions(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input ListVersionsInput) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input ListVersionsInput) (*mcp.CallToolResult, any, error) {
+		if input.SpecID == "" {
+			return errorResult("spec_id is required"), nil, nil
+		}
+
+		// The strongest availability wins, so collect from weakest to strongest.
+		availability := map[string]string{}
+		releases := map[string]string{}
+		tokens := map[string]string{}
+
+		archived, archiveErr := pipeline.ListVersions(ctx, src.Client, input.SpecID, src.UseCache)
+		for _, sv := range archived {
+			dotted, ok := specver.TokenToDotted(sv.Version)
+			if !ok {
+				dotted = sv.Version
+			}
+			availability[dotted] = availabilityArchive
+			tokens[dotted] = sv.Version
+			releases[dotted] = fmt.Sprintf("%d", sv.Release)
+		}
+
+		if src.Store != nil {
+			cached, err := src.Store.CachedVersions(input.SpecID)
+			if err != nil {
+				return errorResult(fmt.Sprintf("failed to list cached versions: %v", err)), nil, nil
+			}
+			for _, v := range cached {
+				availability[v] = availabilityCached
+			}
+		}
+
+		specs, err := src.DB.ListSpecVersions(input.SpecID)
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to list versions: %v", err)), nil, nil
+		}
+		for _, s := range specs {
+			availability[s.Version] = availabilityDatabase
+			if s.Release != "" {
+				releases[s.Version] = s.Release
+			}
+			if s.VersionToken != "" {
+				tokens[s.Version] = s.VersionToken
+			}
+		}
+
+		if len(availability) == 0 {
+			if archiveErr != nil {
+				return errorResult(fmt.Sprintf("no versions found for %s: %v", input.SpecID, archiveErr)), nil, nil
+			}
+			if parts, partsErr := src.DB.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+			}
+			return errorResult(fmt.Sprintf("no versions found for %s", input.SpecID)), nil, nil
+		}
+
+		out := ListVersionsOutput{SpecID: input.SpecID}
+		for version, avail := range availability {
+			release := releases[version]
+			if release == "" {
+				release = specver.ReleaseOf(version)
+			}
+			out.Versions = append(out.Versions, VersionInfo{
+				Version:      version,
+				Release:      release,
+				Token:        tokens[version],
+				Availability: avail,
+			})
+		}
+		sort.Slice(out.Versions, func(i, j int) bool {
+			return specver.Compare(out.Versions[i].Version, out.Versions[j].Version) > 0
+		})
+
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to marshal: %v", err)), nil, nil
+		}
+		return textResult(string(data)), nil, nil
+	}
+}

--- a/tools/references.go
+++ b/tools/references.go
@@ -44,7 +44,9 @@ func HandleGetReferences(d *db.DB) func(ctx context.Context, req *mcp.CallToolRe
 			return errorResult("section_number is required for outgoing direction"), nil, nil
 		}
 
-		refs, err := d.GetReferences(input.SpecID, input.SectionNumber, direction, input.IncludeSubsections)
+		// Cross-references are only extracted for the version the database was
+		// built with, so this always answers about that version.
+		refs, err := d.GetReferences(input.SpecID, "", input.SectionNumber, direction, input.IncludeSubsections)
 		if err != nil {
 			return errorResult(fmt.Sprintf("get references failed: %v", err)), nil, nil
 		}

--- a/tools/source.go
+++ b/tools/source.go
@@ -1,0 +1,192 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
+	"github.com/higebu/3gpp-mcp/versionstore"
+)
+
+// Source reads specification text from the prebuilt database, falling back to
+// the on-demand version cache for versions the build did not import.
+type Source struct {
+	DB *db.DB
+	// Store is nil when on-demand fetching is unavailable, either because the
+	// cache file could not be opened or because it was turned off explicitly.
+	Store  *versionstore.Store
+	Client *http.Client
+	// Budget bounds how long a tool call waits for a fetch before telling the
+	// caller to retry. Zero means the versionstore default.
+	Budget time.Duration
+	// UseCache controls the archive directory listing cache.
+	UseCache bool
+}
+
+// NewSource returns a Source that reads only the prebuilt database.
+func NewSource(d *db.DB) *Source {
+	return &Source{DB: d, UseCache: true}
+}
+
+// errFetchInProgress is returned when a fetch outlives the call's budget.
+type errFetchInProgress struct {
+	specID  string
+	version string
+}
+
+func (e *errFetchInProgress) Error() string {
+	return fmt.Sprintf("%s v%s is being downloaded and converted. This takes up to a few minutes for a large specification. Call the same tool again to get the content.", e.specID, e.version)
+}
+
+// errVersionUnavailable is returned when a requested version cannot be served,
+// carrying the versions that do exist so the caller can pick one.
+type errVersionUnavailable struct {
+	specID    string
+	version   string
+	reason    string
+	available []string
+}
+
+func (e *errVersionUnavailable) Error() string {
+	msg := fmt.Sprintf("%s v%s is not available: %s", e.specID, e.version, e.reason)
+	if len(e.available) > 0 {
+		msg += "\nVersions in the archive: " + strings.Join(e.available, ", ")
+	}
+	return msg
+}
+
+// resolution says where a requested version was found.
+type resolution struct {
+	// version is the canonical dotted version that was resolved.
+	version string
+	// archived is true when the content comes from the on-demand cache rather
+	// than the prebuilt database, meaning images and cross-references for it
+	// were never imported.
+	archived bool
+}
+
+// resolve locates a requested version, fetching it on demand when needed. An
+// empty request resolves to whatever the prebuilt database holds.
+func (s *Source) resolve(ctx context.Context, specID, request string) (resolution, error) {
+	if request == "" {
+		return resolution{}, nil
+	}
+
+	dotted, _, err := specver.Normalize(request)
+	if err != nil {
+		return resolution{}, &errVersionUnavailable{specID: specID, version: request, reason: err.Error()}
+	}
+
+	// A version the build already imported is served from the prebuilt
+	// database, which also has its images and cross-references.
+	if dotted != "" {
+		if v, err := s.DB.ResolveVersion(specID, dotted); err == nil {
+			return resolution{version: v}, nil
+		} else if !errors.Is(err, db.ErrNoVersion) {
+			return resolution{}, err
+		}
+	}
+
+	if s.Store == nil {
+		return resolution{}, &errVersionUnavailable{
+			specID:  specID,
+			version: request,
+			reason:  "on-demand fetching is disabled, and this version is not in the database",
+		}
+	}
+
+	// Skip the archive listing entirely when the exact version is already
+	// cached; this is the common case for a repeated call.
+	if dotted != "" {
+		cached, err := s.Store.Has(specID, dotted)
+		if err != nil {
+			return resolution{}, err
+		}
+		if cached {
+			return resolution{version: dotted, archived: true}, nil
+		}
+	}
+
+	sv, available, err := pipeline.ResolveVersion(ctx, s.Client, specID, request, s.UseCache)
+	if err != nil {
+		return resolution{}, &errVersionUnavailable{
+			specID:    specID,
+			version:   request,
+			reason:    err.Error(),
+			available: versionLabels(available),
+		}
+	}
+
+	canonical, ok := specver.TokenToDotted(sv.Version)
+	if !ok {
+		canonical = sv.Version
+	}
+
+	// A release selector such as "Rel-18" may well land on the version the
+	// build imported, so check the database again now that it is resolved.
+	if v, err := s.DB.ResolveVersion(specID, canonical); err == nil {
+		return resolution{version: v}, nil
+	} else if !errors.Is(err, db.ErrNoVersion) {
+		return resolution{}, err
+	}
+
+	switch err := s.Store.Ensure(ctx, specID, canonical, sv, s.Budget); {
+	case err == nil:
+	case errors.Is(err, versionstore.ErrInProgress):
+		return resolution{}, &errFetchInProgress{specID: specID, version: canonical}
+	default:
+		return resolution{}, &errVersionUnavailable{
+			specID:  specID,
+			version: canonical,
+			reason:  err.Error(),
+		}
+	}
+	return resolution{version: canonical, archived: true}, nil
+}
+
+// GetSection returns a section from whichever source holds the version.
+func (s *Source) GetSection(ctx context.Context, specID, version, number string, includeSubsections bool) ([]db.Section, resolution, error) {
+	res, err := s.resolve(ctx, specID, version)
+	if err != nil {
+		return nil, res, err
+	}
+	if res.archived {
+		sections, err := s.Store.GetSection(specID, res.version, number, includeSubsections)
+		return sections, res, err
+	}
+	sections, err := s.DB.GetSection(specID, res.version, number, includeSubsections)
+	return sections, res, err
+}
+
+// GetTOC returns the section structure from whichever source holds the version.
+func (s *Source) GetTOC(ctx context.Context, specID, version string) ([]db.Section, resolution, error) {
+	res, err := s.resolve(ctx, specID, version)
+	if err != nil {
+		return nil, res, err
+	}
+	if res.archived {
+		sections, err := s.Store.GetTOC(specID, res.version)
+		return sections, res, err
+	}
+	sections, err := s.DB.GetTOC(specID, res.version)
+	return sections, res, err
+}
+
+// versionLabels renders archive entries as dotted versions for error messages.
+func versionLabels(available []*pipeline.SpecVersion) []string {
+	labels := make([]string, 0, len(available))
+	for _, sv := range available {
+		if dotted, ok := specver.TokenToDotted(sv.Version); ok {
+			labels = append(labels, dotted)
+			continue
+		}
+		labels = append(labels, sv.Version)
+	}
+	return labels
+}

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -1,0 +1,294 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/versionstore"
+)
+
+// redirectTransport rewrites all request URLs to point at the test server,
+// allowing tests to exercise code that uses the hardcoded pipeline baseURL.
+type redirectTransport struct {
+	base    http.RoundTripper
+	testURL string
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	target, err := url.Parse(rt.testURL + req.URL.Path)
+	if err != nil {
+		return nil, err
+	}
+	req.URL = target
+	return rt.base.RoundTrip(req)
+}
+
+// archiveClient serves a listing for TS 23.501 covering the seeded v18.6.0 plus
+// two versions the database does not have.
+func archiveClient(t *testing.T) *http.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, _ *http.Request) {
+		for _, name := range []string{"23501-i60.zip", "23501-j50.zip", "23501-k20.zip"} {
+			fmt.Fprintf(w, `<a href="%s">%s</a>`+"\n", name, name)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+}
+
+// sourceWithStore builds a Source backed by the seeded database plus a version
+// cache whose fetcher returns canned sections instead of downloading.
+func sourceWithStore(t *testing.T, d *db.DB, fetcher versionstore.Fetcher) *Source {
+	t.Helper()
+	store, err := versionstore.Open(versionstore.Options{
+		Path:    filepath.Join(t.TempDir(), "versions.db"),
+		Fetcher: fetcher,
+	})
+	if err != nil {
+		t.Fatalf("versionstore.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	src := NewSource(d)
+	src.Store = store
+	src.Client = archiveClient(t)
+	src.UseCache = false
+	src.Budget = 5 * time.Second
+	return src
+}
+
+func cannedFetcher(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+	return db.Spec{Title: "System architecture", Release: "19", Series: "23"},
+		[]db.Section{{
+			Number:  "5.1",
+			Title:   "General",
+			Level:   2,
+			Content: "## 5.1 General\nArchived text.",
+		}}, nil
+}
+
+// TestGetSectionUsesDatabaseVersion checks that asking for the version the
+// build imported is served from the database, not fetched.
+func TestGetSectionUsesDatabaseVersion(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, func(context.Context, *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		t.Error("fetcher must not run for a version already in the database")
+		return db.Spec{}, nil, nil
+	})
+
+	for _, request := range []string{"", "18.6.0", "i60"} {
+		sections, res, err := src.GetSection(context.Background(), "TS 23.501", request, "1", false)
+		if err != nil {
+			t.Fatalf("GetSection(%q): %v", request, err)
+		}
+		if len(sections) != 1 {
+			t.Fatalf("GetSection(%q) = %d sections, want 1", request, len(sections))
+		}
+		if res.archived {
+			t.Errorf("GetSection(%q) reported archived, want database", request)
+		}
+	}
+}
+
+// TestGetSectionFetchesArchivedVersion covers the on-demand path end to end.
+func TestGetSectionFetchesArchivedVersion(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+
+	sections, res, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false)
+	if err != nil {
+		t.Fatalf("GetSection: %v", err)
+	}
+	if !res.archived || res.version != "19.5.0" {
+		t.Fatalf("resolution = %+v, want archived v19.5.0", res)
+	}
+	if len(sections) != 1 || !strings.Contains(sections[0].Content, "Archived text") {
+		t.Fatalf("GetSection = %+v, want the fetched content", sections)
+	}
+	if sections[0].SpecID != "TS 23.501" || sections[0].Version != "19.5.0" {
+		t.Errorf("section identity = %s v%s, want TS 23.501 v19.5.0", sections[0].SpecID, sections[0].Version)
+	}
+
+	// The archive token names the same version, so the second call must hit the
+	// cache rather than fetch again.
+	toc, res, err := src.GetTOC(context.Background(), "TS 23.501", "j50")
+	if err != nil {
+		t.Fatalf("GetTOC: %v", err)
+	}
+	if !res.archived || len(toc) != 1 {
+		t.Errorf("GetTOC = %+v, %+v; want one archived section", toc, res)
+	}
+}
+
+// TestHandleGetSectionArchivedHeader checks that the provenance line names the
+// version and warns that images and references are missing, on every page.
+func TestHandleGetSectionArchivedHeader(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	handler := HandleGetSection(src)
+
+	result, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "5.1",
+		Version:       "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := getTextContent(result)
+	want := "[Source: TS 23.501 v19.5.0 (Rel-19) — Section 5.1 (archived version; images and cross-references unavailable)]"
+	if !strings.HasPrefix(text, want) {
+		t.Errorf("header = %q, want prefix %q", text, want)
+	}
+
+	// The same header must survive on a later page.
+	page2, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "5.1",
+		Version:       "19.5.0",
+		Offset:        1,
+		MaxLines:      1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(getTextContent(page2), want) {
+		t.Errorf("page 2 lost the source header: %q", getTextContent(page2))
+	}
+}
+
+// TestGetSectionWithoutStore checks the message when on-demand fetching is off.
+func TestGetSectionWithoutStore(t *testing.T) {
+	d := setupTestDB(t)
+	src := NewSource(d)
+	handler := HandleGetSection(src)
+
+	result, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "5.1",
+		Version:       "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result")
+	}
+	if text := getTextContent(result); !strings.Contains(text, "on-demand fetching is disabled") {
+		t.Errorf("message = %q, want it to say fetching is disabled", text)
+	}
+}
+
+// TestGetSectionUnknownVersionListsAvailable checks that a bad version tells
+// the caller which versions do exist.
+func TestGetSectionUnknownVersionListsAvailable(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	handler := HandleGetSection(src)
+
+	result, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "5.1",
+		Version:       "12.0.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := getTextContent(result)
+	if !result.IsError {
+		t.Fatalf("expected an error result, got %q", text)
+	}
+	for _, want := range []string{"20.2.0", "19.5.0", "18.6.0"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("message %q should list available version %s", text, want)
+		}
+	}
+}
+
+// TestFetchStillRunningIsNotAnError checks that a fetch exceeding the budget
+// returns a retry hint rather than a tool error, so the caller comes back.
+func TestFetchStillRunningIsNotAnError(t *testing.T) {
+	d := setupTestDB(t)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	src := sourceWithStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		<-release
+		return cannedFetcher(ctx, sv)
+	})
+	src.Budget = 20 * time.Millisecond
+	handler := HandleGetSection(src)
+
+	result, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "5.1",
+		Version:       "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Error("a fetch that is still running should not be reported as a tool error")
+	}
+	if text := getTextContent(result); !strings.Contains(text, "Call the same tool again") {
+		t.Errorf("message = %q, want a retry hint", text)
+	}
+}
+
+func TestHandleListVersions(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	handler := HandleListVersions(src)
+
+	// Cache one version so all three availability values appear.
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	result, _, err := handler(context.Background(), nil, ListVersionsInput{SpecID: "TS 23.501"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := getTextContent(result)
+
+	var out ListVersionsOutput
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("unmarshal %q: %v", text, err)
+	}
+	if len(out.Versions) != 3 {
+		t.Fatalf("got %d versions, want 3: %+v", len(out.Versions), out.Versions)
+	}
+	want := []VersionInfo{
+		{Version: "20.2.0", Release: "20", Token: "k20", Availability: availabilityArchive},
+		{Version: "19.5.0", Release: "19", Token: "j50", Availability: availabilityCached},
+		{Version: "18.6.0", Release: "18", Token: "i60", Availability: availabilityDatabase},
+	}
+	for i, w := range want {
+		if out.Versions[i] != w {
+			t.Errorf("versions[%d] = %+v, want %+v", i, out.Versions[i], w)
+		}
+	}
+}
+
+func TestHandleListVersionsRequiresSpecID(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleListVersions(NewSource(d))
+	result, _, err := handler(context.Background(), nil, ListVersionsInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected an error result for a missing spec_id")
+	}
+}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -74,7 +74,7 @@ func TestHandleListSpecs(t *testing.T) {
 
 func TestHandleGetTOC(t *testing.T) {
 	d := setupTestDB(t)
-	handler := HandleGetTOC(d)
+	handler := HandleGetTOC(NewSource(d))
 
 	t.Run("valid spec", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, GetTOCInput{SpecID: "TS 23.501"})
@@ -104,9 +104,9 @@ func TestHandleGetTOC(t *testing.T) {
 	})
 
 	t.Run("family spec id with multiple parts", func(t *testing.T) {
-		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
-    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+		if err := d.ExecScript(`INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 38.101-1', '18.6.0', 'i60', 'Part 1', '18', '38'),
+    ('TS 38.101-2', '18.6.0', 'i60', 'Part 2', '18', '38');`); err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 
@@ -121,8 +121,8 @@ func TestHandleGetTOC(t *testing.T) {
 	})
 
 	t.Run("section with no real number is not duplicated", func(t *testing.T) {
-		if err := d.ExecScript(`INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 23.501', 'MRB-Identity', 'MRB-Identity', 2, '5', 'IE body.');`); err != nil {
+		if err := d.ExecScript(`INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.6.0', 'MRB-Identity', 'MRB-Identity', 2, '5', 'IE body.');`); err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 
@@ -142,7 +142,7 @@ func TestHandleGetTOC(t *testing.T) {
 
 func TestHandleGetSection(t *testing.T) {
 	d := setupTestDB(t)
-	handler := HandleGetSection(d)
+	handler := HandleGetSection(NewSource(d))
 
 	t.Run("valid section", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, GetSectionInput{
@@ -258,9 +258,9 @@ func TestHandleGetSection(t *testing.T) {
 	})
 
 	t.Run("family spec id with multiple parts", func(t *testing.T) {
-		if err := d.ExecScript(`INSERT INTO specs (id, title, version, release, series) VALUES
-    ('TS 38.101-1', 'Part 1', '18.6.0', 'Rel-18', '38'),
-    ('TS 38.101-2', 'Part 2', '18.6.0', 'Rel-18', '38');`); err != nil {
+		if err := d.ExecScript(`INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 38.101-1', '18.6.0', 'i60', 'Part 1', '18', '38'),
+    ('TS 38.101-2', '18.6.0', 'i60', 'Part 2', '18', '38');`); err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 
@@ -278,8 +278,8 @@ func TestHandleGetSection(t *testing.T) {
 	})
 
 	t.Run("unnumbered heading looked up by title as section_number", func(t *testing.T) {
-		if err := d.ExecScript(`INSERT INTO sections (spec_id, number, title, level, parent_number, content) VALUES
-    ('TS 23.501', 'MRB-Identity', 'MRB-Identity', 2, '5', '### MRB-Identity` + "\n\n" + `IE body.');`); err != nil {
+		if err := d.ExecScript(`INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.6.0', 'MRB-Identity', 'MRB-Identity', 2, '5', '### MRB-Identity` + "\n\n" + `IE body.');`); err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 
@@ -330,7 +330,7 @@ func TestHandleSearch(t *testing.T) {
 		if !strings.Contains(text, "TS 23.501") {
 			t.Errorf("expected search result for TS 23.501, got: %s", text)
 		}
-		if !strings.Contains(text, `"version": "18.6.0"`) || !strings.Contains(text, `"release": "Rel-18"`) {
+		if !strings.Contains(text, `"version": "18.6.0"`) || !strings.Contains(text, `"release": "18"`) {
 			t.Errorf("expected version/release in search results, got: %s", text)
 		}
 	})
@@ -735,7 +735,7 @@ func TestHandleSearch_EdgeCases(t *testing.T) {
 // that was previously exercised only for happy paths.
 func TestHandleGetSection_PaginationEdges(t *testing.T) {
 	d := setupTestDB(t)
-	handler := HandleGetSection(d)
+	handler := HandleGetSection(NewSource(d))
 
 	t.Run("offset beyond content", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, GetSectionInput{

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -1,0 +1,470 @@
+// Package versionstore caches specification versions that the prebuilt
+// database does not hold.
+//
+// A build imports one version per spec. Reading a past version therefore means
+// downloading and converting it on demand, which takes seconds to minutes. The
+// results go into a separate SQLite file so the prebuilt database stays
+// read-only, its full-text index keeps covering exactly one version per spec,
+// and the cache survives the weekly rebuild that replaces the main database.
+package versionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/db"
+	_ "modernc.org/sqlite"
+)
+
+// ErrInProgress reports that a fetch did not finish within the caller's budget.
+// The fetch keeps running in the background, so repeating the same call later
+// returns the content.
+var ErrInProgress = errors.New("version fetch still in progress")
+
+// DefaultLimitBytes is the default cache size limit.
+const DefaultLimitBytes int64 = 1024 << 20 // 1 GiB
+
+// DefaultBudget is how long a caller waits for a fetch before being told to
+// come back. MCP clients time out well before a large spec finishes.
+const DefaultBudget = 60 * time.Second
+
+// DefaultFileName is the cache file created inside the XDG cache directory.
+const DefaultFileName = "versions.db"
+
+// schema mirrors the spec and section tables of the main database, without the
+// full-text index: cached versions must never appear in search results.
+const schema = db.SpecTablesSchema + `
+CREATE TABLE IF NOT EXISTS cache_entries (
+    spec_id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    bytes INTEGER NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    last_used_at INTEGER NOT NULL,
+    PRIMARY KEY (spec_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cache_lru ON cache_entries(last_used_at);
+`
+
+// Store is a size-bounded cache of converted spec versions.
+type Store struct {
+	conn       *sql.DB
+	limitBytes int64
+	client     *http.Client
+	timeout    time.Duration
+	fetcher    Fetcher
+
+	mu       sync.Mutex
+	inflight map[string]*fetch
+}
+
+// Fetcher downloads and converts one archive entry. Only tests set it; the
+// zero value uses the real pipeline.
+type Fetcher func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error)
+
+// fetch tracks one in-progress download so concurrent callers asking for the
+// same version share a single download instead of racing.
+type fetch struct {
+	done chan struct{}
+	err  error
+}
+
+// Options configures a Store.
+type Options struct {
+	// Path is the cache file. Empty means the default location.
+	Path string
+	// LimitBytes caps the total size of cached section content. A negative
+	// value disables eviction; zero keeps only the most recently fetched
+	// version. Callers pass an explicit limit — DefaultLimitBytes is exported
+	// for that — rather than relying on zero to mean "default", so that a user
+	// asking for a limit of zero gets one.
+	LimitBytes int64
+	// Client is used for archive downloads. Nil means a default client.
+	Client *http.Client
+	// Timeout bounds a single archive download. Zero means the pipeline default.
+	Timeout time.Duration
+	// Fetcher replaces the download-and-convert step. Only tests set it.
+	Fetcher Fetcher
+}
+
+// DefaultPath returns the cache file location inside the XDG cache directory.
+func DefaultPath() (string, error) {
+	dir, err := pipeline.CacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, DefaultFileName), nil
+}
+
+// Open creates or opens the version cache. It returns an error when the file
+// cannot be written — a read-only or ephemeral filesystem, for instance — and
+// callers are expected to carry on with on-demand fetching disabled rather than
+// to treat that as fatal.
+func Open(opts Options) (*Store, error) {
+	path := opts.Path
+	if path == "" {
+		p, err := DefaultPath()
+		if err != nil {
+			return nil, err
+		}
+		path = p
+	}
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create cache dir: %w", err)
+		}
+	}
+
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open version cache: %w", err)
+	}
+	// One connection serializes writes and avoids SQLITE_BUSY; the stdio server
+	// runs as one process per project, so several may share this file.
+	conn.SetMaxOpenConns(1)
+	// auto_vacuum only takes effect on a database with no tables yet, so it has
+	// to be set before the schema is created.
+	for _, pragma := range []string{
+		"PRAGMA auto_vacuum=INCREMENTAL",
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := conn.Exec(pragma); err != nil {
+			log.Printf("warning: version cache %s failed: %v", pragma, err)
+		}
+	}
+	if err := conn.Ping(); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("ping version cache: %w", err)
+	}
+	if _, err := conn.Exec(schema); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("create version cache schema: %w", err)
+	}
+
+	return &Store{
+		conn:       conn,
+		limitBytes: opts.LimitBytes,
+		client:     opts.Client,
+		timeout:    opts.Timeout,
+		fetcher:    opts.Fetcher,
+		inflight:   map[string]*fetch{},
+	}, nil
+}
+
+func (s *Store) Close() error {
+	return s.conn.Close()
+}
+
+// Has reports whether a version is already cached.
+func (s *Store) Has(specID, version string) (bool, error) {
+	var one int
+	err := s.conn.QueryRow(
+		"SELECT 1 FROM cache_entries WHERE spec_id = ? AND version = ?",
+		specID, version,
+	).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check version cache: %w", err)
+	}
+	return true, nil
+}
+
+// CachedVersions returns the versions of a spec held in the cache.
+func (s *Store) CachedVersions(specID string) ([]string, error) {
+	rows, err := s.conn.Query(
+		"SELECT version FROM cache_entries WHERE spec_id = ? ORDER BY version",
+		specID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list cached versions: %w", err)
+	}
+	defer rows.Close()
+
+	var versions []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan cached version: %w", err)
+		}
+		versions = append(versions, v)
+	}
+	return versions, rows.Err()
+}
+
+// GetSpec returns the cached spec record for a version.
+func (s *Store) GetSpec(specID, version string) (*db.Spec, error) {
+	var spec db.Spec
+	err := s.conn.QueryRow(
+		"SELECT id, version, COALESCE(version_token, ''), title, COALESCE(release, ''), COALESCE(series, '') FROM specs WHERE id = ? AND version = ?",
+		specID, version,
+	).Scan(&spec.ID, &spec.Version, &spec.VersionToken, &spec.Title, &spec.Release, &spec.Series)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cached spec: %w", err)
+	}
+	return &spec, nil
+}
+
+// GetTOC returns the section structure of a cached version.
+func (s *Store) GetTOC(specID, version string) ([]db.Section, error) {
+	s.touch(specID, version)
+	return s.querySections(
+		"SELECT s.spec_id, s.version, s.number, s.title, s.level, COALESCE(s.parent_number, ''), '', COALESCE(p.release, '') "+
+			"FROM sections s LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version "+
+			"WHERE s.spec_id = ? AND s.version = ? ORDER BY s.id",
+		specID, version,
+	)
+}
+
+// GetSection returns a cached section, optionally with its subsections.
+func (s *Store) GetSection(specID, version, number string, includeSubsections bool) ([]db.Section, error) {
+	s.touch(specID, version)
+	const projection = "SELECT s.spec_id, s.version, s.number, s.title, s.level, COALESCE(s.parent_number, ''), s.content, COALESCE(p.release, '') " +
+		"FROM sections s LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE s.spec_id = ? AND s.version = ?"
+	if includeSubsections {
+		return s.querySections(
+			projection+" AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
+			specID, version, number, number,
+		)
+	}
+	return s.querySections(projection+" AND s.number = ?", specID, version, number)
+}
+
+func (s *Store) querySections(query string, args ...any) ([]db.Section, error) {
+	rows, err := s.conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query cached sections: %w", err)
+	}
+	defer rows.Close()
+
+	var sections []db.Section
+	for rows.Next() {
+		var sec db.Section
+		if err := rows.Scan(&sec.SpecID, &sec.Version, &sec.Number, &sec.Title, &sec.Level, &sec.ParentNumber, &sec.Content, &sec.Release); err != nil {
+			return nil, fmt.Errorf("scan cached section: %w", err)
+		}
+		sections = append(sections, sec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query cached sections: iterate: %w", err)
+	}
+	return sections, nil
+}
+
+// touch records a use for LRU ordering. A failure here only costs eviction
+// accuracy, so it is logged rather than propagated to the read path.
+func (s *Store) touch(specID, version string) {
+	_, err := s.conn.Exec(
+		"UPDATE cache_entries SET last_used_at = ? WHERE spec_id = ? AND version = ?",
+		time.Now().Unix(), specID, version,
+	)
+	if err != nil {
+		log.Printf("warning: version cache touch failed for %s v%s: %v", specID, version, err)
+	}
+}
+
+// Ensure makes a version available in the cache, downloading and converting it
+// when necessary.
+//
+// A fetch that outlives budget keeps running on a context detached from the
+// caller's, and Ensure returns ErrInProgress. Repeating the call later joins
+// the same fetch and eventually returns the cached content. Concurrent callers
+// asking for the same version share one download.
+// specID and version are the keys callers will look the result up by; they win
+// over whatever the downloaded document says about itself, which for legacy
+// specs is often wrong or missing.
+func (s *Store) Ensure(ctx context.Context, specID, version string, sv *pipeline.SpecVersion, budget time.Duration) error {
+	cached, err := s.Has(specID, version)
+	if err != nil {
+		return err
+	}
+	if cached {
+		return nil
+	}
+	if budget <= 0 {
+		budget = DefaultBudget
+	}
+
+	key := specID + "@" + version
+	s.mu.Lock()
+	f, running := s.inflight[key]
+	if !running {
+		f = &fetch{done: make(chan struct{})}
+		s.inflight[key] = f
+		// The fetch outlives this request on purpose: a caller that gives up
+		// waiting should not throw away minutes of download and conversion.
+		go s.run(context.WithoutCancel(ctx), key, specID, version, sv, f)
+	}
+	s.mu.Unlock()
+
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-f.done:
+		return f.err
+	case <-timer.C:
+		return fmt.Errorf("%w: %s v%s", ErrInProgress, specID, version)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// run performs one fetch and publishes its outcome to everyone waiting on it.
+func (s *Store) run(ctx context.Context, key, specID, version string, sv *pipeline.SpecVersion, f *fetch) {
+	defer func() {
+		s.mu.Lock()
+		delete(s.inflight, key)
+		s.mu.Unlock()
+		close(f.done)
+	}()
+
+	spec, sections, err := s.fetch(ctx, sv)
+	if err != nil {
+		f.err = err
+		return
+	}
+	spec.ID, spec.Version = specID, version
+	for i := range sections {
+		sections[i].SpecID = specID
+		sections[i].Version = version
+	}
+	if err := s.put(spec, sections); err != nil {
+		f.err = err
+	}
+}
+
+// fetch downloads and converts one archive entry. It is a field so tests can
+// supply documents without reaching the network.
+func (s *Store) fetch(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+	if s.fetcher != nil {
+		return s.fetcher(ctx, sv)
+	}
+	return pipeline.FetchVersion(ctx, s.client, sv, s.timeout)
+}
+
+// put writes a fetched version into the cache and enforces the size limit.
+func (s *Store) put(spec db.Spec, sections []db.Section) error {
+	tx, err := s.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin cache transaction: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
+	if _, err := tx.Exec(
+		"INSERT OR REPLACE INTO specs (id, version, version_token, title, release, series) VALUES (?, ?, ?, ?, ?, ?)",
+		spec.ID, spec.Version, spec.VersionToken, spec.Title, spec.Release, spec.Series,
+	); err != nil {
+		return fmt.Errorf("cache spec: %w", err)
+	}
+
+	if _, err := tx.Exec("DELETE FROM sections WHERE spec_id = ? AND version = ?", spec.ID, spec.Version); err != nil {
+		return fmt.Errorf("clear cached sections: %w", err)
+	}
+	stmt, err := tx.Prepare(
+		"INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare cache insert: %w", err)
+	}
+	defer stmt.Close()
+
+	var bytes int64
+	for _, sec := range sections {
+		if _, err := stmt.Exec(sec.SpecID, sec.Version, sec.Number, sec.Title, sec.Level, sec.ParentNumber, sec.Content); err != nil {
+			return fmt.Errorf("cache section: %w", err)
+		}
+		bytes += int64(len(sec.Content)) + int64(len(sec.Title))
+	}
+
+	now := time.Now().Unix()
+	if _, err := tx.Exec(
+		"INSERT OR REPLACE INTO cache_entries (spec_id, version, bytes, fetched_at, last_used_at) VALUES (?, ?, ?, ?, ?)",
+		spec.ID, spec.Version, bytes, now, now,
+	); err != nil {
+		return fmt.Errorf("record cache entry: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit cache transaction: %w", err)
+	}
+	return s.evict(spec.ID, spec.Version)
+}
+
+// evict drops least-recently-used versions until the cache fits its limit. The
+// entry named by keepSpecID/keepVersion is never dropped: it was just fetched,
+// and evicting it would make the fetch pointless when a single spec is larger
+// than the whole limit.
+func (s *Store) evict(keepSpecID, keepVersion string) error {
+	if s.limitBytes < 0 {
+		return nil
+	}
+
+	for {
+		var total sql.NullInt64
+		if err := s.conn.QueryRow("SELECT SUM(bytes) FROM cache_entries").Scan(&total); err != nil {
+			return fmt.Errorf("measure version cache: %w", err)
+		}
+		if !total.Valid || total.Int64 <= s.limitBytes {
+			return nil
+		}
+
+		var specID, version string
+		err := s.conn.QueryRow(
+			"SELECT spec_id, version FROM cache_entries WHERE NOT (spec_id = ? AND version = ?) ORDER BY last_used_at, rowid LIMIT 1",
+			keepSpecID, keepVersion,
+		).Scan(&specID, &version)
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Printf("version cache: %s v%s alone exceeds the %d byte limit; keeping it", keepSpecID, keepVersion, s.limitBytes)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("pick eviction victim: %w", err)
+		}
+		if err := s.delete(specID, version); err != nil {
+			return err
+		}
+		log.Printf("version cache: evicted %s v%s", specID, version)
+	}
+}
+
+// delete removes one cached version and returns its pages to the filesystem.
+func (s *Store) delete(specID, version string) error {
+	tx, err := s.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin eviction: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, q := range []string{
+		"DELETE FROM sections WHERE spec_id = ? AND version = ?",
+		"DELETE FROM specs WHERE id = ? AND version = ?",
+		"DELETE FROM cache_entries WHERE spec_id = ? AND version = ?",
+	} {
+		if _, err := tx.Exec(q, specID, version); err != nil {
+			return fmt.Errorf("evict %s v%s: %w", specID, version, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit eviction: %w", err)
+	}
+
+	// Without this the file keeps the freed pages and never shrinks.
+	if _, err := s.conn.Exec("PRAGMA incremental_vacuum"); err != nil {
+		log.Printf("warning: version cache incremental_vacuum failed: %v", err)
+	}
+	return nil
+}

--- a/versionstore/versionstore_test.go
+++ b/versionstore/versionstore_test.go
@@ -1,0 +1,356 @@
+package versionstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/db"
+)
+
+// fakeSpec builds a spec plus sections of roughly size bytes of content.
+func fakeSpec(specID, version string, size int) (db.Spec, []db.Section) {
+	spec := db.Spec{ID: specID, Version: version, Title: specID, Release: "18", Series: "23"}
+	sections := []db.Section{{
+		SpecID:  specID,
+		Version: version,
+		Number:  "1",
+		Title:   "Scope",
+		Level:   1,
+		Content: strings.Repeat("x", size),
+	}, {
+		SpecID:       specID,
+		Version:      version,
+		Number:       "1.1",
+		Title:        "General",
+		Level:        2,
+		ParentNumber: "1",
+		Content:      "general text",
+	}}
+	return spec, sections
+}
+
+func entry(specID string) *pipeline.SpecVersion {
+	return &pipeline.SpecVersion{SpecID: specID, Version: "i60", Release: 18}
+}
+
+// openStore creates a store in a temp directory with a stub fetcher.
+func openStore(t *testing.T, limit int64, fetcher Fetcher) *Store {
+	t.Helper()
+	s, err := Open(Options{
+		Path:       filepath.Join(t.TempDir(), "versions.db"),
+		LimitBytes: limit,
+		Fetcher:    fetcher,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestEnsureAndRead(t *testing.T) {
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("ignored", "ignored", 16)
+		return spec, sections, nil
+	})
+
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	// The caller's spec ID and version win over whatever the fetcher returned.
+	has, err := s.Has("TS 23.501", "18.6.0")
+	if err != nil || !has {
+		t.Fatalf("Has = %v, %v; want true, nil", has, err)
+	}
+
+	sections, err := s.GetSection("TS 23.501", "18.6.0", "1", false)
+	if err != nil {
+		t.Fatalf("GetSection: %v", err)
+	}
+	if len(sections) != 1 || sections[0].Number != "1" {
+		t.Fatalf("GetSection = %+v, want one section 1", sections)
+	}
+	if sections[0].SpecID != "TS 23.501" || sections[0].Version != "18.6.0" {
+		t.Errorf("section identity = %s v%s, want TS 23.501 v18.6.0", sections[0].SpecID, sections[0].Version)
+	}
+	if sections[0].Release != "18" {
+		t.Errorf("Release = %q, want 18", sections[0].Release)
+	}
+
+	withSubs, err := s.GetSection("TS 23.501", "18.6.0", "1", true)
+	if err != nil {
+		t.Fatalf("GetSection subsections: %v", err)
+	}
+	if len(withSubs) != 2 {
+		t.Errorf("GetSection with subsections = %d sections, want 2", len(withSubs))
+	}
+
+	toc, err := s.GetTOC("TS 23.501", "18.6.0")
+	if err != nil {
+		t.Fatalf("GetTOC: %v", err)
+	}
+	if len(toc) != 2 || toc[0].Content != "" {
+		t.Errorf("GetTOC = %+v, want 2 sections without content", toc)
+	}
+
+	versions, err := s.CachedVersions("TS 23.501")
+	if err != nil || len(versions) != 1 || versions[0] != "18.6.0" {
+		t.Errorf("CachedVersions = %v, %v; want [18.6.0], nil", versions, err)
+	}
+
+	spec, err := s.GetSpec("TS 23.501", "18.6.0")
+	if err != nil || spec == nil || spec.ID != "TS 23.501" {
+		t.Errorf("GetSpec = %+v, %v", spec, err)
+	}
+	missing, err := s.GetSpec("TS 23.501", "1.0.0")
+	if err != nil || missing != nil {
+		t.Errorf("GetSpec(missing) = %+v, %v; want nil, nil", missing, err)
+	}
+}
+
+func TestEnsureIsCachedOnSecondCall(t *testing.T) {
+	var calls atomic.Int32
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		calls.Add(1)
+		spec, sections := fakeSpec("TS 23.501", "18.6.0", 8)
+		return spec, sections, nil
+	})
+
+	for range 3 {
+		if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("fetcher called %d times, want 1", got)
+	}
+}
+
+// TestEnsureSingleflight checks that concurrent callers for the same version
+// share one download instead of each starting their own.
+func TestEnsureSingleflight(t *testing.T) {
+	release := make(chan struct{})
+	var calls atomic.Int32
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		calls.Add(1)
+		<-release
+		spec, sections := fakeSpec("TS 23.501", "18.6.0", 8)
+		return spec, sections, nil
+	})
+
+	const callers = 4
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute)
+		}()
+	}
+	// Give every caller a chance to join the same in-flight fetch.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: %v", i, err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("fetcher called %d times, want 1", got)
+	}
+}
+
+// TestEnsureBudgetExceeded checks that a slow fetch yields ErrInProgress and
+// still completes in the background, so a later call finds the content.
+func TestEnsureBudgetExceeded(t *testing.T) {
+	release := make(chan struct{})
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		<-release
+		spec, sections := fakeSpec("TS 23.501", "18.6.0", 8)
+		return spec, sections, nil
+	})
+
+	err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), 20*time.Millisecond)
+	if !errors.Is(err, ErrInProgress) {
+		t.Fatalf("Ensure = %v, want ErrInProgress", err)
+	}
+
+	close(release)
+	// The background fetch keeps running; a second call joins it and succeeds.
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure after budget: %v", err)
+	}
+	has, err := s.Has("TS 23.501", "18.6.0")
+	if err != nil || !has {
+		t.Errorf("Has after background completion = %v, %v; want true, nil", has, err)
+	}
+}
+
+// TestEnsureSurvivesCallerCancellation checks that a cancelled request does not
+// throw away the download it started.
+func TestEnsureSurvivesCallerCancellation(t *testing.T) {
+	started := make(chan struct{})
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		close(started)
+		if err := ctx.Err(); err != nil {
+			return db.Spec{}, nil, err
+		}
+		time.Sleep(30 * time.Millisecond)
+		if err := ctx.Err(); err != nil {
+			return db.Spec{}, nil, err
+		}
+		spec, sections := fakeSpec("TS 23.501", "18.6.0", 8)
+		return spec, sections, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+	if err := s.Ensure(ctx, "TS 23.501", "18.6.0", entry("23.501"), time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Ensure = %v, want context.Canceled", err)
+	}
+
+	// The detached fetch should still land in the cache.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("fetch did not complete after the caller was cancelled")
+}
+
+func TestEnsurePropagatesFetchError(t *testing.T) {
+	want := errors.New("boom")
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		return db.Spec{}, nil, want
+	})
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); !errors.Is(err, want) {
+		t.Errorf("Ensure = %v, want %v", err, want)
+	}
+	// A failed fetch must not leave a cache entry behind.
+	if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+		t.Error("failed fetch left a cache entry")
+	}
+}
+
+// TestEvictionDropsLeastRecentlyUsed fills the cache past its limit and checks
+// that the oldest entry goes and the newest stays.
+func TestEvictionDropsLeastRecentlyUsed(t *testing.T) {
+	const size = 4096
+	// An entry counts the content and title of both of its sections.
+	entryBytes := int64(size + len("Scope") + len("general text") + len("General"))
+	// Two entries fit exactly; the third must push one out. Entries written in
+	// the same second tie on last_used_at and are broken by insertion order, so
+	// the oldest is unambiguous without slowing the test down.
+	s := openStore(t, 2*entryBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", size)
+		return spec, sections, nil
+	})
+
+	specs := []string{"TS 23.501", "TS 23.502", "TS 23.503"}
+	for _, id := range specs {
+		if err := s.Ensure(context.Background(), id, "18.6.0", entry(id), time.Minute); err != nil {
+			t.Fatalf("Ensure %s: %v", id, err)
+		}
+	}
+
+	if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+		t.Error("oldest entry TS 23.501 should have been evicted")
+	}
+	for _, id := range specs[1:] {
+		if has, _ := s.Has(id, "18.6.0"); !has {
+			t.Errorf("%s should still be cached", id)
+		}
+	}
+
+	// Evicted sections must go with the entry, not linger.
+	sections, err := s.GetSection("TS 23.501", "18.6.0", "1", false)
+	if err != nil {
+		t.Fatalf("GetSection: %v", err)
+	}
+	if len(sections) != 0 {
+		t.Errorf("evicted spec still has %d sections", len(sections))
+	}
+}
+
+// TestEvictionKeepsAnOversizedEntry checks that a spec larger than the whole
+// limit is kept rather than deleted immediately after being fetched.
+func TestEvictionKeepsAnOversizedEntry(t *testing.T) {
+	s := openStore(t, 16, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 4096)
+		return spec, sections, nil
+	})
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	if has, _ := s.Has("TS 23.501", "18.6.0"); !has {
+		t.Error("an entry larger than the limit should be kept, not evicted on arrival")
+	}
+}
+
+func TestNegativeLimitDisablesEviction(t *testing.T) {
+	s := openStore(t, -1, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 4096)
+		return spec, sections, nil
+	})
+	for i := range 3 {
+		id := fmt.Sprintf("TS 23.50%d", i)
+		if err := s.Ensure(context.Background(), id, "18.6.0", entry(id), time.Minute); err != nil {
+			t.Fatalf("Ensure %s: %v", id, err)
+		}
+	}
+	for i := range 3 {
+		id := fmt.Sprintf("TS 23.50%d", i)
+		if has, _ := s.Has(id, "18.6.0"); !has {
+			t.Errorf("%s evicted despite eviction being disabled", id)
+		}
+	}
+}
+
+// TestZeroLimitKeepsOnlyTheNewest checks that an explicit limit of zero is
+// honoured rather than silently replaced by the default.
+func TestZeroLimitKeepsOnlyTheNewest(t *testing.T) {
+	s := openStore(t, 0, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 512)
+		return spec, sections, nil
+	})
+	for _, id := range []string{"TS 23.501", "TS 23.502"} {
+		if err := s.Ensure(context.Background(), id, "18.6.0", entry(id), time.Minute); err != nil {
+			t.Fatalf("Ensure %s: %v", id, err)
+		}
+	}
+	if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+		t.Error("a zero limit should have evicted the older entry")
+	}
+	if has, _ := s.Has("TS 23.502", "18.6.0"); !has {
+		t.Error("the most recently fetched entry should be kept even at a zero limit")
+	}
+}
+
+func TestOpenRejectsUnwritablePath(t *testing.T) {
+	// A path whose parent is an existing file cannot be created.
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := Open(Options{Path: filepath.Join(file, "versions.db")}); err == nil {
+		t.Error("Open on an unwritable path should fail so the caller can disable fetching")
+	}
+}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
 )
 
 type handler struct {
@@ -92,6 +93,9 @@ func (h *handler) initTemplates() {
 			return "/specs/" + url.PathEscape(specID) + "/sections/" + number
 		},
 		"refURL": refURL,
+		// releaseLabel renders a bare release number as "Rel-18"; anything else
+		// is shown unchanged.
+		"releaseLabel": specver.ReleaseLabel,
 		"add": func(a, b int) int {
 			return a + b
 		},
@@ -206,7 +210,9 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
 	prev, next := adjacentSections(toc, number)
 
 	data := specData{
-		Spec:       &db.Spec{ID: specID},
+		// GetTOC already joined the version and release of the spec being
+		// viewed, so the header can name them without a second query.
+		Spec:       &db.Spec{ID: specID, Version: toc[0].Version, Release: toc[0].Release},
 		TOC:        toc,
 		Sections:   rendered,
 		Current:    number,

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -182,7 +182,7 @@ func (h *handler) handleSection(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
-	toc, err := h.db.GetTOC(specID)
+	toc, err := h.db.GetTOC(specID, "")
 	if err != nil || len(toc) == 0 {
 		h.renderError(w, http.StatusNotFound, fmt.Sprintf("Specification %q not found", specID))
 		return
@@ -193,16 +193,16 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, specID, number string) {
 		number = toc[0].Number
 	}
 
-	sections, err := h.db.GetSection(specID, number, false)
+	sections, err := h.db.GetSection(specID, "", number, false)
 	if err != nil || len(sections) == 0 {
 		h.renderError(w, http.StatusNotFound, fmt.Sprintf("Section %q not found in %s", number, specID))
 		return
 	}
 
-	bracketMap, _ := h.db.GetBracketMap(specID)
+	bracketMap, _ := h.db.GetBracketMap(specID, "")
 	rendered := renderSections(sections, specID, bracketMap)
 	openAPIs, _ := h.db.ListOpenAPI(specID)
-	refs, _ := h.db.GetReferences(specID, number, db.DirectionOutgoing, false)
+	refs, _ := h.db.GetReferences(specID, "", number, db.DirectionOutgoing, false)
 	prev, next := adjacentSections(toc, number)
 
 	data := specData{
@@ -245,7 +245,7 @@ func (h *handler) handleImage(w http.ResponseWriter, r *http.Request) {
 	specID := r.PathValue("specID")
 	name := r.PathValue("name")
 
-	img, err := h.db.GetImage(specID, name)
+	img, err := h.db.GetImage(specID, "", name)
 	if err != nil {
 		http.NotFound(w, r)
 		return

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -270,7 +270,10 @@ mark {
     background: var(--bg-secondary);
     font-weight: 600;
     position: sticky;
-    top: 48px;
+    /* Sticks to .table-responsive, not the viewport: an overflow container is
+       the sticky containing block. Offsetting by the navbar height pushed the
+       header down over the first row, hiding it. */
+    top: 0;
 }
 
 .specs-table tbody tr:hover {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -359,6 +359,20 @@ mark {
     font-weight: 600;
 }
 
+.toc-version {
+    margin-top: 2px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+/* Names the exact version the text below came from, matching the
+   "[Source: ...]" line the MCP get_section tool prepends. */
+.section-source {
+    margin-bottom: 12px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
 .toc-nav {
     padding: 8px 0;
 }

--- a/web/templates/spec.html
+++ b/web/templates/spec.html
@@ -5,6 +5,9 @@
     <aside class="toc-sidebar" id="toc-sidebar">
         <div class="toc-header">
             <h3>{{.Spec.ID}}</h3>
+            {{if .Spec.Version}}
+            <p class="toc-version">v{{.Spec.Version}}{{with releaseLabel .Spec.Release}} ({{.}}){{end}}</p>
+            {{end}}
         </div>
         <nav class="toc-nav">
             <ul class="toc-list">
@@ -32,6 +35,10 @@
 
     <div class="section-content">
         {{template "section-nav" .}}
+
+        {{if .Spec.Version}}
+        <p class="section-source">Source: {{.Spec.ID}} v{{.Spec.Version}}{{with releaseLabel .Spec.Release}} ({{.}}){{end}}</p>
+        {{end}}
 
         {{range .Sections}}
         <article class="section">

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -256,6 +256,9 @@ func TestHandleSpec(t *testing.T) {
 	if !strings.Contains(body, `name="spec_id" value="TS 23.501"`) {
 		t.Errorf("expected navbar search to be pre-filled with the current spec ID, got:\n%s", body)
 	}
+	if !strings.Contains(body, `<p class="toc-version">v18.6.0 (Rel-18)</p>`) {
+		t.Errorf("expected the TOC header to name the spec version, got:\n%s", body)
+	}
 }
 
 func TestHandleSection(t *testing.T) {
@@ -274,6 +277,11 @@ func TestHandleSection(t *testing.T) {
 	body := readBody(t, resp)
 	if !strings.Contains(body, "General") {
 		t.Error("should contain section title 'General'")
+	}
+	// The reader must be able to tell which version the text came from,
+	// matching the "[Source: ...]" line the get_section MCP tool prepends.
+	if !strings.Contains(body, "Source: TS 23.501 v18.6.0 (Rel-18)") {
+		t.Errorf("expected the section to name its spec version, got:\n%s", body)
 	}
 }
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -489,6 +489,7 @@ func TestHandleImage(t *testing.T) {
 	imgData := []byte("\x89PNG\r\n\x1a\nfake-png-bytes")
 	if err := d.UpsertImage(db.Image{
 		SpecID:      "TS 23.501",
+		Version:     "18.6.0",
 		Name:        "fig1.png",
 		MIMEType:    "image/png",
 		Data:        imgData,


### PR DESCRIPTION
Sections could only be read for the single version baked into the database, so
comparing a procedure across releases was impossible. The version column also
mixed two formats: base-36 archive tokens (`k20`) taken from filenames and
dotted versions (`18.6.0`) scraped from document bodies, so `get_section` was
reporting provenance like `TS 23.501 vk20 (20)`.

## Changes

- Make version a first-class schema dimension: `specs` is keyed by
  `(id, version)` and `sections` by `(spec_id, version, number)`. Inserting a
  version drops any other version of the same spec, since the FTS index has no
  version column and a second version would double every search hit.
- Normalize versions to the dotted form and keep the archive token alongside it
  in `specs.version_token`, so provenance reads `TS 23.501 v20.2.0 (Rel-20)` and
  archive files stay resolvable. `internal/specver` converts between the two.
- Add `version` to `get_section` and `get_toc`. It accepts the dotted form
  (`18.6.0`), the archive token (`i60`), a release selector (`Rel-18` or `18`)
  or `latest`. A version the build did not import is downloaded and converted on
  demand into a separate cache database, kept under an LRU byte limit and never
  indexed by FTS. A fetch that outlives the call's budget returns a retry hint
  rather than an error and keeps running in the background.
- Add `list_versions` to discover which versions exist in the archive, the
  database and the cache.
- Show the spec version in the web viewer, which previously named only the spec
  ID, and fix a sticky table header that was hiding the first row of the spec
  list.

Prebuilt databases are unaffected: `build` still imports one version per spec
and `search` still covers only that version. `get_image` and `get_references`
likewise only have data for that version, so an archived section returns text
alone and says so in its source header.

## Serve flags

| Flag | Description | Default |
|------|-------------|---------|
| `--no-fetch` | Disable on-demand fetching | `false` |
| `--version-cache` | Cache path | `$XDG_CACHE_HOME/3gpp-mcp/versions.db` |
| `--version-cache-mb` | Cache size limit in MB (`0` keeps only the newest fetch, `-1` unlimited) | `1024` |
| `--fetch-budget` | Wait before asking the caller to retry | `60s` |

When the cache cannot be created — a read-only or ephemeral filesystem such as
the `scratch`-based container image — the server logs a warning and runs with
on-demand fetching disabled; everything else keeps working.

## Testing

- `go test -race ./...` passes, including the integration tests that fetch from
  the 3GPP archive.
- New unit tests cover version conversion, archive version resolution against a
  fake archive, cache eviction, request deduplication, budget expiry with
  background completion, and the tool-level routing between database and cache.
- Verified end to end against a database built from TS 21.905: provenance
  headers on every page, on-demand fetch of v18.0.0 and Rel-17, cache eviction
  with `--version-cache-mb 0`, and `--no-fetch`.

## Breaking change

The schema is incompatible with existing databases. Rebuild with
`make build-db`.