### PR TITLE
feat!: remove --all flag, allow --series as sole selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install import import-dir build-db download-specs download-latest-specs download-all-specs update-specs db-info test clean web
+.PHONY: build install import import-dir build-db download-specs download-latest-specs update-specs db-info test clean web
 
 SPECS_DIR ?= specs
 DB_PATH ?= data/3gpp.db
@@ -39,10 +39,6 @@ download-specs: build
 # Download the single latest version of each spec across all releases
 download-latest-specs: build
 	./$(BIN_DIR)/3gpp-mcp download --latest --output-dir $(SPECS_DIR) --convert-doc
-
-# Download all versions of all specs across all releases
-download-all-specs: build
-	./$(BIN_DIR)/3gpp-mcp download --all --output-dir $(SPECS_DIR) --convert-doc
 
 # Update specs in DB to latest versions
 update-specs: build

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Download and import specifications into the database (recommended for initial se
 |------|-------------|---------|
 | `--db` | Output SQLite database path | `3gpp.db` |
 | `--release` | Process specs for a specific release (e.g. `19`) | |
-| `--latest` | Process the latest version across all releases (the default selection) | `false` |
+| `--latest` | Select every spec at its latest version (use when no other selector is given) | `false` |
 | `--spec` | Process a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated (e.g. `23,29`) | |
 | `--workers` | Number of parallel workers | NumCPU |
@@ -380,7 +380,7 @@ Download specifications without conversion.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--release` | Download specs for a specific release | |
-| `--latest` | Download the latest version across all releases (the default selection) | `false` |
+| `--latest` | Select every spec at its latest version (use when no other selector is given) | `false` |
 | `--spec` | Download a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated | |
 | `--output-dir` | Output directory | `specs` |

--- a/README.md
+++ b/README.md
@@ -365,8 +365,7 @@ Download and import specifications into the database (recommended for initial se
 |------|-------------|---------|
 | `--db` | Output SQLite database path | `3gpp.db` |
 | `--release` | Process specs for a specific release (e.g. `19`) | |
-| `--latest` | Process the latest version across all releases | `false` |
-| `--all` | Process all versions | `false` |
+| `--latest` | Process the latest version across all releases (the default selection) | `false` |
 | `--spec` | Process a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated (e.g. `23,29`) | |
 | `--workers` | Number of parallel workers | NumCPU |
@@ -381,8 +380,7 @@ Download specifications without conversion.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--release` | Download specs for a specific release | |
-| `--latest` | Download the latest version across all releases | `false` |
-| `--all` | Download all versions | `false` |
+| `--latest` | Download the latest version across all releases (the default selection) | `false` |
 | `--spec` | Download a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated | |
 | `--output-dir` | Output directory | `specs` |

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -354,8 +354,13 @@ func cmdConvertDir(args []string) {
 	}
 }
 
+// selectorGiven reports whether at least one spec selector flag was provided.
+func selectorGiven(release int, latest bool, spec, series string) bool {
+	return release != 0 || latest || spec != "" || series != ""
+}
+
 // resolveSpecs fetches, parses, and filters specs based on CLI flags.
