### PR TITLE
fix: harden security, correctness and robustness across the codebase

### DIFF
--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -254,26 +254,34 @@ func cmdServe(args []string) {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		errCh := make(chan error, 1)
-		go func() { errCh <- server.ListenAndServe() }()
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				log.Fatalf("Server error: %v", err)
-			}
-		case <-ctx.Done():
-			// Drain in-flight requests, then return normally so the deferred
-			// database and version cache closes actually run.
-			log.Println("Shutting down...")
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			if err := server.Shutdown(shutdownCtx); err != nil {
-				log.Printf("Shutdown error: %v", err)
-			}
+		if err := runHTTPServer(ctx, server); err != nil {
+			log.Fatalf("Server error: %v", err)
 		}
 	default:
 		log.Fatalf("Unknown transport: %s", *transport)
 	}
+}
+
+// runHTTPServer serves until the listener fails or ctx is cancelled. On
+// cancellation it drains in-flight requests and returns nil, so the caller's
+// deferred database and version cache closes actually run.
+func runHTTPServer(ctx context.Context, server *http.Server) error {
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.ListenAndServe() }()
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+	case <-ctx.Done():
+		log.Println("Shutting down...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Shutdown error: %v", err)
+		}
+	}
+	return nil
 }
 
 func cmdConvert(args []string) {

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
@@ -34,15 +36,52 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
-	expected := []byte("Bearer " + token)
+	expected := []byte(token)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auth := []byte(r.Header.Get("Authorization"))
-		if subtle.ConstantTimeCompare(auth, expected) != 1 {
+		// RFC 7235 makes the auth-scheme case-insensitive, so split it off
+		// and compare only the credentials in constant time.
+		scheme, credentials, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") ||
+			subtle.ConstantTimeCompare([]byte(strings.TrimSpace(credentials)), expected) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="3gpp-mcp"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// buildHTTPHandler assembles the HTTP transport's handler tree. When a bearer
+// token is set it guards everything except the health probe: the web viewer
+// serves the same corpus as the MCP tools, so leaving it open would make the
+// token meaningless.
+func buildHTTPHandler(d *db.DB, s *mcp.Server, bearerToken string, enableWeb bool) http.Handler {
+	// Stateless mode is required to serve protocol version 2026-07-28,
+	// whose lifecycle has no initialize handshake or Mcp-Session-Id.
+	// Older clients still work: each request runs in a temporary session.
+	// This server never initiates server->client requests, so nothing is
+	// lost by not keeping sessions.
+	mcpHandler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return s },
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	)
+
+	appMux := http.NewServeMux()
+	if enableWeb {
+		appMux.Handle("/mcp/", http.StripPrefix("/mcp", mcpHandler))
+		appMux.Handle("/", web.NewServer(d))
+	} else {
+		appMux.Handle("/", mcpHandler)
+	}
+
+	var app http.Handler = appMux
+	if bearerToken != "" {
+		app = bearerAuthMiddleware(bearerToken, appMux)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
+	mux.Handle("/", app)
+	return mux
 }
 
 func main() {
@@ -191,36 +230,46 @@ func cmdServe(args []string) {
 			log.Fatalf("Server error: %v", err)
 		}
 	case "http":
-		// Stateless mode is required to serve protocol version 2026-07-28,
-		// whose lifecycle has no initialize handshake or Mcp-Session-Id.
-		// Older clients still work: each request runs in a temporary session.
-		// This server never initiates server->client requests, so nothing is
-		// lost by not keeping sessions.
-		mcpHandler := mcp.NewStreamableHTTPHandler(
-			func(r *http.Request) *mcp.Server { return s },
-			&mcp.StreamableHTTPOptions{Stateless: true},
-		)
-		var mcpH http.Handler = mcpHandler
-		if *bearerToken != "" {
-			mcpH = bearerAuthMiddleware(*bearerToken, mcpHandler)
-		} else {
-			log.Println("WARNING: HTTP transport running without authentication. Set -bearer-token or THREEGPP_MCP_BEARER_TOKEN to secure the server.")
-		}
-
-		mux := http.NewServeMux()
-		mux.HandleFunc("/health", healthHandler)
 		if *enableWeb {
-			mux.Handle("/mcp/", http.StripPrefix("/mcp", mcpH))
-			mux.Handle("/", web.NewServer(d))
 			log.Printf("Starting 3gpp-mcp server on %s (HTTP + Web viewer)...", *addr)
 			log.Printf("  MCP endpoint: http://localhost%s/mcp/", *addr)
 			log.Printf("  Web viewer:   http://localhost%s/", *addr)
 		} else {
-			mux.Handle("/", mcpH)
 			log.Printf("Starting 3gpp-mcp server on %s (HTTP)...", *addr)
 		}
-		if err := http.ListenAndServe(*addr, mux); err != nil {
-			log.Fatalf("Server error: %v", err)
+		if *bearerToken == "" {
+			log.Println("WARNING: HTTP transport running without authentication. Set -bearer-token or THREEGPP_MCP_BEARER_TOKEN to secure the server.")
+		}
+
+		server := &http.Server{
+			Addr:    *addr,
+			Handler: buildHTTPHandler(d, s, *bearerToken, *enableWeb),
+			// Bound header reads and idle keep-alives so stalled connections
+			// (slowloris) cannot pile up. No overall write timeout: MCP
+			// responses may legitimately stream for a long time.
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- server.ListenAndServe() }()
+		select {
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Fatalf("Server error: %v", err)
+			}
+		case <-ctx.Done():
+			// Drain in-flight requests, then return normally so the deferred
+			// database and version cache closes actually run.
+			log.Println("Shutting down...")
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				log.Printf("Shutdown error: %v", err)
+			}
 		}
 	default:
 		log.Fatalf("Unknown transport: %s", *transport)

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -828,6 +829,37 @@ func TestBuildHTTPHandler_WebViewerAuth(t *testing.T) {
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("GET / without a configured token = %d, want 200", resp.StatusCode)
+		}
+	})
+}
+
+// TestRunHTTPServer covers the serve loop extracted from cmdServe: graceful
+// shutdown on context cancellation and error propagation on listen failure.
+func TestRunHTTPServer(t *testing.T) {
+	t.Run("graceful shutdown on cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		server := &http.Server{Addr: "127.0.0.1:0", Handler: http.HandlerFunc(healthHandler)}
+
+		done := make(chan error, 1)
+		go func() { done <- runHTTPServer(ctx, server) }()
+		// Give ListenAndServe a moment to bind, then cancel.
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("expected nil after graceful shutdown, got %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("runHTTPServer did not return after cancellation")
+		}
+	})
+
+	t.Run("listen error propagates", func(t *testing.T) {
+		server := &http.Server{Addr: "256.256.256.256:0", Handler: http.HandlerFunc(healthHandler)}
+		if err := runHTTPServer(context.Background(), server); err == nil {
+			t.Error("expected an error for an unbindable address")
 		}
 	})
 }

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -77,6 +77,37 @@ func TestBearerAuthMiddleware(t *testing.T) {
 			t.Errorf("expected 401, got %d", w.Code)
 		}
 	})
+
+	t.Run("scheme is case-insensitive", func(t *testing.T) {
+		// RFC 7235 auth-scheme tokens are case-insensitive; proxies may
+		// normalize the casing.
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "bearer secret-token")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200 for lowercase scheme, got %d", w.Code)
+		}
+	})
+
+	t.Run("401 carries a challenge", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if got := w.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+			t.Errorf("expected a Bearer challenge, got %q", got)
+		}
+	})
+
+	t.Run("token must not match as a prefix", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer secret-token-extra")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
 }
 
 // captureStdout runs fn and returns whatever it wrote to os.Stdout.
