### PR TITLE
fix(cmd): add --convert-doc flag to import-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Import all `.docx` files in a directory into the database. Alias: `convert-dir`.
 |------|-------------|---------|
 | `--db` | Output SQLite database path | `3gpp.db` |
 | `--parse-workers` | Number of parallel parse workers | NumCPU |
+| `--convert-doc` | Convert `.doc` to `.docx` using LibreOffice | `false` |
 | `--convert-image` | Convert EMF/WMF images to PNG using LibreOffice | `false` |
 
 Usage: `3gpp-mcp import-dir --db data/3gpp.db ./specs`

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -253,6 +253,7 @@ func cmdConvertDir(args []string) {
 	fs := flag.NewFlagSet("import-dir", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "Output SQLite database path")
 	workers := fs.Int("parse-workers", runtime.NumCPU(), "Number of parallel parse workers")
+	convertDoc := fs.Bool("convert-doc", false, "Convert .doc to .docx using LibreOffice")
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
 	_ = fs.Parse(args)
 
@@ -278,7 +279,7 @@ func cmdConvertDir(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	if err := pipeline.ConvertDir(ctx, d, dirPath, *workers, *convertImage); err != nil {
+	if err := pipeline.ConvertDir(ctx, d, dirPath, *workers, *convertDoc, *convertImage); err != nil {
 		log.Fatalf("Convert dir failed: %v", err)
 	}
 }

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -310,6 +310,42 @@ func TestCmdConvertDir_HappyPath(t *testing.T) {
 	}
 }
 
+// TestCmdConvertDir_ConvertDocFlag verifies that import-dir accepts
+// -convert-doc (#63). The directory has no .doc files, so ConvertDocFiles is
+// a no-op and this does not require LibreOffice to be installed.
+func TestCmdConvertDir_ConvertDocFlag(t *testing.T) {
+	srcDocx := testdataDocxPath(t)
+	if _, err := os.Stat(srcDocx); err != nil {
+		t.Skipf("testdata .docx not available: %v", err)
+	}
+	docxBytes, err := os.ReadFile(srcDocx)
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "23274-i20.docx"), docxBytes, 0o644); err != nil {
+		t.Fatalf("write docx: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), "dir.db")
+
+	_ = captureStdout(t, func() {
+		cmdConvertDir([]string{"-db", dbPath, "-parse-workers", "1", "-convert-doc", dir})
+	})
+
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	result, err := d.ListSpecs("", "", -1, 0)
+	if err != nil {
+		t.Fatalf("list specs: %v", err)
+	}
+	if len(result.Specs) == 0 {
+		t.Error("expected at least one spec inserted")
+	}
+}
+
 // TestCmdConvert_OptionsAfterPath exercises the os.Exit(1) path taken when a
 // flag is placed after <docx-file>. Go's flag package stops parsing at the
 // first non-flag argument, so a trailing flag like --convert-image would

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -348,7 +348,19 @@ func ConvertSingleFile(ctx context.Context, d *db.DB, docxPath string, convertIm
 }
 
 // ConvertDir converts all .docx files in a directory and stores them in the database.
-func ConvertDir(ctx context.Context, d *db.DB, dirPath string, workers int, convertImage bool) error {
+// If convertDoc is true, any .doc files in dirPath are first converted to .docx
+// (written alongside the originals) using LibreOffice before the directory is scanned.
+func ConvertDir(ctx context.Context, d *db.DB, dirPath string, workers int, convertDoc, convertImage bool) error {
+	if convertDoc {
+		n, err := ConvertDocFiles(ctx, dirPath, dirPath)
+		if err != nil {
+			log.Printf("doc conversion: %v", err)
+		}
+		if n > 0 {
+			log.Printf("Converted %d .doc file(s) to .docx", n)
+		}
+	}
+
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -351,13 +351,15 @@ func ConvertSingleFile(ctx context.Context, d *db.DB, docxPath string, convertIm
 // If convertDoc is true, any .doc files in dirPath are first converted to .docx
 // (written alongside the originals) using LibreOffice before the directory is scanned.
 func ConvertDir(ctx context.Context, d *db.DB, dirPath string, workers int, convertDoc, convertImage bool) error {
+	var docConvertErr error
 	if convertDoc {
 		n, err := ConvertDocFiles(ctx, dirPath, dirPath)
-		if err != nil {
-			log.Printf("doc conversion: %v", err)
-		}
 		if n > 0 {
 			log.Printf("Converted %d .doc file(s) to .docx", n)
+		}
+		if err != nil {
+			log.Printf("doc conversion: %v", err)
+			docConvertErr = fmt.Errorf("convert .doc files: %w", err)
 		}
 	}
 
@@ -464,5 +466,5 @@ func ConvertDir(ctx context.Context, d *db.DB, dirPath string, workers int, conv
 		log.Printf("  %d of %d files failed to parse", parseErrors, len(files))
 	}
 
-	return nil
+	return docConvertErr
 }

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -86,7 +86,7 @@ func TestConvertDir_Race(t *testing.T) {
 
 	d := setupTestDB(t)
 
-	if err := ConvertDir(context.Background(), d, dir, 4, false); err != nil {
+	if err := ConvertDir(context.Background(), d, dir, 4, false, false); err != nil {
 		t.Fatalf("ConvertDir: %v", err)
 	}
 
@@ -351,12 +351,42 @@ func TestPipelineRun_ContextCancel(t *testing.T) {
 	}
 }
 
+// TestConvertDir_ConvertDocNoDocFiles verifies that passing convertDoc=true
+// to ConvertDir does not break the normal .docx-only import path (#63):
+// ConvertDocFiles is a no-op when the directory has no .doc files, so this
+// does not require LibreOffice.
+func TestConvertDir_ConvertDocNoDocFiles(t *testing.T) {
+	docxData, err := os.ReadFile(testdataDocxPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.docx"), docxData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := setupTestDB(t)
+
+	if err := ConvertDir(context.Background(), d, dir, 1, true, false); err != nil {
+		t.Fatalf("ConvertDir with convertDoc=true: %v", err)
+	}
+
+	result, err := d.ListSpecs("", "", -1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Specs) == 0 {
+		t.Error("expected at least one spec in DB after ConvertDir")
+	}
+}
+
 // TestConvertDir_EmptyDirError verifies ConvertDir returns an error when no
 // .docx files are present.
 func TestConvertDir_EmptyDirError(t *testing.T) {
 	dir := t.TempDir()
 	d := setupTestDB(t)
-	err := ConvertDir(context.Background(), d, dir, 1, false)
+	err := ConvertDir(context.Background(), d, dir, 1, false, false)
 	if err == nil {
 		t.Fatal("expected error for empty directory")
 	}
@@ -369,7 +399,7 @@ func TestConvertDir_EmptyDirError(t *testing.T) {
 // when the directory does not exist.
 func TestConvertDir_MissingDir(t *testing.T) {
 	d := setupTestDB(t)
-	err := ConvertDir(context.Background(), d, filepath.Join(t.TempDir(), "nope"), 1, false)
+	err := ConvertDir(context.Background(), d, filepath.Join(t.TempDir(), "nope"), 1, false, false)
 	if err == nil {
 		t.Fatal("expected error for missing directory")
 	}

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -381,6 +381,44 @@ func TestConvertDir_ConvertDocNoDocFiles(t *testing.T) {
 	}
 }
 
+// TestConvertDir_ConvertDocFailurePropagates verifies that a .doc conversion
+// failure is surfaced as a non-nil error from ConvertDir instead of being
+// silently logged (#64 review), while a valid pre-existing .docx in the same
+// directory is still imported. PATH is overridden so the libreoffice
+// invocation fails deterministically regardless of whether LibreOffice is
+// actually installed on the host.
+func TestConvertDir_ConvertDocFailurePropagates(t *testing.T) {
+	docxData, err := os.ReadFile(testdataDocxPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "good.docx"), docxData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bad.doc"), []byte("not a real doc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", t.TempDir())
+
+	d := setupTestDB(t)
+
+	err = ConvertDir(context.Background(), d, dir, 1, true, false)
+	if err == nil {
+		t.Fatal("expected error when .doc conversion fails")
+	}
+
+	result, listErr := d.ListSpecs("", "", -1, 0)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(result.Specs) == 0 {
+		t.Error("expected the pre-existing .docx to still be imported despite the conversion error")
+	}
+}
+
 // TestConvertDir_EmptyDirError verifies ConvertDir returns an error when no
 // .docx files are present.
 func TestConvertDir_EmptyDirError(t *testing.T) {


### PR DESCRIPTION
## Why

`import-dir` did not support `--convert-doc`, even though `build`, `download`, and `update` all do. Directories containing `.doc` files (e.g. specs that only ship as `.doc`, like TS 24.229) could not be imported without a separate manual conversion step.

## What

- `pipeline.ConvertDir` now takes a `convertDoc` parameter. When true, it converts any `.doc` files in the directory to `.docx` (in place, via LibreOffice) before scanning the directory.
- `cmdConvertDir` (the `import-dir` CLI command) gains a `--convert-doc` flag, mirroring the existing flag on `build`/`download`/`update`.
- Updated README flag table for `import-dir`.
- Added tests covering the flag/parameter path without requiring LibreOffice (no `.doc` files present, so the conversion step is a no-op).

Closes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_011DKdVoxki3XYMnwVYNUWMu)_