-func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, seriesFlag string, release int, allVersions, useCache bool, scrapeConcurrency int) []*pipeline.SpecVersion {
+func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, seriesFlag string, release int, useCache bool, scrapeConcurrency int) []*pipeline.SpecVersion {
 	var seriesFilter []string
 	if seriesFlag != "" {
 		seriesFilter = strings.Split(seriesFlag, ",")
@@ -391,14 +396,13 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 	}
 	fmt.Printf("Parsed %d spec entries\n", len(specs))
 
-	return pipeline.FilterSpecs(specs, release, seriesFilter, specFlag, !allVersions)
+	return pipeline.FilterSpecs(specs, release, seriesFilter, specFlag, true)
 }
 
 func cmdDownload(args []string) {
 	fs := flag.NewFlagSet("download", flag.ExitOnError)
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
-	latest := fs.Bool("latest", false, "Download the single latest version of each spec")
-	allVersions := fs.Bool("all", false, "Download all versions")
+	latest := fs.Bool("latest", false, "Download the single latest version of each spec (the default selection)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
 	outputDir := fs.String("output-dir", "specs", "Output directory")
@@ -410,15 +414,15 @@ func cmdDownload(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	if *release == 0 && !*latest && !*allVersions && *specFlag == "" {
-		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --all, or --spec")
+	if !selectorGiven(*release, *latest, *specFlag, *seriesFlag) {
+		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
 		os.Exit(1)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache, *scrapeWorkers)
+	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, !*noCache, *scrapeWorkers)
 
 	if len(filtered) == 0 {
 		fmt.Println("No specs matched the filters.")
@@ -444,8 +448,7 @@ func cmdPipeline(args []string) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "Output SQLite database path")
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
-	latest := fs.Bool("latest", false, "Download the single latest version of each spec")
-	allVersions := fs.Bool("all", false, "Download all versions")
+	latest := fs.Bool("latest", false, "Process the single latest version of each spec (the default selection)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
 	workers := fs.Int("workers", runtime.NumCPU(), "Number of parallel workers")
@@ -457,8 +460,8 @@ func cmdPipeline(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	if *release == 0 && !*latest && !*allVersions && *specFlag == "" {
-		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --all, or --spec")
+	if !selectorGiven(*release, *latest, *specFlag, *seriesFlag) {
+		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
 		os.Exit(1)
 	}
 
@@ -475,7 +478,7 @@ func cmdPipeline(args []string) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, *allVersions, !*noCache, *scrapeWorkers)
+	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, !*noCache, *scrapeWorkers)
 
 	if len(filtered) == 0 {
 		fmt.Println("No specs matched the filters.")

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -354,9 +354,17 @@ func cmdConvertDir(args []string) {
 	}
 }
 
-// selectorGiven reports whether at least one spec selector flag was provided.
-func selectorGiven(release int, latest bool, spec, series string) bool {
-	return release != 0 || latest || spec != "" || series != ""
+// exit is swapped in tests to cover fatal CLI-argument paths without
+// terminating the test process.
+var exit = os.Exit
+
+// requireSelector exits unless at least one spec selector flag was provided.
+func requireSelector(release int, latest bool, spec, series string) {
+	if release != 0 || latest || spec != "" || series != "" {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
+	exit(1)
 }
 
 // resolveSpecs fetches, parses, and filters specs based on CLI flags.
@@ -414,10 +422,7 @@ func cmdDownload(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	if !selectorGiven(*release, *latest, *specFlag, *seriesFlag) {
-		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
-		os.Exit(1)
-	}
+	requireSelector(*release, *latest, *specFlag, *seriesFlag)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -460,10 +465,7 @@ func cmdPipeline(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	if !selectorGiven(*release, *latest, *specFlag, *seriesFlag) {
-		fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
-		os.Exit(1)
-	}
+	requireSelector(*release, *latest, *specFlag, *seriesFlag)
 
 	d, err := db.OpenReadWrite(*dbPath)
 	if err != nil {

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -402,7 +402,7 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 func cmdDownload(args []string) {
 	fs := flag.NewFlagSet("download", flag.ExitOnError)
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
-	latest := fs.Bool("latest", false, "Download the single latest version of each spec (the default selection)")
+	latest := fs.Bool("latest", false, "Select every spec at its latest version (use when no other selector is given)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
 	outputDir := fs.String("output-dir", "specs", "Output directory")
@@ -448,7 +448,7 @@ func cmdPipeline(args []string) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "Output SQLite database path")
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
-	latest := fs.Bool("latest", false, "Process the single latest version of each spec (the default selection)")
+	latest := fs.Bool("latest", false, "Select every spec at its latest version (use when no other selector is given)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
 	workers := fs.Int("workers", runtime.NumCPU(), "Number of parallel workers")

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -279,31 +279,69 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 	}
 }
 
-// TestSelectorGiven covers the selector guard shared by cmdDownload and
-// cmdPipeline, including --series as a valid sole selector.
-func TestSelectorGiven(t *testing.T) {
+// TestRequireSelector covers the selector guard shared by cmdDownload and
+// cmdPipeline, including --series as a valid sole selector and the exit path
+// taken when no selector is given.
+func TestRequireSelector(t *testing.T) {
 	tests := []struct {
-		name    string
-		release int
-		latest  bool
-		spec    string
-		series  string
-		want    bool
+		name     string
+		release  int
+		latest   bool
+		spec     string
+		series   string
+		wantExit bool
 	}{
-		{"none", 0, false, "", "", false},
-		{"release", 19, false, "", "", true},
-		{"latest", 0, true, "", "", true},
-		{"spec", 0, false, "23.501", "", true},
-		{"series alone", 0, false, "", "23,29", true},
+		{"none", 0, false, "", "", true},
+		{"release", 19, false, "", "", false},
+		{"latest", 0, true, "", "", false},
+		{"spec", 0, false, "23.501", "", false},
+		{"series alone", 0, false, "", "23,29", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := selectorGiven(tt.release, tt.latest, tt.spec, tt.series); got != tt.want {
-				t.Errorf("selectorGiven(%d, %v, %q, %q) = %v, want %v",
-					tt.release, tt.latest, tt.spec, tt.series, got, tt.want)
+			exitCode := -1
+			orig := exit
+			exit = func(code int) { exitCode = code }
+			t.Cleanup(func() { exit = orig })
+
+			stderr := captureStderr(t, func() {
+				requireSelector(tt.release, tt.latest, tt.spec, tt.series)
+			})
+
+			if tt.wantExit {
+				if exitCode != 1 {
+					t.Errorf("exit code = %d, want 1", exitCode)
+				}
+				if !strings.Contains(stderr, "Specify --release, --latest, --series, or --spec") {
+					t.Errorf("stderr = %q, want selector message", stderr)
+				}
+			} else if exitCode != -1 {
+				t.Errorf("exit(%d) called, want no exit", exitCode)
 			}
 		})
 	}
+}
+
+// captureStderr runs fn and returns whatever it wrote to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	fn()
+	w.Close()
+	return <-done
 }
 
 // TestCmdConvert_HappyPath imports a single real 3GPP .docx testdata file via

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -222,14 +222,13 @@ func TestResolveSpecs_FromSpecList(t *testing.T) {
 			"",    // specFlag
 			"",    // seriesFlag
 			0,     // release
-			false, // allVersions
 			false, // useCache
 			0,     // scrapeConcurrency
 		)
 		if len(specs) == 0 {
 			t.Error("expected at least one spec, got 0")
 		}
-		// latestOnly=true (because allVersions=false), so expect 1 per SpecID.
+		// resolveSpecs keeps only the latest version, so expect 1 per SpecID.
 		ids := map[string]bool{}
 		for _, s := range specs {
 			ids[s.SpecID] = true
@@ -265,7 +264,6 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 			"23.501", // specFlag
 			"",       // seriesFlag
 			0,        // release
-			false,    // allVersions
 			false,    // useCache
 			0,        // scrapeConcurrency
 		)
@@ -278,6 +276,33 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 	})
 	if !strings.Contains(out, "Fetching versions for 23.501") {
 		t.Errorf("expected progress message, got: %s", out)
+	}
+}
+
+// TestSelectorGiven covers the selector guard shared by cmdDownload and
+// cmdPipeline, including --series as a valid sole selector.
+func TestSelectorGiven(t *testing.T) {
+	tests := []struct {
+		name    string
+		release int
+		latest  bool
+		spec    string
+		series  string
+		want    bool
+	}{
+		{"none", 0, false, "", "", false},
+		{"release", 19, false, "", "", true},
+		{"latest", 0, true, "", "", true},
+		{"spec", 0, false, "23.501", "", true},
+		{"series alone", 0, false, "", "23,29", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectorGiven(tt.release, tt.latest, tt.spec, tt.series); got != tt.want {
+				t.Errorf("selectorGiven(%d, %v, %q, %q) = %v, want %v",
+					tt.release, tt.latest, tt.spec, tt.series, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -432,7 +457,7 @@ func TestCmdDownload_NoMatch(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		cmdDownload([]string{
-			"-all",
+			"-latest",
 			"-spec-list", listPath,
 			"-output-dir", outDir,
 			"-no-cache",
@@ -454,7 +479,7 @@ func TestCmdPipeline_NoMatch(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		cmdPipeline([]string{
-			"-all",
+			"-latest",
 			"-db", dbPath,
 			"-spec-list", listPath,
 			"-no-cache",
@@ -586,7 +611,6 @@ func TestResolveSpecs_FetchAllSeries(t *testing.T) {
 			"",    // specFlag
 			"23",  // seriesFlag
 			0,     // release
-			false, // allVersions (latestOnly=true)
 			false, // useCache
 			0,     // scrapeConcurrency
 		)


### PR DESCRIPTION
## Summary

- Remove the `--all` flag from `build` and `download`. `build --all` was broken: workers imported every version of a spec concurrently and each insert deleted the other versions, leaving one arbitrary version in the database. Spec coverage is already guaranteed by `--release`, and archived versions are served on demand at runtime, so pre-fetching all versions is no longer needed.
- Fix the selector guard to accept `--series` alone (previously `--series 23` without another selector was rejected).
- Clarify the `--latest` help text as the explicit form of the default selection.
- Drop the `download-all-specs` make target and the `--all` rows from the README flag tables.

## Test plan

- `go test -race ./...` passes, including a new table test for the extracted `selectorGiven` guard (`--series` alone accepted, no selector rejected).
- `gofmt -l .` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuAtQHjSR8nEgmkJGrfn7x)_