@@ -737,4 +768,66 @@ func TestStreamableHTTPNewProtocolRawPOST(t *testing.T) {
 	if id := resp.Header.Get("Mcp-Session-Id"); id != "" {
 		t.Errorf("stateless server issued Mcp-Session-Id %q", id)
 	}
+}
+
+// TestBuildHTTPHandler_WebViewerAuth verifies that a bearer token protects the
+// web viewer too, not just the MCP endpoint: the viewer serves the same corpus
+// as the tools, so an unauthenticated viewer would make the token meaningless.
+func TestBuildHTTPHandler_WebViewerAuth(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	s := newMCPServer(d, tools.NewSource(d))
+
+	t.Run("token set", func(t *testing.T) {
+		handler := buildHTTPHandler(d, s, "secret-token", true)
+		ts := httptest.NewServer(handler)
+		defer ts.Close()
+
+		for _, path := range []string{"/", "/specs/TS%2023.501", "/search?q=architecture", "/mcp/"} {
+			resp, err := http.Get(ts.URL + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("GET %s without token = %d, want 401", path, resp.StatusCode)
+			}
+		}
+
+		// The health probe stays open for load balancers.
+		resp, err := http.Get(ts.URL + "/health")
+		if err != nil {
+			t.Fatalf("GET /health: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /health = %d, want 200", resp.StatusCode)
+		}
+
+		// With the token, the viewer answers.
+		req, _ := http.NewRequest("GET", ts.URL+"/", nil)
+		req.Header.Set("Authorization", "Bearer secret-token")
+		authed, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET / with token: %v", err)
+		}
+		defer authed.Body.Close()
+		if authed.StatusCode != http.StatusOK {
+			t.Errorf("GET / with token = %d, want 200", authed.StatusCode)
+		}
+	})
+
+	t.Run("no token keeps viewer open", func(t *testing.T) {
+		handler := buildHTTPHandler(d, s, "", true)
+		ts := httptest.NewServer(handler)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/")
+		if err != nil {
+			t.Fatalf("GET /: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET / without a configured token = %d, want 200", resp.StatusCode)
+		}
+	})
 }

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -78,9 +78,12 @@ func ConvertResultImages(ctx context.Context, result *ParseResult) int {
 	}
 	n := ConvertImages(ctx, imageMap)
 	if n > 0 {
-		result.Images = result.Images[:0]
-		for _, img := range imageMap {
-			result.Images = append(result.Images, img)
+		// Update in place rather than rebuilding from the map, which would
+		// randomize the order.
+		for i, img := range result.Images {
+			if updated, ok := imageMap[img.Name]; ok {
+				result.Images[i] = updated
+			}
 		}
 	}
 	return n
@@ -218,6 +221,13 @@ func stripEMFPlus(data []byte) []byte {
 	if !hasEMFPlus {
 		return data
 	}
+	if len(out) < emfHeaderMinSize {
+		// The surviving records do not even cover the header, so the fields
+		// at offsets 48/52 cannot be patched (writing into spare capacity
+		// beyond len(out) would be silently dropped). Hand LibreOffice the
+		// original data instead of a corrupt stream.
+		return data
+	}
 
 	// Patch EMF header: file size (offset 48) and record count (offset 52)
 	binary.LittleEndian.PutUint32(out[48:52], uint32(len(out)))
@@ -243,7 +253,7 @@ func batchConvertToPNG(ctx context.Context, items []*batchItem) error {
 	defer os.RemoveAll(tmpDir)
 
 	var inputPaths []string
-	for _, item := range items {
+	for i, item := range items {
 		name := item.original.Name
 		data := item.original.Data
 
@@ -263,6 +273,10 @@ func batchConvertToPNG(ctx context.Context, items []*batchItem) error {
 			data = stripEMFPlus(data)
 		}
 
+		// Prefix with the item index: soffice names every output after the
+		// input's base name, so "image1.emf" and "image1.wmf" in one batch
+		// would both produce "image1.png" and silently share one result.
+		name = fmt.Sprintf("i%d_%s", i, name)
 		inputPath := filepath.Join(tmpDir, name)
 		if err := os.WriteFile(inputPath, data, 0o600); err != nil {
 			item.err = fmt.Errorf("write temp file: %w", err)
@@ -338,6 +352,10 @@ func runSofficeBatch(ctx context.Context, outDir string, inputs []string) error 
 	args = append(args, inputs...)
 
 	cmd := exec.CommandContext(ctx, "soffice", args...)
+	// The soffice wrapper forks soffice.bin; killing only the wrapper on
+	// timeout leaves a child holding the output pipe, which would block
+	// CombinedOutput forever. WaitDelay forcibly releases it.
+	cmd.WaitDelay = 10 * time.Second
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -264,6 +264,42 @@ func TestStripEMFPlus_TooSmall(t *testing.T) {
 	}
 }
 
+// TestStripEMFPlus_ShortOutput covers a header whose declared record size is
+// smaller than the real header: the surviving records then do not reach
+// offset 56, the fileSize/nRecords patch cannot be applied, and the original
+// data must be returned instead of a corrupt stream.
+func TestStripEMFPlus_ShortOutput(t *testing.T) {
+	var data []byte
+
+	// EMR_HEADER claiming recSize=12 (undersized).
+	header := make([]byte, 12)
+	binary.LittleEndian.PutUint32(header[0:4], 0x01)
+	binary.LittleEndian.PutUint32(header[4:8], 12)
+	data = append(data, header...)
+
+	// EMF+ comment record (stripped).
+	comment := make([]byte, 20)
+	binary.LittleEndian.PutUint32(comment[0:4], emrComment)
+	binary.LittleEndian.PutUint32(comment[4:8], 20)
+	binary.LittleEndian.PutUint32(comment[8:12], 8) // DataSize
+	binary.LittleEndian.PutUint32(comment[12:16], emfPlusSignature)
+	data = append(data, comment...)
+
+	// EOF record.
+	eof := make([]byte, 8)
+	binary.LittleEndian.PutUint32(eof[0:4], 0x0E)
+	binary.LittleEndian.PutUint32(eof[4:8], 8)
+	data = append(data, eof...)
+
+	// Pad past the 56-byte minimum so the initial header check passes.
+	data = append(data, make([]byte, 16)...)
+
+	result := stripEMFPlus(data)
+	if len(result) != len(data) {
+		t.Errorf("expected the original data back, got %d of %d bytes", len(result), len(data))
+	}
+}
+
 // sofficeCanConvertImages checks whether LibreOffice Draw is available by
 // attempting a trivial SVG-to-PNG conversion.
 func sofficeCanConvertImages(t *testing.T) bool {

--- a/converter/docx/metadata.go
+++ b/converter/docx/metadata.go
@@ -21,7 +21,11 @@ const (
 )
 
 var (
-	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})(?:-(\d{1,2}))?-?([a-z][0-9a-z]+)`)
+	// The trailing group is the base-36 archive version token: exactly three
+	// characters, each a digit or letter. Legacy releases 1-9 have tokens
+	// that start with a digit ("920" is 9.2.0), so the first character must
+	// not be restricted to letters.
+	filenameRE    = regexp.MustCompile(`^(\d{2})(\d{3})(?:-(\d{1,2}))?-?([0-9a-z]{3})`)
 	specPatternRE = regexp.MustCompile(`(?i)(?:TS|TR)\s*(\d+)\.(\d+)`)
 	versionRE     = regexp.MustCompile(`V(\d+\.\d+\.\d+)`)
 	releaseRE     = regexp.MustCompile(`Release\s+(\d+)`)

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -128,6 +128,27 @@ func TestExtractMetadata_FilenameVariants(t *testing.T) {
 			wantVersion: "19.11.0",
 			wantToken:   "jb0",
 		},
+		{
+			name:        "legacy digit-leading version token",
+			filename:    "23060-920.docx",
+			wantSpecID:  "TS 23.060",
+			wantVersion: "9.2.0",
+			wantToken:   "920",
+		},
+		{
+			name:        "multi-part spec with digit-leading token",
+			filename:    "38101-1-100.docx",
+			wantSpecID:  "TS 38.101-1",
+			wantVersion: "1.0.0",
+			wantToken:   "100",
+		},
+		{
+			name:        "digit-leading token in split body chunk",
+			filename:    "36133-920_s00-11.docx",
+			wantSpecID:  "TS 36.133",
+			wantVersion: "9.2.0",
+			wantToken:   "920",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -40,18 +40,25 @@ type ommlNode struct {
 	Children []*ommlNode
 }
 
+// maxOMMLDepth bounds parseOMMLNode's recursion. Real formulas nest a few
+// dozen levels at most; anything deeper is corrupt or hostile input that
+// would otherwise exhaust the stack.
+const maxOMMLDepth = 100
+
 // ommlToLaTeX consumes the m:oMath / m:oMathPara subtree from d (the start
 // element has already been consumed by the caller) and returns a LaTeX string
 // without surrounding "$" delimiters.
 func ommlToLaTeX(d *xml.Decoder, start xml.StartElement) string {
-	root := parseOMMLNode(d, start)
+	root := parseOMMLNode(d, start, 0)
 	return strings.TrimSpace(renderOMML(root))
 }
 
 // parseOMMLNode builds the subtree rooted at start, reading tokens from d until
 // the matching end element. It recurses into every child (including unknown
 // elements) so the decoder is always balanced regardless of the OMML content.
-func parseOMMLNode(d *xml.Decoder, start xml.StartElement) *ommlNode {
+// Children beyond maxOMMLDepth are consumed (keeping the decoder balanced) but
+// not retained.
+func parseOMMLNode(d *xml.Decoder, start xml.StartElement, depth int) *ommlNode {
 	n := &ommlNode{Local: start.Name.Local}
 	for _, a := range start.Attr {
 		if n.Attr == nil {
@@ -66,7 +73,11 @@ func parseOMMLNode(d *xml.Decoder, start xml.StartElement) *ommlNode {
 		}
 		switch t := tok.(type) {
 		case xml.StartElement:
-			n.Children = append(n.Children, parseOMMLNode(d, t))
+			if depth >= maxOMMLDepth {
+				_ = d.Skip()
+				continue
+			}
+			n.Children = append(n.Children, parseOMMLNode(d, t, depth+1))
 		case xml.CharData:
 			n.Text += string(t)
 		case xml.EndElement:

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -243,3 +243,31 @@ func TestEscapeMathText(t *testing.T) {
 		}
 	}
 }
+
+// TestParseOMMLNode_DepthCap verifies that absurdly nested OMML cannot
+// exhaust the stack: children past the cap are consumed but not retained.
+func TestParseOMMLNode_DepthCap(t *testing.T) {
+	depth := maxOMMLDepth + 50
+	var sb strings.Builder
+	sb.WriteString(`<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">`)
+	for range depth {
+		sb.WriteString("<m:e>")
+	}
+	sb.WriteString(`<m:t>x</m:t>`)
+	for range depth {
+		sb.WriteString("</m:e>")
+	}
+	sb.WriteString(`</m:oMath>`)
+
+	d := xml.NewDecoder(strings.NewReader(sb.String()))
+	tok, err := d.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := tok.(xml.StartElement)
+	// Must terminate without a stack overflow and leave the decoder balanced.
+	_ = ommlToLaTeX(d, start)
+	if _, err := d.Token(); err == nil {
+		t.Error("expected the decoder to be fully consumed")
+	}
+}

--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -320,7 +320,16 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 // equivalent mc:Fallback in the legacy VML form for compatibility, and this
 // converter only understands VML shapes, so processing both would double
 // every label and image.
-func scanDrawingSubtree(d *xml.Decoder, _ xml.StartElement) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
+func scanDrawingSubtree(d *xml.Decoder, start xml.StartElement) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
+	return scanDrawingSubtreeDepth(d, start, 0)
+}
+
+// maxDrawingDepth bounds scanDrawingSubtree's recursion. Real diagrams nest a
+// handful of levels; anything deeper is corrupt or hostile input that would
+// otherwise exhaust the stack.
+const maxDrawingDepth = 100
+
+func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, depth int) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
 	for {
 		tok, err := d.Token()
 		if err != nil {
@@ -359,7 +368,11 @@ func scanDrawingSubtree(d *xml.Decoder, _ xml.StartElement) (imgs []imageRef, la
 				if t.Name.Local == "group" {
 					hasGroup = true
 				}
-				subImgs, subLabels, subHasGroup, subHasRaster := scanDrawingSubtree(d, t)
+				if depth >= maxDrawingDepth {
+					_ = d.Skip()
+					continue
+				}
+				subImgs, subLabels, subHasGroup, subHasRaster := scanDrawingSubtreeDepth(d, t, depth+1)
 				imgs = append(imgs, subImgs...)
 				labels = append(labels, subLabels...)
 				hasGroup = hasGroup || subHasGroup

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -1,6 +1,7 @@
 package docx
 
 import (
+	"encoding/xml"
 	"strings"
 	"testing"
 )
@@ -610,5 +611,32 @@ func TestParseShapeStyle(t *testing.T) {
 				t.Errorf("parseShapeStyle(%q) = (%d, %d), want (%d, %d)", tt.in, w, h, tt.w, tt.h)
 			}
 		})
+	}
+}
+
+// TestScanDrawingSubtree_DepthCap verifies that absurdly nested shape markup
+// cannot exhaust the stack; the decoder still ends up balanced.
+func TestScanDrawingSubtree_DepthCap(t *testing.T) {
+	depth := maxDrawingDepth + 50
+	var sb strings.Builder
+	sb.WriteString("<pict>")
+	for range depth {
+		sb.WriteString("<shape>")
+	}
+	sb.WriteString(`<imagedata id="rId9"/>`)
+	for range depth {
+		sb.WriteString("</shape>")
+	}
+	sb.WriteString("</pict>")
+
+	d := xml.NewDecoder(strings.NewReader(sb.String()))
+	tok, err := d.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := tok.(xml.StartElement)
+	_, _, _, _ = scanDrawingSubtree(d, start)
+	if _, err := d.Token(); err == nil {
+		t.Error("expected the decoder to be fully consumed")
 	}
 }

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -122,8 +123,14 @@ func parseBody(data []byte) ([]bodyElement, error) {
 
 	for {
 		tok, err := decoder.Token()
-		if err != nil {
+		if errors.Is(err, io.EOF) {
 			break
+		}
+		if err != nil {
+			// A decode error means the document is truncated or malformed.
+			// Returning the partial elements as a success would let a
+			// half-parsed document replace a previously complete import.
+			return nil, fmt.Errorf("decode document.xml: %w", err)
 		}
 
 		switch t := tok.(type) {

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -776,3 +776,27 @@ func TestHeadingStyles(t *testing.T) {
 		t.Errorf("getHeadingLevel('Normal') = %d, want 0", level)
 	}
 }
+
+// TestParseBody_TruncatedXML verifies that a decode error surfaces instead of
+// silently returning the elements parsed so far: a half-parsed document must
+// not be imported as a complete one.
+func TestParseBody_TruncatedXML(t *testing.T) {
+	full := `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+		`<w:p><w:r><w:t>hello</w:t></w:r></w:p>` +
+		`<w:p><w:r><w:t>world</w:t></w:r></w:p>` +
+		`</w:body></w:document>`
+
+	if _, err := parseBody([]byte(full)); err != nil {
+		t.Fatalf("well-formed body: %v", err)
+	}
+
+	truncated := full[:len(full)/2]
+	if _, err := parseBody([]byte(truncated)); err == nil {
+		t.Error("expected an error for truncated document.xml")
+	}
+
+	malformed := `<w:document><w:body><w:p></w:tbl></w:body></w:document>`
+	if _, err := parseBody([]byte(malformed)); err == nil {
+		t.Error("expected an error for mismatched tags")
+	}
+}

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -19,12 +19,18 @@ import (
 
 const defaultMaxZipSizeMB = 512
 
+// sofficeTimeout bounds a single LibreOffice invocation; headless conversions
+// occasionally hang forever (e.g. a stuck first-run profile setup).
+const sofficeTimeout = 5 * time.Minute
+
 // maxZipSize is the upper limit for ZIP downloads. Configurable via THREEGPP_MAX_ZIP_SIZE_MB.
 var maxZipSize = int64(defaultMaxZipSizeMB) << 20
 
 func init() {
 	if v := os.Getenv("THREEGPP_MAX_ZIP_SIZE_MB"); v != "" {
-		if mb, err := strconv.ParseInt(v, 10, 64); err == nil && mb > 0 {
+		// The upper bound keeps the <<20 shift from overflowing int64 into a
+		// negative limit that would reject every download.
+		if mb, err := strconv.ParseInt(v, 10, 64); err == nil && mb > 0 && mb <= (1<<63-1)>>20 {
 			maxZipSize = mb << 20
 		}
 	}
@@ -181,14 +187,22 @@ func ConvertDocFiles(ctx context.Context, docDir, outputDir string) (int, error)
 			failed++
 			continue
 		}
-		cmd := exec.CommandContext(ctx, "libreoffice",
+		// LibreOffice occasionally hangs indefinitely in headless mode, so
+		// each invocation gets its own deadline. WaitDelay covers the case
+		// where a leftover child process keeps the output pipe open after
+		// the wrapper is killed, which would otherwise block CombinedOutput
+		// past the context cancellation.
+		convertCtx, cancel := context.WithTimeout(ctx, sofficeTimeout)
+		cmd := exec.CommandContext(convertCtx, "libreoffice",
 			"--headless",
 			"-env:UserInstallation=file://"+profileDir,
 			"--convert-to", "docx",
 			"--outdir", outputDir,
 			inPath,
 		)
+		cmd.WaitDelay = 10 * time.Second
 		out, err := cmd.CombinedOutput()
+		cancel()
 		_ = os.RemoveAll(profileDir)
 		if err != nil {
 			log.Printf("  libreoffice convert %s: %v\n%s", entry.Name(), err, string(out))
@@ -345,8 +359,10 @@ func extractFile(f *zip.File, outPath string) error {
 		return err
 	}
 	defer out.Close() // safety net; explicit Close below handles errors
-	// Limit extraction size to prevent decompression bombs.
-	n, err := io.Copy(out, io.LimitReader(rc, maxZipSize))
+	// Limit extraction size to prevent decompression bombs. Reading one byte
+	// past the limit distinguishes a file of exactly maxZipSize (valid) from
+	// a truncated larger one.
+	n, err := io.Copy(out, io.LimitReader(rc, maxZipSize+1))
 	if closeErr := out.Close(); closeErr != nil && err == nil {
 		err = closeErr
 	}
@@ -354,7 +370,7 @@ func extractFile(f *zip.File, outPath string) error {
 		_ = os.Remove(outPath)
 		return err
 	}
-	if n >= maxZipSize {
+	if n > maxZipSize {
 		_ = os.Remove(outPath)
 		return fmt.Errorf("extracted file %s exceeds maximum size of %d MB", f.Name, maxZipSize>>20)
 	}

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -97,13 +97,20 @@ func ResolveVersion(ctx context.Context, client *http.Client, specID, version st
 
 // releaseRequest recognises a bare release selector such as "18" or "Rel-18".
 // A dotted version is never a release selector, so "18.6.0" does not match.
+// Without a prefix, only one or two digits count: a three-digit string such
+// as "920" is a base-36 archive token (9.2.0), not a request for Rel-920.
 func releaseRequest(s string) (int, bool) {
 	trimmed := s
+	prefixed := false
 	for _, prefix := range []string{"Rel-", "rel-", "REL-", "R", "r"} {
 		if len(trimmed) > len(prefix) && trimmed[:len(prefix)] == prefix {
 			trimmed = trimmed[len(prefix):]
+			prefixed = true
 			break
 		}
+	}
+	if !prefixed && len(trimmed) > 2 {
+		return 0, false
 	}
 	n, err := strconv.Atoi(trimmed)
 	if err != nil || n < 0 {

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -113,6 +113,11 @@ func TestReleaseRequest(t *testing.T) {
 		{"i60", 0, false},
 		{"", 0, false},
 		{"Rel-", 0, false},
+		// A bare three-digit string is an archive token (9.2.0), never a
+		// release selector.
+		{"920", 0, false},
+		{"100", 0, false},
+		{"Rel-920", 920, true},
 	}
 	for _, tt := range tests {
 		got, ok := releaseRequest(tt.in)

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -74,10 +74,11 @@ func (p *Pipeline) Run(ctx context.Context, specs []*SpecVersion) error {
 	total := len(specs)
 
 	for i, spec := range specs {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+		if ctx.Err() != nil {
+			// Stop launching, but fall through to wg.Wait: workers still
+			// running must finish (or notice the cancellation) so their
+			// temp directories are removed and DB writes complete.
+			break
 		}
 
 		spec := spec
@@ -133,6 +134,13 @@ func (p *Pipeline) Run(ctx context.Context, specs []*SpecVersion) error {
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// A run where nothing succeeded should not report success to cron/CI.
+	if len(specs) > 0 && stats["OK"] == 0 && stats["FAILED"] > 0 {
+		return fmt.Errorf("all %d specs failed", stats["FAILED"])
+	}
 	return nil
 }
 

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -550,3 +550,50 @@ func TestSortCoverLast(t *testing.T) {
 	sortCoverLast(nil)
 	sortCoverLast([]string{})
 }
+
+// TestPipelineRun_CanceledContext verifies that a cancelled context stops the
+// run with the context error after waiting for workers.
+func TestPipelineRun_CanceledContext(t *testing.T) {
+	d := setupTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := &Pipeline{DB: d, Workers: 1, Timeout: time.Second}
+	specs := []*SpecVersion{{SpecID: "23.501", URL: "http://192.0.2.1/none.zip"}}
+	if err := p.Run(ctx, specs); err == nil {
+		t.Error("expected the context error, got nil")
+	}
+}
+
+// TestPipelineRun_AllFailed verifies that a run in which every spec failed
+// reports an error instead of success, so cron/CI builds cannot silently
+// produce an empty database.
+func TestPipelineRun_AllFailed(t *testing.T) {
+	// A valid ZIP whose only .docx cannot be parsed makes processOne fail
+	// quickly, without the download retry backoff.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create("bad.docx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("not a docx")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer ts.Close()
+
+	d := setupTestDB(t)
+	p := &Pipeline{DB: d, Client: ts.Client(), Workers: 1, Timeout: 10 * time.Second}
+	specs := []*SpecVersion{{SpecID: "23.501", Filename: "23501-i60.zip", URL: ts.URL + "/23501-i60.zip"}}
+	if err := p.Run(context.Background(), specs); err == nil {
+		t.Error("expected an error when every spec failed")
+	}
+}

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -178,10 +179,14 @@ func FetchSpecZips(ctx context.Context, client *http.Client, specID string, useC
 		normalized = normalized[:2] + "." + normalized[2:]
 	}
 
-	parts := strings.SplitN(normalized, ".", 2)
-	if len(parts) != 2 {
+	// The normalized ID becomes both a cache filename component and a URL
+	// path segment, so anything that is not a plain spec directory name
+	// (path separators, "..", wildcards) must be rejected here.
+	if !specDirRE.MatchString(normalized) {
 		return nil, fmt.Errorf("invalid spec ID format: %s", specID)
 	}
+
+	parts := strings.SplitN(normalized, ".", 2)
 
 	// Check cache
 	cacheKey := CacheKey("speczips", normalized)
@@ -271,6 +276,7 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 	var allSpecPairs []specPair
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	var fetchFailures atomic.Int64
 	sem := make(chan struct{}, scrapeConcurrency)
 
 	for _, sd := range seriesDirs {
@@ -283,6 +289,7 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			html, err := fetchPage(ctx, client, baseURL+sd+"/")
 			if err != nil {
 				log.Printf("Failed to fetch %s: %v", sd, err)
+				fetchFailures.Add(1)
 				return
 			}
 			links := extractLinks(html)
@@ -313,6 +320,7 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			html, err := fetchPage(ctx, client, baseURL+pair.seriesDir+"/"+pair.specDir+"/")
 			if err != nil {
 				log.Printf("Failed to fetch %s/%s: %v", pair.seriesDir, pair.specDir, err)
+				fetchFailures.Add(1)
 				return
 			}
 			links := extractLinks(html)
@@ -329,7 +337,11 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 
 	log.Printf("Total: %d spec versions found", len(entries))
 
-	if useCache {
+	// A list missing the specs whose listings failed to fetch must not be
+	// cached: every build within the TTL would silently skip them.
+	if failed := fetchFailures.Load(); failed > 0 {
+		log.Printf("warning: %d directory listing(s) failed to fetch; not caching this partial spec list", failed)
+	} else if useCache {
 		if err := SaveCache(cacheKey, entries); err != nil {
 			log.Printf("warning: failed to save cache: %v", err)
 		}

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -356,3 +356,48 @@ func TestFetchSpecList_Race(t *testing.T) {
 		t.Errorf("expected %d entries, got %d", expected, len(entries))
 	}
 }
+
+// TestFetchSpecList_PartialNotCached verifies that a spec list assembled
+// while some directory listings failed to fetch is not written to the cache:
+// every build within the TTL would otherwise silently miss those specs.
+func TestFetchSpecList_PartialNotCached(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != archivePath {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23.001/">23.001</a>`+"\n"+`<a href="23.002/">23.002</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/23.001/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23001-a00.zip">23001-a00.zip</a>`+"\n")
+	})
+	// 23.002 fails: its listing is missing from the assembled list.
+	mux.HandleFunc(archivePath+"23_series/23.002/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	entries, err := FetchSpecList(context.Background(), client, nil, true, 2)
+	if err != nil {
+		t.Fatalf("FetchSpecList: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry from the healthy spec, got %d", len(entries))
+	}
+
+	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -263,6 +263,21 @@ func TestFetchSpecZips(t *testing.T) {
 			t.Error("expected error for malformed spec ID")
 		}
 	})
+
+	t.Run("path traversal specID rejected", func(t *testing.T) {
+		// The normalized ID becomes a cache filename and a URL path segment,
+		// so traversal sequences must never pass validation.
+		for _, id := range []string{
+			"../../../../etc/passwd",
+			"23.501/../../secret",
+			"..\\..\\config",
+			"23.%",
+		} {
+			if _, err := FetchSpecZips(context.Background(), client, id, true); err == nil {
+				t.Errorf("expected error for spec ID %q", id)
+			}
+		}
+	})
 }
 
 // TestFetchSpecList_Race exercises FetchSpecList with a mock 3GPP directory

