### PR TITLE
release: pass Apple credentials to goreleaser directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,6 @@ jobs:
         with:
           go-version-file: go.mod
       -
-        name: Install rcodesign
-        run: |
-          cd /tmp
-          curl -LO https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.27.0/apple-codesign-0.27.0-x86_64-unknown-linux-musl.tar.gz
-          tar xzf apple-codesign-0.27.0-x86_64-unknown-linux-musl.tar.gz
-          sudo mv apple-codesign-0.27.0-x86_64-unknown-linux-musl/rcodesign /usr/local/bin/
-          rm -rf apple-codesign-0.27.0-x86_64-unknown-linux-musl*
-      -
-        name: Decode Apple credentials
-        env:
-          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-          AC_API_KEY_P8_BASE64: ${{ secrets.AC_API_KEY_P8_BASE64 }}
-        run: |
-          echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 -d > /tmp/certificate.p12
-          echo "$AC_API_KEY_P8_BASE64" | base64 -d > /tmp/api_key.p8
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -48,8 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          APPLE_CERTIFICATE_P12: /tmp/certificate.p12
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
           AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
-          AC_API_KEY_P8: /tmp/api_key.p8
+          AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8_BASE64 }}


### PR DESCRIPTION
## Why

Releases here work fine, so this is a cleanup rather than a fix — it ports two changes from [higebu/rfc-mcp#2](https://github.com/higebu/rfc-mcp/pull/2), where this same workflow (byte-identical before this change) failed in a way that took a while to diagnose.

On rfc-mcp the Apple secrets were not registered yet, and the failure surfaced two minutes into the run as:

```
⨯ release failed after 2m12s
  error=unable to decode p12 file: pkcs12: error reading P12 data: asn1: syntax error: sequence truncated
```

`base64 -d` exits 0 on empty input, so the decode step turned an unset secret into a 0-byte `/tmp/certificate.p12`, and the real problem (a missing secret) only showed up as an ASN.1 parse error deep inside the signer.

## What

- Drop the `Decode Apple credentials` step. goreleaser accepts base64'd contents in place of a file path for both `notarize.macos[].sign.certificate` and `notarize.macos[].notarize.key`, so the secrets go straight into the env — no intermediate file that can silently be empty. A missing secret now fails at template evaluation with the variable name in the message.
- Drop the `Install rcodesign` step. goreleaser v2 signs macOS binaries with its built-in quill and never invoked `rcodesign` — the 10 MB download and `sudo mv` were dead weight on every release. The `pkcs12:` error above coming from goreleaser's own Go code confirms it.

`.goreleaser.yaml` is unchanged; the env var names stay the same, only their contents change from a path to base64. The job is now Checkout → Set up Go → Run GoReleaser.

## Verification

Verified on rfc-mcp, which carries this exact workflow:

- `goreleaser check` passes.
- Dry run with a self-signed p12 and dummy p8 passed as base64 env vars: `goreleaser release --snapshot --clean --skip=homebrew,publish` builds all 8 targets, then stops at `no certificates found for CN="Developer ID Application: Test"` — the p12 is decoded and unlocked, only the (expected) lack of a real Apple chain stops it. The old code path died earlier, at `unable to decode p12 file`.
- Real release: [run 30248440022](https://github.com/higebu/rfc-mcp/actions/runs/30248440022) succeeded end to end with these two steps removed — 8 archives + checksums published, notarization passed, and the Homebrew cask landed in `higebu/homebrew-tap`.

Existing secrets on this repo already hold base64 (the old decode step assumed it), so nothing needs re-entering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmQWqbhUHCBqt5G2HLxs6P)_