### PR TITLE
fix(docx): bound soffice invocation with a timeout

### DIFF
--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -3,6 +3,7 @@ package docx
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // toPNGName replaces a filename's extension with .png.
@@ -305,6 +307,11 @@ func batchConvertToPNG(ctx context.Context, items []*batchItem) error {
 	return nil
 }
 
+// sofficeTimeout bounds a single soffice invocation. LibreOffice occasionally
+// hangs indefinitely in headless mode (e.g. a stuck first-run profile setup),
+// which would otherwise block ConvertDir forever; see issue #60.
+const sofficeTimeout = 5 * time.Minute
+
 // runSofficeBatch invokes `soffice --convert-to png` with the given inputs,
 // writing PNG outputs to outDir. Each invocation uses a fresh user profile
 // so that repeated calls do not contend for LibreOffice's per-profile lock.
@@ -318,6 +325,9 @@ func runSofficeBatch(ctx context.Context, outDir string, inputs []string) error 
 	}
 	defer os.RemoveAll(profileDir)
 
+	ctx, cancel := context.WithTimeout(ctx, sofficeTimeout)
+	defer cancel()
+
 	args := []string{
 		"--headless",
 		"--norestore",
@@ -330,6 +340,9 @@ func runSofficeBatch(ctx context.Context, outDir string, inputs []string) error 
 	cmd := exec.CommandContext(ctx, "soffice", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("soffice timed out after %s (output: %s)", sofficeTimeout, string(output))
+		}
 		return fmt.Errorf("%w (output: %s)", err, string(output))
 	}
 	return nil

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestConvertResultImages_Real downloads TS 26.274 from the 3GPP archive and
@@ -326,5 +327,28 @@ func TestUpdateImagePlaceholders_TableImageRef(t *testing.T) {
 	wantPNG := `<table><tr><td><img src="image://image3.png" alt="Figure"></td></tr></table>`
 	if got[2] != wantPNG {
 		t.Errorf("already-PNG table img should be unchanged:\n got:  %q\n want: %q", got[2], wantPNG)
+	}
+}
+
+// TestRunSofficeBatch_Timeout verifies that runSofficeBatch reports a
+// dedicated timeout error instead of hanging when the context deadline is
+// exceeded (see issue #60). Uses an already-expired parent deadline so the
+// test runs instantly and does not depend on soffice being installed.
+func TestRunSofficeBatch_Timeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "a.emf")
+	if err := os.WriteFile(inputPath, []byte("not a real emf"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	err := runSofficeBatch(ctx, tmpDir, []string{inputPath})
+	if err == nil {
+		t.Fatal("expected error for expired context, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `runSofficeBatch` had no timeout, so a hung `soffice` process (e.g. a stuck headless first-run) blocked `import-dir --convert-image` forever, as reported in #60.
- Wrap the soffice invocation's context with a 5-minute timeout. On timeout the batch fails with a clear error instead of hanging, and `ConvertDir` continues with the other files.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `go test -race -short ./...`
- [ ] `golangci-lint run` — could not run in this environment (golangci-lint binary built with go1.25, repo targets go1.26; pre-existing environment limitation unrelated to this change)

Closes #60