### PR TITLE
fix(cli): error when import/import-dir flags follow the path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Import a single `.docx` file into the database. Alias: `convert`.
 
 Usage: `3gpp-mcp import --db data/3gpp.db path/to/spec.docx`
 
+Flags must come before the file path; anything after it is treated as a positional argument, not an option.
+
 ### `import-dir`
 
 Import all `.docx` files in a directory into the database. Alias: `convert-dir`.
@@ -408,6 +410,8 @@ Import all `.docx` files in a directory into the database. Alias: `convert-dir`.
 | `--convert-image` | Convert EMF/WMF images to PNG using LibreOffice | `false` |
 
 Usage: `3gpp-mcp import-dir --db data/3gpp.db ./specs`
+
+Flags must come before the directory path; anything after it is treated as a positional argument, not an option.
 
 ### `update`
 

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -220,8 +220,11 @@ func cmdConvert(args []string) {
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
 	_ = fs.Parse(args)
 
-	if fs.NArg() < 1 {
+	// flag stops parsing at the first non-flag argument, so any option placed
+	// after <docx-file> is silently left in fs.Args() instead of being applied.
+	if fs.NArg() != 1 {
 		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp import [options] <docx-file>")
+		fmt.Fprintln(os.Stderr, "Options must come before <docx-file>.")
 		os.Exit(1)
 	}
 	docxPath := fs.Arg(0)
@@ -253,8 +256,11 @@ func cmdConvertDir(args []string) {
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
 	_ = fs.Parse(args)
 
-	if fs.NArg() < 1 {
+	// flag stops parsing at the first non-flag argument, so any option placed
+	// after <directory> is silently left in fs.Args() instead of being applied.
+	if fs.NArg() != 1 {
 		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp import-dir [options] <directory>")
+		fmt.Fprintln(os.Stderr, "Options must come before <directory>.")
 		os.Exit(1)
 	}
 	dirPath := fs.Arg(0)

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -310,6 +310,44 @@ func TestCmdConvertDir_HappyPath(t *testing.T) {
 	}
 }
 
+// TestCmdConvert_OptionsAfterPath exercises the os.Exit(1) path taken when a
+// flag is placed after <docx-file>. Go's flag package stops parsing at the
+// first non-flag argument, so a trailing flag like --convert-image would
+// otherwise be silently ignored instead of applied (#57).
+func TestCmdConvert_OptionsAfterPath(t *testing.T) {
+	if os.Getenv("CMD_CONVERT_OPTIONS_AFTER_PATH_HELPER") == "1" {
+		cmdConvert([]string{"some.docx", "-convert-image"})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdConvert_OptionsAfterPath")
+	cmd.Env = append(os.Environ(), "CMD_CONVERT_OPTIONS_AFTER_PATH_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when an option follows <docx-file>")
+	}
+	if !strings.Contains(string(stderr), "Options must come before <docx-file>") {
+		t.Errorf("expected stderr to explain option order, got: %s", stderr)
+	}
+}
+
+// TestCmdConvertDir_OptionsAfterPath is the import-dir counterpart of
+// TestCmdConvert_OptionsAfterPath (#57).
+func TestCmdConvertDir_OptionsAfterPath(t *testing.T) {
+	if os.Getenv("CMD_CONVERT_DIR_OPTIONS_AFTER_PATH_HELPER") == "1" {
+		cmdConvertDir([]string{"./specs", "-convert-image"})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdConvertDir_OptionsAfterPath")
+	cmd.Env = append(os.Environ(), "CMD_CONVERT_DIR_OPTIONS_AFTER_PATH_HELPER=1")
+	stderr, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected non-zero exit when an option follows <directory>")
+	}
+	if !strings.Contains(string(stderr), "Options must come before <directory>") {
+		t.Errorf("expected stderr to explain option order, got: %s", stderr)
+	}
+}
+
 // TestCmdDownload_NoMatch verifies cmdDownload cleanly returns when the spec
 // list yields zero specs after filtering (exercises flag parsing, resolveSpecs
 // file-load branch, and the early return path).


### PR DESCRIPTION
## Summary
- Go's `flag` package stops parsing at the first non-flag argument, so running e.g. `3gpp-mcp import-dir --db data/3gpp.db ./specs --convert-image` (directory before the flag) silently ignores `--convert-image` instead of applying it.
- `cmdConvert` (`import`) and `cmdConvertDir` (`import-dir`) now reject any extra positional arguments left over after parsing, with a usage message that explains options must come before the path.
- Documented the ordering requirement in the README for both commands.

Closes #57

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `golangci-lint run ./...`
- [x] `go test -race -coverprofile=coverage.out ./...`
- [x] Added `TestCmdConvert_OptionsAfterPath` / `TestCmdConvertDir_OptionsAfterPath` regression tests reproducing the exact reported command ordering


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpjVesXEenABkBBukvbwHf)_