### PR TITLE
fix(docker): bundle CA certificates in final scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
     --timeout 120s \
     --scrape-workers 4
 
-# 3) Final image: just the binary and the baked-in database.
+# 3) Final image: just the binary, the baked-in database, and CA certificates
+#    (needed for on-demand HTTPS fetches of versions not in the prebuilt DB).
 FROM scratch
+COPY --from=db-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=go-builder /3gpp-mcp /3gpp-mcp
 COPY --from=db-builder /3gpp.db /3gpp.db
 ENTRYPOINT ["/3gpp-mcp"]


### PR DESCRIPTION
## Summary
- The final runtime image is built `FROM scratch` and had no CA certificates, so on-demand HTTPS fetches of spec versions not baked into the prebuilt DB failed with a TLS error.
- Copy `/etc/ssl/certs/ca-certificates.crt` from the `db-builder` stage (which already installs `ca-certificates`) into the final image.

## Test plan
- [ ] `docker build` the image and confirm `get_section`/`list_versions` can fetch a version not in the prebuilt DB without a TLS error

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1p6jQvMhgYhyzNg7wRGcp)_