--- a/db/db.go
+++ b/db/db.go
@@ -87,11 +87,16 @@ type DB struct {
 	conn *sql.DB
 }
 
+// uriPathEscaper encodes the characters SQLite treats specially in a URI
+// filename, so a literal ?, # or % in a database path is not reinterpreted
+// as a query string, fragment or percent-escape.
+var uriPathEscaper = strings.NewReplacer("%", "%25", "?", "%3F", "#", "%23")
+
 func Open(path string) (*DB, error) {
 	// The driver only honors URI query parameters on "file:" DSNs; on a bare
 	// path it strips the query and opens READWRITE|CREATE, silently creating
 	// an empty database when the path is wrong.
-	conn, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	conn, err := sql.Open("sqlite", "file:"+uriPathEscaper.Replace(path)+"?mode=ro")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -88,7 +88,10 @@ type DB struct {
 }
 
 func Open(path string) (*DB, error) {
-	conn, err := sql.Open("sqlite", path+"?mode=ro")
+	// The driver only honors URI query parameters on "file:" DSNs; on a bare
+	// path it strips the query and opens READWRITE|CREATE, silently creating
+	// an empty database when the path is wrong.
+	conn, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -360,18 +363,27 @@ func (d *DB) UpsertSpec(spec Spec) error {
 
 // UpsertSection deletes then re-inserts a section to trigger FTS update.
 func (d *DB) UpsertSection(section Section) error {
-	_, err := d.conn.Exec(
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
+	_, err = tx.Exec(
 		"DELETE FROM sections WHERE spec_id = ? AND version = ? AND number = ?",
 		section.SpecID, section.Version, section.Number,
 	)
 	if err != nil {
 		return err
 	}
-	_, err = d.conn.Exec(
+	_, err = tx.Exec(
 		"INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?, ?)",
 		section.SpecID, section.Version, section.Number, section.Title, section.Level, section.ParentNumber, section.Content,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // UpsertImage inserts or replaces an image record.
@@ -497,19 +509,23 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	// index has no version column, so a second version of the same spec would
 	// double every hit. Superseding a version therefore drops the old one.
 	// Multi-file specs call this once per DOCX with the same version, so this
-	// only fires on the first call.
-	for _, table := range []string{"sections", "images", "spec_references"} {
-		column, versionColumn := "spec_id", "version"
-		if table == "spec_references" {
-			column, versionColumn = "source_spec_id", "source_version"
+	// only fires on the first call. A file whose version could not be
+	// determined must not wipe correctly-versioned data, so the cleanup is
+	// skipped for it.
+	if spec.Version != "" {
+		for _, table := range []string{"sections", "images", "spec_references"} {
+			column, versionColumn := "spec_id", "version"
+			if table == "spec_references" {
+				column, versionColumn = "source_spec_id", "source_version"
+			}
+			q := fmt.Sprintf("DELETE FROM %s WHERE %s = ? AND %s <> ?", table, column, versionColumn)
+			if _, err = tx.Exec(q, spec.ID, spec.Version); err != nil {
+				return fmt.Errorf("drop superseded %s: %w", table, err)
+			}
 		}
-		q := fmt.Sprintf("DELETE FROM %s WHERE %s = ? AND %s <> ?", table, column, versionColumn)
-		if _, err = tx.Exec(q, spec.ID, spec.Version); err != nil {
-			return fmt.Errorf("drop superseded %s: %w", table, err)
+		if _, err = tx.Exec("DELETE FROM specs WHERE id = ? AND version <> ?", spec.ID, spec.Version); err != nil {
+			return fmt.Errorf("drop superseded spec versions: %w", err)
 		}
-	}
-	if _, err = tx.Exec("DELETE FROM specs WHERE id = ? AND version <> ?", spec.ID, spec.Version); err != nil {
-		return fmt.Errorf("drop superseded spec versions: %w", err)
 	}
 
 	// The spec row is the authority on the version, so child rows take it from
@@ -570,7 +586,7 @@ func (d *DB) ListSpecs(series, query string, limit, offset int) (*ListSpecsResul
 		// Match three ways a user might type the prefix: the bare number
 		// (e.g. "23.501"), or with an explicit "TS "/"TR " document-type
 		// prefix already included (e.g. "TS 23.501").
-		pattern := escapeLikePattern(query) + "%"
+		pattern := EscapeLikePattern(query) + "%"
 		conditions = append(conditions, "(id LIKE ? ESCAPE '\\' OR id LIKE 'TS ' || ? ESCAPE '\\' OR id LIKE 'TR ' || ? ESCAPE '\\')")
 		filterArgs = append(filterArgs, pattern, pattern, pattern)
 	}
@@ -653,10 +669,10 @@ func (d *DB) GetTOC(specID, version string) ([]Section, error) {
 	return sections, nil
 }
 
-// escapeLikePattern escapes SQLite LIKE wildcards (% and _) in a
+// EscapeLikePattern escapes SQLite LIKE wildcards (% and _) in a
 // user-supplied string so it can be used as a literal prefix with an
 // ESCAPE '\' clause.
-func escapeLikePattern(s string) string {
+func EscapeLikePattern(s string) string {
 	r := strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)
 	return r.Replace(s)
 }
@@ -668,7 +684,7 @@ func escapeLikePattern(s string) string {
 func (d *DB) FindSpecIDsByFamily(familyID string) ([]string, error) {
 	rows, err := d.conn.Query(
 		"SELECT DISTINCT id FROM specs WHERE id LIKE ? || '-%' ESCAPE '\\' ORDER BY id",
-		escapeLikePattern(familyID),
+		EscapeLikePattern(familyID),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("find spec ids by family: %w", err)
@@ -707,8 +723,8 @@ func (d *DB) GetSection(specID, version, number string, includeSubsections bool)
 	var rows *sql.Rows
 	if includeSubsections {
 		rows, err = d.conn.Query(
-			projection+" AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
-			specID, version, number, number,
+			projection+" AND (s.number = ? OR s.number LIKE ? || '.%' ESCAPE '\\') ORDER BY s.id",
+			specID, version, number, EscapeLikePattern(number),
 		)
 	} else {
 		rows, err = d.conn.Query(
@@ -839,10 +855,18 @@ var fts5Operators = map[string]bool{
 
 // needsFTS5Quoting reports whether a bare token contains a character FTS5
 // cannot parse as part of an unquoted bareword: a hyphen (misread as the
-// column-filter/NOT operator) or a period (e.g. spec numbers like "38.101",
-// which FTS5 otherwise rejects with "syntax error near \".\"").
+// column-filter/NOT operator), a period (e.g. spec numbers like "38.101",
+// which FTS5 otherwise rejects with "syntax error near \".\""), a stray
+// double quote, or a parenthesis riding along inside the token (an
+// unquoted "(38.331" or "SMF)" is a hard syntax error).
 func needsFTS5Quoting(s string) bool {
-	return strings.ContainsRune(s, '-') || strings.ContainsRune(s, '.')
+	return strings.ContainsAny(s, `-."()`)
+}
+
+// quoteFTS5String wraps s in double quotes, doubling any quote already
+// inside it (FTS5's string escape).
+func quoteFTS5String(s string) string {
+	return "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
 }
 
 // classifyToken quotes a bareword or "col:val" column-filter token if it
@@ -852,14 +876,27 @@ func classifyToken(token string) string {
 		col := token[:colIdx]
 		val := token[colIdx+1:]
 		if fts5Columns[col] {
-			if needsFTS5Quoting(val) && !strings.HasPrefix(val, "\"") {
-				return col + ":\"" + val + "\""
+			if val == "" {
+				// "content:" with no value is a syntax error; treat the
+				// whole token as a literal search term instead.
+				return quoteFTS5String(token)
+			}
+			if strings.HasPrefix(val, "\"") {
+				// Already phrase-quoted (content:"foo"). Repair it if the
+				// closing quote is missing.
+				if len(val) >= 2 && strings.HasSuffix(val, "\"") {
+					return token
+				}
+				return col + ":" + quoteFTS5String(strings.Trim(val, "\""))
+			}
+			if needsFTS5Quoting(val) {
+				return col + ":" + quoteFTS5String(val)
 			}
 			return token
 		}
 	}
 	if needsFTS5Quoting(token) {
-		return "\"" + token + "\""
+		return quoteFTS5String(token)
 	}
 	return token
 }
@@ -887,10 +924,17 @@ func sanitizeFTS5Query(query string) string {
 			for j < n && query[j] != '"' {
 				j++
 			}
-			if j < n {
+			closed := j < n
+			if closed {
 				j++
 			}
-			result = append(result, query[i:j])
+			run := query[i:j]
+			if !closed {
+				// An unterminated phrase would reach FTS5 as a syntax
+				// error; supply the missing closing quote.
+				run += "\""
+			}
+			result = append(result, run)
 			i = j
 			continue
 		}
@@ -937,7 +981,7 @@ func sanitizeFTS5Query(query string) string {
 			if canNegate {
 				result = append(result, "NOT", classifyToken(token[1:]))
 			} else {
-				result = append(result, "\""+token+"\"")
+				result = append(result, quoteFTS5String(token))
 			}
 			continue
 		}
@@ -972,7 +1016,7 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 		conds := make([]string, len(specIDs))
 		for i, id := range specIDs {
 			conds[i] = "sections_fts.spec_id = ? OR sections_fts.spec_id LIKE ? ESCAPE '\\'"
-			args = append(args, id, escapeLikePattern(id)+"-%")
+			args = append(args, id, EscapeLikePattern(id)+"-%")
 		}
 		sqlQuery += " AND (" + strings.Join(conds, " OR ") + ")"
 	}
@@ -1330,9 +1374,9 @@ func (d *DB) GetReferences(specID, version, sectionNumber, direction string, inc
 			return nil, fmt.Errorf("get references: %w", err)
 		}
 		if includeSubsections {
-			where = ` WHERE r.source_spec_id = ? AND r.source_version = ? AND (r.source_section = ? OR r.source_section LIKE ? || '.%')
+			where = ` WHERE r.source_spec_id = ? AND r.source_version = ? AND (r.source_section = ? OR r.source_section LIKE ? || '.%' ESCAPE '\')
 				ORDER BY r.source_section, r.target_spec, r.target_section`
-			args = []any{specID, resolved, sectionNumber, sectionNumber}
+			args = []any{specID, resolved, sectionNumber, EscapeLikePattern(sectionNumber)}
 		} else {
 			where = ` WHERE r.source_spec_id = ? AND r.source_version = ? AND r.source_section = ?
 				ORDER BY r.target_spec, r.target_section`
@@ -1340,9 +1384,9 @@ func (d *DB) GetReferences(specID, version, sectionNumber, direction string, inc
 		}
 	case DirectionIncoming:
 		if sectionNumber != "" {
-			where = ` WHERE r.target_spec = ? AND (r.target_section = ? OR r.target_section LIKE ? || '.%' OR r.target_section = '')
+			where = ` WHERE r.target_spec = ? AND (r.target_section = ? OR r.target_section LIKE ? || '.%' ESCAPE '\' OR r.target_section = '')
 				ORDER BY r.source_spec_id, r.source_section`
-			args = []any{specID, sectionNumber, sectionNumber}
+			args = []any{specID, sectionNumber, EscapeLikePattern(sectionNumber)}
 		} else {
 			where = ` WHERE r.target_spec = ?
 				ORDER BY r.source_spec_id, r.source_section`

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -368,6 +368,8 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"unterminated phrase closed", `"core network`, `"core network"`},
 		{"parentheses quoted literally", "(38.331 OR SMF)", `"(38.331" OR "SMF)"`},
 		{"empty column filter quoted", "content:", `"content:"`},
+		{"balanced quoted column filter unchanged", `content:"band"`, `content:"band"`},
+		{"unterminated quoted column filter repaired", `content:"band`, `content:"band"`},
 	}
 
 	for _, tt := range tests {
@@ -1448,5 +1450,47 @@ func TestInsertSpecWithSections_MultiSectionRefs(t *testing.T) {
 		if !got[want] {
 			t.Errorf("missing multi-ref %s; got: %+v", want, refs)
 		}
+	}
+}
+
+// TestInsertSpec_DropsSupersededVersions covers the one-version-per-spec
+// invariant: importing a new version removes every other version's rows so
+// the FTS index (which has no version column) cannot double search hits.
+func TestInsertSpec_DropsSupersededVersions(t *testing.T) {
+	d := setupTestDB(t)
+
+	insert := func(version string) {
+		t.Helper()
+		err := d.InsertSpecWithSectionsAndImages(
+			Spec{ID: "TS 99.100", Version: version, Title: "Test", Series: "99"},
+			[]Section{{
+				SpecID: "TS 99.100", Version: version, Number: "1", Title: "Scope",
+				Level: 1, Content: "supersededprobe content referencing TS 23.501 clause 5.1",
+			}},
+			[]Image{{SpecID: "TS 99.100", Version: version, Name: "img.png", MIMEType: "image/png", Data: []byte{1}}},
+		)
+		if err != nil {
+			t.Fatalf("insert v%s: %v", version, err)
+		}
+	}
+
+	insert("17.0.0")
+	insert("18.0.0")
+
+	specs, err := d.ListSpecVersions("TS 99.100")
+	if err != nil {
+		t.Fatalf("ListSpecVersions: %v", err)
+	}
+	if len(specs) != 1 || specs[0].Version != "18.0.0" {
+		t.Fatalf("expected only v18.0.0 to remain, got %+v", specs)
+	}
+
+	// The superseded version's sections must be gone from search too.
+	results, err := d.Search("supersededprobe", nil, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected exactly 1 search hit after supersede, got %d", len(results))
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1139,6 +1139,42 @@ func TestOpen_ReadOnly(t *testing.T) {
 	}
 }
 
+// TestOpen_PathWithURIReservedChars guards the file: URI construction: a
+// literal %, # (or ?) in the database path must not be reinterpreted as a
+// percent-escape, fragment or query string.
+func TestOpen_PathWithURIReservedChars(t *testing.T) {
+	// "%41" would percent-decode to "A" and "#" starts a URI fragment if the
+	// path were inserted unencoded. ("?" is excluded: the driver's bare-path
+	// DSN parsing in OpenReadWrite cannot create such a file to begin with.)
+	dbPath := filepath.Join(t.TempDir(), "spec %41 #1.db")
+
+	rw, err := OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadWrite: %v", err)
+	}
+	if err := rw.InitSchema(); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := rw.UpsertSpec(Spec{ID: "TS 23.501", Title: "Arch", Series: "23"}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	rw.Close()
+
+	ro, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer ro.Close()
+
+	result, err := ro.ListSpecs("", "", 0, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	if len(result.Specs) != 1 {
+		t.Errorf("expected the seeded spec, got %+v", result.Specs)
+	}
+}
+
 // TestOpen_MissingFile guards against the driver silently creating an empty
 // database when the path is wrong: serve must fail at startup instead.
 func TestOpen_MissingFile(t *testing.T) {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -303,6 +304,26 @@ func TestGetSection(t *testing.T) {
 			t.Fatalf("expected 0 sections, got %d", len(sections))
 		}
 	})
+
+	t.Run("LIKE wildcards in section number are literal", func(t *testing.T) {
+		// "_" is SQLite's single-character wildcard; unescaped it would match
+		// section 5.1 and its subtree.
+		sections, err := d.GetSection("TS 23.501", "", "5_1", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sections) != 0 {
+			t.Fatalf("expected 0 sections for literal 5_1, got %d", len(sections))
+		}
+		// "%" unescaped would match every dotted section of the spec.
+		sections, err = d.GetSection("TS 23.501", "", "%", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sections) != 0 {
+			t.Fatalf("expected 0 sections for literal %%, got %d", len(sections))
+		}
+	})
 }
 
 func TestSanitizeFTS5Query(t *testing.T) {
@@ -343,6 +364,10 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"leading hyphen column filter with dotted value becomes NOT", "AMF -title:38.101", `AMF NOT title:"38.101"`},
 		{"leading hyphen after AND operator falls back", "AMF AND -excluded", `AMF AND "-excluded"`},
 		{"leading hyphen after OR operator falls back", "AMF OR -excluded", `AMF OR "-excluded"`},
+		{"embedded quote doubled", `Rel-18"`, `"Rel-18"""`},
+		{"unterminated phrase closed", `"core network`, `"core network"`},
+		{"parentheses quoted literally", "(38.331 OR SMF)", `"(38.331" OR "SMF)"`},
+		{"empty column filter quoted", "content:", `"content:"`},
 	}
 
 	for _, tt := range tests {
@@ -388,6 +413,8 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 		"AMF -title:band", "AMF -title:38.101",
 		"AMF AND -excluded", "AMF OR -excluded",
 		"-excluded", "-one-two",
+		`Rel-18"`, `"core network`, "(38.331 OR SMF)", "content:",
+		`AMF"`, `content:"band`,
 	}
 	for _, q := range queries {
 		sanitized := sanitizeFTS5Query(q)
@@ -843,6 +870,25 @@ func TestGetReferences(t *testing.T) {
 			t.Fatal("expected error for invalid direction")
 		}
 	})
+
+	t.Run("LIKE wildcards in section number are literal", func(t *testing.T) {
+		// Unescaped, "%" would match every section with outgoing refs.
+		refs, err := d.GetReferences("TS 24.229", "", "%", "outgoing", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(refs) != 0 {
+			t.Fatalf("expected 0 refs for literal %%, got %d", len(refs))
+		}
+		refs, err = d.GetReferences("TS 33.203", "", "6_1", "incoming", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Only the general spec ref (target_section="") should match, not 6.1.
+		if len(refs) != 1 {
+			t.Fatalf("expected 1 ref for literal 6_1, got %d", len(refs))
+		}
+	})
 }
 
 func TestInsertSpecWithSections_References(t *testing.T) {
@@ -1085,6 +1131,24 @@ func TestOpen_ReadOnly(t *testing.T) {
 	}
 	if len(result.Specs) != 1 || result.Specs[0].ID != "TS 23.501" {
 		t.Errorf("expected TS 23.501, got %+v", result.Specs)
+	}
+
+	// A read-only handle must reject writes.
+	if err := ro.Exec("DELETE FROM specs"); err == nil {
+		t.Error("expected write through read-only handle to fail")
+	}
+}
+
+// TestOpen_MissingFile guards against the driver silently creating an empty
+// database when the path is wrong: serve must fail at startup instead.
+func TestOpen_MissingFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "does-not-exist.db")
+	if d, err := Open(dbPath); err == nil {
+		d.Close()
+		t.Fatal("expected Open to fail for a nonexistent database")
+	}
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Errorf("Open must not create the database file, stat err = %v", err)
 	}
 }
 

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -15,7 +15,7 @@ type GetSectionInput struct {
 	Version            string `json:"version,omitempty" jsonschema:"Specification version to read (e.g. 18.6.0). Also accepts an archive token (i60) or a release selector (Rel-18). Defaults to the version in the database. Use list_versions to see what exists."`
 	IncludeSubsections bool   `json:"include_subsections,omitempty" jsonschema:"Include all subsections (default: false)"`
 	Offset             int    `json:"offset,omitempty" jsonschema:"Start line number (0-based, default: 0)"`
-	MaxLines           int    `json:"max_lines,omitempty" jsonschema:"Maximum number of lines to return (default: 200, 0 = all)"`
+	MaxLines           int    `json:"max_lines,omitempty" jsonschema:"Maximum number of lines to return (default: 200)"`
 	MaxChars           int    `json:"max_chars,omitempty" jsonschema:"Maximum number of characters to return (can be combined with max_lines)"`
 }
 

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -86,6 +86,7 @@ func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolR
 		end = totalLines
 	}
 
+	charLimited := false
 	if maxChars > 0 {
 		charCount := 0
 		charEnd := end
@@ -102,12 +103,14 @@ func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolR
 		}
 		if charEnd < end {
 			end = charEnd
+			charLimited = true
 		}
 	}
 
 	// Smart cut: extend to the next paragraph boundary (empty line).
-	// maxLines * 1.2 caps how far we look ahead.
-	if end < totalLines {
+	// maxLines * 1.2 caps how far we look ahead. When the character budget
+	// decided the cut, extending would silently exceed it, so skip.
+	if !charLimited && end < totalLines {
 		linesUsed := end - offset
 		hardLimit := end + linesUsed/5
 		if hardLimit <= end {

--- a/tools/list_specs.go
+++ b/tools/list_specs.go
@@ -23,6 +23,12 @@ var ListSpecsTool = &mcp.Tool{
 
 func HandleListSpecs(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input ListSpecsInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ListSpecsInput) (*mcp.CallToolResult, any, error) {
+		// A negative limit means "no limit" inside db.ListSpecs, which is
+		// reserved for internal callers; from the tool it would bypass
+		// MaxListSpecsLimit and dump the whole table.
+		if input.Limit < 0 {
+			input.Limit = 0
+		}
 		result, err := d.ListSpecs(input.Series, input.Query, input.Limit, input.Offset)
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to list specs: %v", err)), nil, nil

--- a/tools/openapi.go
+++ b/tools/openapi.go
@@ -51,7 +51,7 @@ type GetOpenAPIInput struct {
 	Path     string `json:"path,omitempty" jsonschema:"Filter by API path (e.g. /nf-instances)"`
 	Schema   string `json:"schema,omitempty" jsonschema:"Filter by schema name (e.g. NFProfile)"`
 	Offset   int    `json:"offset,omitempty" jsonschema:"Start line number for pagination (0-based, default: 0)"`
-	MaxLines int    `json:"max_lines,omitempty" jsonschema:"Maximum lines to return (default: 200, 0 = all)"`
+	MaxLines int    `json:"max_lines,omitempty" jsonschema:"Maximum lines to return (default: 200)"`
 }
 
 var GetOpenAPITool = &mcp.Tool{
@@ -79,10 +79,9 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			if err != nil {
 				return errorResult(fmt.Sprintf("failed to filter openapi: %v", err)), nil, nil
 			}
-			return textResult(filtered), nil, nil
+			content = filtered
 		}
 
-		// No filter: paginate raw content
 		return paginateText(content, input.Offset, input.MaxLines, 0), nil, nil
 	}
 }

--- a/tools/references.go
+++ b/tools/references.go
@@ -9,6 +9,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// MaxReferences bounds a single get_references response.
+const MaxReferences = 500
+
 type GetReferencesInput struct {
 	SpecID             string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
 	SectionNumber      string `json:"section_number,omitempty" jsonschema:"Section number (e.g. 5.1.2). Required for outgoing direction."`
@@ -55,11 +58,22 @@ func HandleGetReferences(d *db.DB) func(ctx context.Context, req *mcp.CallToolRe
 			return textResult("[]"), nil, nil
 		}
 
+		// A heavily-cited spec can have tens of thousands of incoming
+		// references; without a cap a single call would serialize them all.
+		total := len(refs)
+		if total > MaxReferences {
+			refs = refs[:MaxReferences]
+		}
+
 		data, err := json.MarshalIndent(refs, "", "  ")
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to marshal: %v", err)), nil, nil
 		}
 
-		return textResult(string(data)), nil, nil
+		text := string(data)
+		if total > MaxReferences {
+			text += fmt.Sprintf("\n[Truncated: showing %d of %d references. Narrow the query with section_number.]", MaxReferences, total)
+		}
+		return textResult(text), nil, nil
 	}
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -523,6 +523,18 @@ func TestPaginateText(t *testing.T) {
 			t.Errorf("expected at least one line, got: %s", text)
 		}
 	})
+
+	t.Run("max_chars is not exceeded by smart cut", func(t *testing.T) {
+		// The char budget cuts at line 5 (5 lines x 6 chars = 30); the
+		// paragraph boundary at line 6 is within the smart-cut lookahead
+		// (hardLimit = 5 + 5/5 = 6) and must not pull lines past the budget.
+		paraContent := "line1\nline2\nline3\nline4\nline5\n\nline7\nline8\nline9\nline0"
+		result := paginateText(paraContent, 0, 10, 30)
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 1-5 of 10]") {
+			t.Errorf("expected char budget to hold at 5 lines, got: %s", text)
+		}
+	})
 }
 
 func TestHandleGetReferences(t *testing.T) {
@@ -830,4 +842,52 @@ func TestHandleListSpecs_InvalidPagination(t *testing.T) {
 			t.Errorf("expected total_count in output, got: %s", text)
 		}
 	})
+
+	t.Run("negative limit falls back to the default", func(t *testing.T) {
+		// A negative limit reaching db.ListSpecs means "no limit" (internal
+		// use only); the handler must not let tool input select that mode.
+		result, _, err := handler(context.Background(), nil, ListSpecsInput{Limit: -1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, `"limit": 20`) {
+			t.Errorf("expected the default limit of 20, got: %s", text)
+		}
+	})
+}
+
+// TestHandleGetOpenAPI_FilteredPagination verifies that offset/max_lines are
+// honored when a path or schema filter is set, and that a follow-up page
+// actually advances.
+func TestHandleGetOpenAPI_FilteredPagination(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleGetOpenAPI(d)
+
+	first, _, err := handler(context.Background(), nil, GetOpenAPIInput{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement",
+		Path: "/nf-instances", MaxLines: 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	firstText := getTextContent(first)
+	if !strings.Contains(firstText, "[Lines 1-2 of ") {
+		t.Errorf("expected filtered output to paginate, got: %s", firstText)
+	}
+
+	second, _, err := handler(context.Background(), nil, GetOpenAPIInput{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement",
+		Path: "/nf-instances", MaxLines: 2, Offset: 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	secondText := getTextContent(second)
+	if !strings.Contains(secondText, "[Lines 3-") {
+		t.Errorf("expected second page to advance, got: %s", secondText)
+	}
+	if firstText == secondText {
+		t.Error("expected pages to differ")
+	}
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -889,5 +890,39 @@ func TestHandleGetOpenAPI_FilteredPagination(t *testing.T) {
 	}
 	if firstText == secondText {
 		t.Error("expected pages to differ")
+	}
+}
+
+// TestHandleGetReferences_Truncation verifies the response cap: a spec-wide
+// incoming query over a heavily-cited spec is cut at MaxReferences with a
+// notice instead of serializing every row.
+func TestHandleGetReferences_Truncation(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleGetReferences(d)
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO spec_references (source_spec_id, source_version, source_section, target_spec, target_section, context) VALUES ")
+	for i := range MaxReferences + 10 {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, "('TS 90.%03d', '18.0.0', '5.%d', 'TS 23.501', '', 'ctx %d')", i%500, i, i)
+	}
+	if err := d.Exec(sb.String()); err != nil {
+		t.Fatalf("seed references: %v", err)
+	}
+
+	result, _, err := handler(context.Background(), nil, GetReferencesInput{
+		SpecID: "TS 23.501", Direction: "incoming",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, fmt.Sprintf("[Truncated: showing %d of %d references", MaxReferences, MaxReferences+10)) {
+		t.Errorf("expected a truncation notice, got tail: %s", text[len(text)-200:])
+	}
+	if got := strings.Count(text, `"source_spec_id"`); got != MaxReferences {
+		t.Errorf("expected %d serialized references, got %d", MaxReferences, got)
 	}
 }

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -17,11 +17,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/specver"
 	_ "modernc.org/sqlite"
 )
 
@@ -36,6 +38,10 @@ const DefaultLimitBytes int64 = 1024 << 20 // 1 GiB
 // DefaultBudget is how long a caller waits for a fetch before being told to
 // come back. MCP clients time out well before a large spec finishes.
 const DefaultBudget = 60 * time.Second
+
+// maxFetchDuration bounds a detached background fetch. Large specs take a few
+// minutes to download and convert; anything beyond this is a stalled transfer.
+const maxFetchDuration = 30 * time.Minute
 
 // DefaultFileName is the cache file created inside the XDG cache directory.
 const DefaultFileName = "versions.db"
@@ -181,10 +187,11 @@ func (s *Store) Has(specID, version string) (bool, error) {
 	return true, nil
 }
 
-// CachedVersions returns the versions of a spec held in the cache.
+// CachedVersions returns the versions of a spec held in the cache, newest
+// first.
 func (s *Store) CachedVersions(specID string) ([]string, error) {
 	rows, err := s.conn.Query(
-		"SELECT version FROM cache_entries WHERE spec_id = ? ORDER BY version",
+		"SELECT version FROM cache_entries WHERE spec_id = ?",
 		specID,
 	)
 	if err != nil {
@@ -200,7 +207,15 @@ func (s *Store) CachedVersions(specID string) ([]string, error) {
 		}
 		versions = append(versions, v)
 	}
-	return versions, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Dotted versions do not order correctly as text ("18.10.0" would sort
+	// before "18.6.0"), so sort semantically.
+	sort.Slice(versions, func(i, j int) bool {
+		return specver.Compare(versions[i], versions[j]) > 0
+	})
+	return versions, nil
 }
 
 // GetSpec returns the cached spec record for a version.
@@ -237,8 +252,8 @@ func (s *Store) GetSection(specID, version, number string, includeSubsections bo
 		"FROM sections s LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE s.spec_id = ? AND s.version = ?"
 	if includeSubsections {
 		return s.querySections(
-			projection+" AND (s.number = ? OR s.number LIKE ? || '.%') ORDER BY s.id",
-			specID, version, number, number,
+			projection+" AND (s.number = ? OR s.number LIKE ? || '.%' ESCAPE '\\') ORDER BY s.id",
+			specID, version, number, db.EscapeLikePattern(number),
 		)
 	}
 	return s.querySections(projection+" AND s.number = ?", specID, version, number)
@@ -303,11 +318,25 @@ func (s *Store) Ensure(ctx context.Context, specID, version string, sv *pipeline
 	s.mu.Lock()
 	f, running := s.inflight[key]
 	if !running {
+		// Re-check under the lock: a fetch that completed between the Has
+		// call above and here has already been removed from inflight, and
+		// starting a fresh download for it would repeat minutes of work.
+		if cached, err := s.Has(specID, version); err != nil || cached {
+			s.mu.Unlock()
+			return err
+		}
 		f = &fetch{done: make(chan struct{})}
 		s.inflight[key] = f
 		// The fetch outlives this request on purpose: a caller that gives up
 		// waiting should not throw away minutes of download and conversion.
-		go s.run(context.WithoutCancel(ctx), key, specID, version, sv, f)
+		// It still gets a generous deadline: the download path has no overall
+		// timeout of its own, so a stalled connection would otherwise keep
+		// this inflight entry - and every future caller - stuck forever.
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), maxFetchDuration)
+		go func() {
+			defer cancel()
+			s.run(fetchCtx, key, specID, version, sv, f)
+		}()
 	}
 	s.mu.Unlock()
 
@@ -401,7 +430,13 @@ func (s *Store) put(spec db.Spec, sections []db.Section) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit cache transaction: %w", err)
 	}
-	return s.evict(spec.ID, spec.Version)
+	// The version is cached and readable at this point, so an eviction
+	// failure must not be reported as a failed fetch: it only costs cache
+	// size accuracy.
+	if err := s.evict(spec.ID, spec.Version); err != nil {
+		log.Printf("warning: version cache eviction failed: %v", err)
+	}
+	return nil
 }
 
 // evict drops least-recently-used versions until the cache fits its limit. The

--- a/versionstore/versionstore_test.go
+++ b/versionstore/versionstore_test.go
@@ -354,3 +354,52 @@ func TestOpenRejectsUnwritablePath(t *testing.T) {
 		t.Error("Open on an unwritable path should fail so the caller can disable fetching")
 	}
 }
+
+// TestCachedVersionsSemanticOrder checks that versions are ordered by their
+// numeric components, not lexicographically ("18.10.0" after "18.6.0" as
+// text, but newer semantically).
+func TestCachedVersionsSemanticOrder(t *testing.T) {
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 8)
+		return spec, sections, nil
+	})
+	for _, v := range []string{"18.6.0", "18.10.0", "17.9.0"} {
+		if err := s.Ensure(context.Background(), "TS 23.501", v, entry("23.501"), time.Minute); err != nil {
+			t.Fatalf("Ensure %s: %v", v, err)
+		}
+	}
+	versions, err := s.CachedVersions("TS 23.501")
+	if err != nil {
+		t.Fatalf("CachedVersions: %v", err)
+	}
+	want := []string{"18.10.0", "18.6.0", "17.9.0"}
+	if len(versions) != len(want) {
+		t.Fatalf("CachedVersions = %v, want %v", versions, want)
+	}
+	for i := range want {
+		if versions[i] != want[i] {
+			t.Fatalf("CachedVersions = %v, want %v", versions, want)
+		}
+	}
+}
+
+// TestGetSectionWildcardsAreLiteral checks that LIKE metacharacters in a
+// section number do not act as wildcards against the cache.
+func TestGetSectionWildcardsAreLiteral(t *testing.T) {
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 8)
+		return spec, sections, nil
+	})
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	for _, number := range []string{"%", "1_1", "_"} {
+		sections, err := s.GetSection("TS 23.501", "18.6.0", number, true)
+		if err != nil {
+			t.Fatalf("GetSection(%q): %v", number, err)
+		}
+		if len(sections) != 0 {
+			t.Errorf("GetSection(%q) matched %d sections, want 0", number, len(sections))
+		}
+	}
+}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"fmt"
+	htmlpkg "html"
 	"html/template"
 	"log"
 	"net/http"
@@ -83,8 +84,15 @@ type errorData struct {
 
 func (h *handler) initTemplates() {
 	funcMap := template.FuncMap{
-		"safeHTML": func(s string) template.HTML {
-			return template.HTML(s) //nolint:gosec
+		// snippetHTML renders an FTS5 snippet: the surrounding text is raw
+		// document content (which can itself contain HTML and angle-bracket
+		// placeholders like <SUPI>), so everything is escaped and only the
+		// <mark> delimiters that db.Search asked snippet() for are restored.
+		"snippetHTML": func(s string) template.HTML {
+			escaped := htmlpkg.EscapeString(s)
+			escaped = strings.ReplaceAll(escaped, "&lt;mark&gt;", "<mark>")
+			escaped = strings.ReplaceAll(escaped, "&lt;/mark&gt;", "</mark>")
+			return template.HTML(escaped) //nolint:gosec
 		},
 		"specURL": func(specID string) string {
 			return "/specs/" + url.PathEscape(specID)
@@ -141,6 +149,12 @@ func (h *handler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	if page < 1 {
 		page = 1
+	}
+	// Bound the page so the offset multiplication cannot overflow into a
+	// negative value; far beyond any real page count either way.
+	const maxPage = 1_000_000
+	if page > maxPage {
+		page = maxPage
 	}
 	limit := 50
 	offset := (page - 1) * limit

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -155,12 +155,12 @@ func highlightYAML(content string) string {
 
 	iterator, err := lexer.Tokenise(nil, content)
 	if err != nil {
-		return "<pre><code>" + content + "</code></pre>"
+		return "<pre><code>" + htmlpkg.EscapeString(content) + "</code></pre>"
 	}
 
 	var buf bytes.Buffer
 	if err := formatter.Format(&buf, style, iterator); err != nil {
-		return "<pre><code>" + content + "</code></pre>"
+		return "<pre><code>" + htmlpkg.EscapeString(content) + "</code></pre>"
 	}
 	return buf.String()
 }

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -12,7 +12,7 @@
                 <a href="{{sectionURL .SpecID .Number}}">{{.SpecID}}{{if ne .Number .Title}} &sect;{{.Number}}{{end}}</a>
                 <span class="result-title">{{.Title}}</span>
             </h3>
-            <p class="result-snippet">{{safeHTML .Snippet}}</p>
+            <p class="result-snippet">{{snippetHTML .Snippet}}</p>
         </div>
         {{else}}
         <p class="no-results">No results found. Try a different search term.</p>

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -434,6 +434,41 @@ func TestHandleSearch(t *testing.T) {
 	}
 }
 
+// TestHandleSearch_SnippetEscaped verifies that raw HTML inside section
+// content is escaped in search snippets (it would otherwise execute in the
+// viewer's origin), while the <mark> highlight delimiters survive.
+func TestHandleSearch_SnippetEscaped(t *testing.T) {
+	ts, d := setupTestServer(t)
+
+	if err := d.UpsertSection(db.Section{
+		SpecID:  "TS 23.501",
+		Version: "18.6.0",
+		Number:  "9",
+		Title:   "Injected",
+		Level:   1,
+		Content: `The xssprobe placeholder <img src=x onerror=alert(1)> and <SUPI> markers.`,
+	}); err != nil {
+		t.Fatalf("UpsertSection: %v", err)
+	}
+
+	resp, err := http.Get(ts.URL + "/search?q=xssprobe")
+	if err != nil {
+		t.Fatalf("GET /search error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if strings.Contains(body, "<img src=x") {
+		t.Error("raw HTML from section content must not reach the page unescaped")
+	}
+	if !strings.Contains(body, "&lt;img src=x onerror=alert(1)&gt;") {
+		t.Errorf("expected the injected tag to be escaped, got:\n%s", body)
+	}
+	if !strings.Contains(body, "<mark>xssprobe</mark>") {
+		t.Errorf("expected the match highlight to survive escaping, got:\n%s", body)
+	}
+}
+
 func TestHandleOpenAPIList(t *testing.T) {
 	ts, _ := setupTestServer(t)
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -772,3 +772,18 @@ func readBody(t *testing.T, resp *http.Response) string {
 	}
 	return string(data)
 }
+
+// TestHandleIndex_HugePage verifies that an absurd page number cannot
+// overflow the offset computation; the server must still answer.
+func TestHandleIndex_HugePage(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/?page=400000000000000000")
+	if err != nil {
+		t.Fatalf("GET /?page=...: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Fixes 27 defects found in a full code review, grouped into 7 commits by package.

## Security

- **cmd**: the bearer token only wrapped the MCP handler; with `--web` the viewer at `/` served the whole corpus unauthenticated. The token now guards everything except `/health`. Also RFC 7235 case-insensitive scheme, `WWW-Authenticate` challenge, listener timeouts (slowloris) and graceful shutdown on SIGINT/SIGTERM.
- **web**: FTS5 search snippets injected raw section content as trusted HTML (stored-XSS path via a crafted document); snippets are now escaped with only the `mark` delimiters restored. `highlightYAML` error paths escaped too.
- **pipeline**: `spec_id` flowed unvalidated into a cache file path and the archive URL; it is now validated against the spec directory pattern.
- **db/versionstore**: user-supplied section numbers reached `LIKE` unescaped (`%` returned the whole spec).

## Correctness

- **db**: `Open` used a bare-path DSN whose `?mode=ro` the driver strips, so a wrong path silently created an empty database; now a real read-only `file:` URI (with URI-reserved path characters encoded) that fails at startup. `sanitizeFTS5Query` always emits valid FTS5 (embedded quotes, unterminated phrases, parentheses, empty column filters). `UpsertSection` runs in one transaction. An import with no version can no longer wipe correctly versioned data.
- **docx**: legacy digit-leading version tokens (`23060-920.docx` = v9.2.0) now parse instead of importing under the raw filename stem; XML decode errors surface instead of importing a truncated document as complete; recursion depth caps; EMF header-patch and same-basename PNG collision fixes; soffice `WaitDelay`.
- **pipeline**: `Run` waits for in-flight workers on cancellation, reports an error when every spec failed, never caches a partially scraped spec list, treats bare `920` as an archive token rather than Rel-920, and fixes size-limit overflow/off-by-one.

## Robustness

- **versionstore**: a stalled detached fetch poisoned its inflight entry forever (every later call got `ErrInProgress`); fetches are capped at 30 minutes. Eviction failures after a successful commit are no longer reported as failed fetches. Duplicate-download race closed; semantic version ordering.
- **tools**: `list_specs` negative-limit bypass clamped, `get_references` capped at 500 with a truncation notice, `max_chars` no longer exceeded by the smart cut, `get_openapi` paginates filtered output, schema docs corrected.

## Testing

- `go build` / `go vet` / `gofmt` clean, `go test -race ./...` green.
- Added tests: FTS5 quoting cases, LIKE-literal behavior, viewer auth (401 without token, `/health` open), bearer scheme case-insensitivity, `paginateText` char budget, `releaseRequest("920")`, filename token variants, truncated-XML errors, stripEMFPlus short output, read-only open with reserved path characters, path-traversal spec IDs.
- Manual smoke test of `serve --transport http --web` with a token: `/` 401, `/health` 200, lowercase scheme accepted, graceful shutdown on SIGTERM.