### PR TITLE
feat: fetch archived version images on demand via get_image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,14 @@ separate SQLite file (`$XDG_CACHE_HOME/3gpp-mcp/versions.db`). That file has no
 FTS tables, so cached versions never reach search. Fetches are deduplicated per
 `(spec, version)`, run on a context detached from the caller so a client timeout
 does not discard minutes of work, and are evicted least-recently-used once the
-size limit is exceeded. The on-demand path deliberately skips images, OpenAPI
-YAML and cross-reference extraction — those are served from the prebuilt
-database for its version only.
+size limit is exceeded. The section fetch skips images, OpenAPI YAML and
+cross-reference extraction. Images are fetched lazily instead: the first
+`get_image`/`list_images` call for an archived version downloads that version's
+ZIP again via `pipeline.FetchVersionImages`, converts EMF/WMF figures to PNG
+when LibreOffice (`soffice`) is available, and caches every image of the
+version alongside its sections (image bytes count against the same LRU limit,
+and a version's text and images are evicted as one unit). OpenAPI YAML and
+cross-references remain prebuilt-only.
 
 ### MCP Tools
 
@@ -120,8 +125,8 @@ Ten tools are exposed via MCP:
 | `list_openapi` | List OpenAPI definitions |
 | `get_openapi` | Get OpenAPI definition (paginated) |
 | `get_references` | Get cross-references for a section (incoming/outgoing) |
-| `list_images` | List embedded images in a spec |
-| `get_image` | Retrieve an embedded image (base64 or PNG) |
+| `list_images` | List embedded images in a spec (optionally a past version) |
+| `get_image` | Retrieve an embedded image (base64 or PNG, optionally a past version) |
 
 ### Transport
 

--- a/README.md
+++ b/README.md
@@ -235,9 +235,12 @@ database, so:
 
 - `search` covers only the version in the database — cross-release full-text
   search is not supported
-- `get_image` and `get_references` only have data for the version in the
-  database, so a section read from an archived version returns text alone and
-  says so in its header
+- `get_references` only has data for the version in the database, and a section
+  read from an archived version says so in its header
+- `get_image` and `list_images` accept a `version` too: an archived version's
+  images are downloaded on their own first use (one extra archive download per
+  version, with the same retry behavior), and EMF/WMF figures are converted to
+  PNG when LibreOffice is installed on the server
 - section numbers move between releases; check `get_toc` for the older version
   before reading a section of it
 
@@ -272,10 +275,10 @@ The `search` tool supports [SQLite FTS5](https://www.sqlite.org/fts5.html) query
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `list_images` | List embedded images in a spec | `spec_id` (required) |
-| `get_image` | Get an embedded image as base64 data viewable by LLMs | `spec_id`, `name` (required): image filename |
+| `list_images` | List embedded images in a spec | `spec_id` (required), `version` (optional) |
+| `get_image` | Get an embedded image as base64 data viewable by LLMs | `spec_id`, `name` (required): image filename, `version` (optional) |
 
-The `build` command extracts images from DOCX files and stores them in the database. PNG/JPEG/GIF/WebP images are directly viewable by LLMs. EMF/WMF images (most 3GPP figures use this format) are stored as raw data by default; use `--convert-image` to convert them to PNG via LibreOffice at build time.
+The `build` command extracts images from DOCX files and stores them in the database. PNG/JPEG/GIF/WebP images are directly viewable by LLMs. EMF/WMF images (most 3GPP figures use this format) are stored as raw data by default; use `--convert-image` to convert them to PNG via LibreOffice at build time. For archived versions read via `version`, images are fetched into the on-demand cache the first time one is requested, and EMF/WMF figures are converted to PNG when LibreOffice is available at runtime.
 
 ```bash
 # Convert EMF/WMF to PNG for LLM viewing (requires LibreOffice)

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -147,7 +147,7 @@ func newMCPServer(d *db.DB, src *tools.Source) *mcp.Server {
 		Version: version,
 	}, &mcp.ServerOptions{
 		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions.\n\n" +
-			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then pass version to get_section or get_toc. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. search only covers the version in the database, and get_image and get_references only have data for that version, so an archived version returns text alone.",
+			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then pass version to get_section or get_toc. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. get_image and list_images also accept a version: an archived version's images are downloaded on their own first use, again taking up to a few minutes before a retry succeeds. search and get_references only have data for the version in the database.",
 	})
 
 	mcp.AddTool(s, tools.ListSpecsTool, tools.HandleListSpecs(d))
@@ -158,8 +158,8 @@ func newMCPServer(d *db.DB, src *tools.Source) *mcp.Server {
 	mcp.AddTool(s, tools.ListOpenAPITool, tools.HandleListOpenAPI(d))
 	mcp.AddTool(s, tools.GetOpenAPITool, tools.HandleGetOpenAPI(d))
 	mcp.AddTool(s, tools.GetReferencesTool, tools.HandleGetReferences(d))
-	mcp.AddTool(s, tools.ListImagesTool, tools.HandleListImages(d))
-	mcp.AddTool(s, tools.GetImageTool, tools.HandleGetImage(d))
+	mcp.AddTool(s, tools.ListImagesTool, tools.HandleListImages(src))
+	mcp.AddTool(s, tools.GetImageTool, tools.HandleGetImage(src))
 
 	return s
 }

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -123,9 +124,9 @@ func releaseRequest(s string) (int, bool) {
 // and returns the resulting records without writing them anywhere.
 //
 // Unlike the build pipeline it deliberately skips images, OpenAPI YAML and
-// cross-reference extraction: those are served from the prebuilt database for
-// the current version only, and carrying them for every fetched version would
-// bloat the cache with data no tool reads.
+// cross-reference extraction. Images are fetched separately and lazily by
+// FetchVersionImages when a tool actually asks for one; carrying them for every
+// fetched version would bloat the cache with data no tool reads.
 func FetchVersion(ctx context.Context, client *http.Client, sv *SpecVersion, timeout time.Duration) (db.Spec, []db.Section, error) {
 	tmpDir, err := os.MkdirTemp("", "3gpp-ondemand-"+sv.SpecID+"-")
 	if err != nil {
@@ -201,6 +202,75 @@ func FetchVersion(ctx context.Context, client *http.Client, sv *SpecVersion, tim
 		sections[i].SpecID = spec.ID
 	}
 	return spec, sections, nil
+}
+
+// FetchVersionImages downloads one archive entry and returns only its embedded
+// images. It backs the lazy image path: the archive offers no partial download,
+// so retrieving even a single image of an archived version costs a full ZIP
+// download, and callers are expected to cache everything returned here.
+//
+// When LibreOffice (soffice) is available, EMF/WMF images are converted to PNG
+// before they are returned, renaming them from image1.emf to image1.png; the
+// caller's lookups must tolerate that rename because section Markdown cached by
+// FetchVersion still names the original file. Zero images is a success, not an
+// error: many specifications simply ship no figures.
+func FetchVersionImages(ctx context.Context, client *http.Client, sv *SpecVersion, timeout time.Duration) ([]db.Image, error) {
+	tmpDir, err := os.MkdirTemp("", "3gpp-ondemand-img-"+sv.SpecID+"-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	result, err := DownloadAndExtract(ctx, client, sv, tmpDir, timeout)
+	if err != nil {
+		return nil, err
+	}
+	switch result.Status {
+	case "OK":
+	case "DOC_ONLY":
+		return nil, fmt.Errorf("%w: %s v%s ships only legacy .doc files, which need LibreOffice to convert; build it into the database with `3gpp-mcp build --convert-doc`",
+			ErrNoDocx, sv.SpecID, displayVersion(sv))
+	default:
+		return nil, fmt.Errorf("%w: %s v%s (%s)", ErrNoDocx, sv.SpecID, displayVersion(sv), result.Status)
+	}
+
+	sortCoverLast(result.DocxFiles)
+	_, sofficeErr := exec.LookPath("soffice")
+	convertImages := sofficeErr == nil
+
+	var images []db.Image
+	// Parts of a multi-file spec each number their images from image1, so the
+	// same policy as the section merge applies: last write wins by name.
+	index := map[string]int{}
+
+	for _, docxPath := range result.DocxFiles {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		parsed, err := docx.ParseDocx(docxPath)
+		if err != nil {
+			log.Printf("  on-demand parse error %s: %v", filepath.Base(docxPath), err)
+			continue
+		}
+		if convertImages {
+			if n := docx.ConvertResultImages(ctx, parsed); n > 0 {
+				log.Printf("  %s: converted %d images to PNG", sv.SpecID, n)
+			}
+		}
+		_, _, fileImages := convertToDBRecords(parsed)
+		for _, img := range fileImages {
+			if i, ok := index[img.Name]; ok {
+				images[i] = img
+				continue
+			}
+			index[img.Name] = len(images)
+			images = append(images, img)
+		}
+		if err := os.Remove(docxPath); err != nil {
+			log.Printf("  warning: failed to remove %s: %v", filepath.Base(docxPath), err)
+		}
+	}
+	return images, nil
 }
 
 // displayVersion formats an archive entry's version for messages, preferring

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -242,6 +242,7 @@ func FetchVersionImages(ctx context.Context, client *http.Client, sv *SpecVersio
 	// Parts of a multi-file spec each number their images from image1, so the
 	// same policy as the section merge applies: last write wins by name.
 	index := map[string]int{}
+	parsedFiles := 0
 
 	for _, docxPath := range result.DocxFiles {
 		if err := ctx.Err(); err != nil {
@@ -252,6 +253,7 @@ func FetchVersionImages(ctx context.Context, client *http.Client, sv *SpecVersio
 			log.Printf("  on-demand parse error %s: %v", filepath.Base(docxPath), err)
 			continue
 		}
+		parsedFiles++
 		if convertImages {
 			if n := docx.ConvertResultImages(ctx, parsed); n > 0 {
 				log.Printf("  %s: converted %d images to PNG", sv.SpecID, n)
@@ -269,6 +271,12 @@ func FetchVersionImages(ctx context.Context, client *http.Client, sv *SpecVersio
 		if err := os.Remove(docxPath); err != nil {
 			log.Printf("  warning: failed to remove %s: %v", filepath.Base(docxPath), err)
 		}
+	}
+	// Zero images from parsed documents means the version has no figures, but
+	// zero parsed documents means the download was unusable — succeeding would
+	// cache "no figures" permanently for a version that may well have them.
+	if parsedFiles == 0 {
+		return nil, fmt.Errorf("%w: %s v%s produced no readable documents", ErrNoDocx, sv.SpecID, displayVersion(sv))
 	}
 	return images, nil
 }

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -200,6 +200,73 @@ func TestFetchVersionImages(t *testing.T) {
 	}
 }
 
+// TestFetchVersionImagesSkipsCorruptPart checks that one unparsable part does
+// not lose the images of the others.
+func TestFetchVersionImagesSkipsCorruptPart(t *testing.T) {
+	archive := makeZipWithFiles(t, map[string][]byte{
+		"23501-i60_s01.docx": []byte("not a zip"),
+		"23501-i60_s02.docx": makeDocxWithImage(t, []byte("png-bytes")),
+	})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-i60.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-i60.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	images, err := FetchVersionImages(context.Background(), client, sv, 0)
+	if err != nil {
+		t.Fatalf("FetchVersionImages: %v", err)
+	}
+	if len(images) != 1 || images[0].Name != "image1.png" {
+		t.Fatalf("images = %+v, want the valid part's image1.png", images)
+	}
+}
+
+// TestFetchVersionImagesNoDocuments checks the error for an archive entry that
+// contains no documents at all.
+func TestFetchVersionImagesNoDocuments(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-i60.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(makeRawZipEntry(t, "readme.txt", []byte("nothing here")))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-i60.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	if _, err := FetchVersionImages(context.Background(), client, sv, 0); !errors.Is(err, ErrNoDocx) {
+		t.Fatalf("FetchVersionImages = %v, want ErrNoDocx", err)
+	}
+}
+
+// TestFetchVersionImagesDownloadError checks that a failed download propagates.
+func TestFetchVersionImagesDownloadError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-i60.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	if _, err := FetchVersionImages(context.Background(), client, sv, 0); err == nil {
+		t.Fatal("FetchVersionImages should fail when the download fails")
+	}
+}
+
 // TestFetchVersionImagesDocOnly checks that a legacy .doc-only version reports
 // the same guidance as the section fetch.
 func TestFetchVersionImagesDocOnly(t *testing.T) {

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -127,6 +127,99 @@ func TestReleaseRequest(t *testing.T) {
 	}
 }
 
+// makeDocxWithImage builds a minimal .docx whose only paragraph embeds
+// word/media/image1.png with the given bytes.
+func makeDocxWithImage(t *testing.T, pngData []byte) []byte {
+	t.Helper()
+	const contentTypes = `<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="xml" ContentType="application/xml"/>
+<Default Extension="png" ContentType="image/png"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+	const rels = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+	const docRels = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>`
+	const doc = `<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<w:body>
+<w:p><w:pPr><w:pStyle w:val="Heading 1"/></w:pPr><w:r><w:t>5 Test</w:t></w:r></w:p>
+<w:p><w:r><w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
+		`<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData>` +
+		`<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:blipFill>` +
+		`<a:blip r:embed="rId5"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>
+</w:body>
+</w:document>`
+	return makeZipWithFiles(t, map[string][]byte{
+		"[Content_Types].xml":          []byte(contentTypes),
+		"_rels/.rels":                  []byte(rels),
+		"word/document.xml":            []byte(doc),
+		"word/_rels/document.xml.rels": []byte(docRels),
+		"word/media/image1.png":        pngData,
+	})
+}
+
+// TestFetchVersionImages covers the lazy image download: images come out of
+// the archive ZIP, and parts of a multi-file spec merge last-write-wins by
+// name, as the section merge does.
+func TestFetchVersionImages(t *testing.T) {
+	archive := makeZipWithFiles(t, map[string][]byte{
+		"23501-i60_s01.docx": makeDocxWithImage(t, []byte("png-part-one")),
+		"23501-i60_s02.docx": makeDocxWithImage(t, []byte("png-part-two")),
+	})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-i60.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-i60.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	images, err := FetchVersionImages(context.Background(), client, sv, 0)
+	if err != nil {
+		t.Fatalf("FetchVersionImages: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("got %d images, want the parts merged into 1: %+v", len(images), images)
+	}
+	img := images[0]
+	if img.Name != "image1.png" || img.MIMEType != "image/png" || !img.LLMReadable {
+		t.Errorf("image = %+v, want a readable image1.png", img)
+	}
+	if string(img.Data) != "png-part-two" {
+		t.Errorf("Data = %q, want the later part to win", img.Data)
+	}
+}
+
+// TestFetchVersionImagesDocOnly checks that a legacy .doc-only version reports
+// the same guidance as the section fetch.
+func TestFetchVersionImagesDocOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-300.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(makeRawZipEntry(t, "23501-300.doc", []byte("legacy")))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-300.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	if _, err := FetchVersionImages(context.Background(), client, sv, 0); !errors.Is(err, ErrNoDocx) {
+		t.Fatalf("FetchVersionImages = %v, want ErrNoDocx", err)
+	}
+}
+
 // TestFetchVersionDocOnly checks the error a legacy .doc-only version gives,
 // since old versions hit this far more often than recent ones.
 func TestFetchVersionDocOnly(t *testing.T) {

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -228,6 +228,31 @@ func TestFetchVersionImagesSkipsCorruptPart(t *testing.T) {
 	}
 }
 
+// TestFetchVersionImagesAllPartsCorrupt checks that an entry whose every part
+// fails to parse errors out instead of reporting a figure-less version, which
+// would be cached permanently.
+func TestFetchVersionImagesAllPartsCorrupt(t *testing.T) {
+	archive := makeZipWithFiles(t, map[string][]byte{
+		"23501-i60_s01.docx": []byte("not a zip"),
+		"23501-i60_s02.docx": []byte("also not a zip"),
+	})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/23501-i60.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	sv := ParseSpecEntry("23_series/23.501/23501-i60.zip")
+	if sv == nil {
+		t.Fatal("ParseSpecEntry returned nil")
+	}
+	if _, err := FetchVersionImages(context.Background(), client, sv, 0); !errors.Is(err, ErrNoDocx) {
+		t.Fatalf("FetchVersionImages = %v, want ErrNoDocx when nothing parses", err)
+	}
+}
+
 // TestFetchVersionImagesNoDocuments checks the error for an archive entry that
 // contains no documents at all.
 func TestFetchVersionImagesNoDocuments(t *testing.T) {

--- a/db/db.go
+++ b/db/db.go
@@ -204,12 +204,30 @@ CREATE INDEX IF NOT EXISTS idx_sections_spec ON sections(spec_id, version);
 CREATE INDEX IF NOT EXISTS idx_sections_number ON sections(spec_id, version, number);
 `
 
+// ImagesTableSchema defines the table that holds embedded images, keyed by
+// (spec_id, version, name). The version cache reuses it verbatim for images
+// fetched on demand.
+const ImagesTableSchema = `
+CREATE TABLE IF NOT EXISTS images (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    spec_id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    name TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    data BLOB NOT NULL,
+    llm_readable BOOLEAN NOT NULL DEFAULT 0,
+    UNIQUE(spec_id, version, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_spec ON images(spec_id, version);
+`
+
 // Schema is the SQL schema for the 3GPP database.
 //
 // A build imports one version per spec, so the FTS index covers exactly that
 // version. Versions fetched on demand are stored in a separate cache database
 // that has no FTS tables, keeping cross-release rows out of search results.
-const Schema = SpecTablesSchema + `
+const Schema = SpecTablesSchema + ImagesTableSchema + `
 
 CREATE VIRTUAL TABLE IF NOT EXISTS sections_fts USING fts5(
     spec_id, number, title, content,
@@ -233,19 +251,6 @@ CREATE TRIGGER IF NOT EXISTS sections_au AFTER UPDATE ON sections BEGIN
     INSERT INTO sections_fts(rowid, spec_id, number, title, content)
     VALUES (new.id, new.spec_id, new.number, new.title, new.content);
 END;
-
-CREATE TABLE IF NOT EXISTS images (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    spec_id TEXT NOT NULL,
-    version TEXT NOT NULL,
-    name TEXT NOT NULL,
-    mime_type TEXT NOT NULL,
-    data BLOB NOT NULL,
-    llm_readable BOOLEAN NOT NULL DEFAULT 0,
-    UNIQUE(spec_id, version, name)
-);
-
-CREATE INDEX IF NOT EXISTS idx_images_spec ON images(spec_id, version);
 
 -- OpenAPI definitions are not keyed by spec version. They ship as standalone
 -- YAML files carrying their own api version, and the pipeline imports them

--- a/tools/get_image.go
+++ b/tools/get_image.go
@@ -4,21 +4,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type GetImageInput struct {
-	SpecID string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
-	Name   string `json:"name" jsonschema:"required,Image filename (e.g. image1.png)"`
+	SpecID  string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+	Name    string `json:"name" jsonschema:"required,Image filename (e.g. image1.png)"`
+	Version string `json:"version,omitempty" jsonschema:"Specification version to read (e.g. 18.6.0). Also accepts an archive token (i60) or a release selector (Rel-18). Defaults to the version in the database. Use list_versions to see what exists."`
 }
 
 var GetImageTool = &mcp.Tool{
 	Name:        "get_image",
-	Description: "Get an embedded image from a 3GPP specification. Returns the image as base64-encoded data that can be directly viewed by the LLM. Use list_images to discover available images for a spec.",
+	Description: "Get an embedded image from a 3GPP specification. Returns the image as base64-encoded data that can be directly viewed by the LLM. Use list_images to discover available images for a spec. Pass `version` to read a past version's image; the images of an archived version are downloaded on first use, which takes up to a few minutes.",
 }
 
-func HandleGetImage(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input GetImageInput) (*mcp.CallToolResult, any, error) {
+func HandleGetImage(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input GetImageInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input GetImageInput) (*mcp.CallToolResult, any, error) {
 		if input.SpecID == "" {
 			return errorResult("spec_id is required"), nil, nil
@@ -27,18 +27,22 @@ func HandleGetImage(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest
 			return errorResult("name is required"), nil, nil
 		}
 
-		// Images are only imported for the version the database was built with,
-		// so this always answers about that version.
-		img, err := d.GetImage(input.SpecID, "", input.Name)
+		img, res, err := src.GetImage(ctx, input.SpecID, input.Version, input.Name)
 		if err != nil {
-			return errorResult(fmt.Sprintf("image not found: %v", err)), nil, nil
+			return versionErrorResult(err, "image not found"), nil, nil
+		}
+		if img == nil {
+			return errorResult(fmt.Sprintf("image %q not found in %s%s", input.Name, input.SpecID, versionSuffix(res))), nil, nil
 		}
 
 		if !img.LLMReadable {
+			hint := "Re-run the pipeline with --convert-image flag to convert EMF/WMF images to PNG."
+			if res.archived {
+				hint = "Converting it needs LibreOffice (soffice), which is not installed on this server."
+			}
 			return errorResult(fmt.Sprintf(
-				"Image %q is in %s format which cannot be displayed. "+
-					"Re-run the pipeline with --convert-image flag to convert EMF/WMF images to PNG.",
-				img.Name, img.MIMEType,
+				"Image %q is in %s format which cannot be displayed. %s",
+				img.Name, img.MIMEType, hint,
 			)), nil, nil
 		}
 

--- a/tools/get_image.go
+++ b/tools/get_image.go
@@ -38,7 +38,7 @@ func HandleGetImage(src *Source) func(ctx context.Context, req *mcp.CallToolRequ
 		if !img.LLMReadable {
 			hint := "Re-run the pipeline with --convert-image flag to convert EMF/WMF images to PNG."
 			if res.archived {
-				hint = "Converting it needs LibreOffice (soffice), which is not installed on this server."
+				hint = "Converting it needs LibreOffice (soffice), which was missing or failed to convert this image when this version's images were fetched."
 			}
 			return errorResult(fmt.Sprintf(
 				"Image %q is in %s format which cannot be displayed. %s",

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -62,14 +62,15 @@ func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRe
 // e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]". Archived versions
 // say so, because get_references only covers the version the database was
 // built with and would silently answer about a different one; images are
-// downloaded on first use, so they stay available.
+// downloaded on first use, but only when the image tools are told the version,
+// so the header reminds the caller to pass it.
 func sourceHeader(s db.Section, withSubsections, archived bool) string {
 	h := fmt.Sprintf("[Source: %s — Section %s", specLabel(s), s.Number)
 	if withSubsections {
 		h += " (+subsections)"
 	}
 	if archived {
-		h += " (archived version; cross-references unavailable)"
+		h += " (archived version; cross-references unavailable; pass this version to get_image/list_images)"
 	}
 	return h + "]"
 }

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -60,15 +60,16 @@ func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRe
 
 // sourceHeader builds the provenance line prepended to every get_section page,
 // e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]". Archived versions
-// say so, because get_image and get_references only cover the version the
-// database was built with and would silently answer about a different one.
+// say so, because get_references only covers the version the database was
+// built with and would silently answer about a different one; images are
+// downloaded on first use, so they stay available.
 func sourceHeader(s db.Section, withSubsections, archived bool) string {
 	h := fmt.Sprintf("[Source: %s — Section %s", specLabel(s), s.Number)
 	if withSubsections {
 		h += " (+subsections)"
 	}
 	if archived {
-		h += " (archived version; images and cross-references unavailable)"
+		h += " (archived version; cross-references unavailable)"
 	}
 	return h + "]"
 }

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -2,10 +2,15 @@ package tools
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/versionstore"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -47,7 +52,7 @@ func seedImages(t *testing.T, d *db.DB) {
 func TestHandleListImages(t *testing.T) {
 	d := setupTestDB(t)
 	seedImages(t, d)
-	handler := HandleListImages(d)
+	handler := HandleListImages(NewSource(d))
 
 	t.Run("valid spec returns images", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 23.501"})
@@ -125,7 +130,7 @@ func TestHandleListImages(t *testing.T) {
 func TestHandleGetImage(t *testing.T) {
 	d := setupTestDB(t)
 	seedImages(t, d)
-	handler := HandleGetImage(d)
+	handler := HandleGetImage(NewSource(d))
 
 	t.Run("returns image content", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, GetImageInput{
@@ -202,4 +207,181 @@ func TestHandleGetImage(t *testing.T) {
 			t.Error("expected error result for empty name")
 		}
 	})
+}
+
+// sourceWithImageStore builds a Source whose version cache serves canned
+// sections and images instead of downloading.
+func sourceWithImageStore(t *testing.T, d *db.DB, imageFetcher versionstore.ImageFetcher) *Source {
+	t.Helper()
+	store, err := versionstore.Open(versionstore.Options{
+		Path:         filepath.Join(t.TempDir(), "versions.db"),
+		Fetcher:      cannedFetcher,
+		ImageFetcher: imageFetcher,
+	})
+	if err != nil {
+		t.Fatalf("versionstore.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	src := NewSource(d)
+	src.Store = store
+	src.Client = archiveClient(t)
+	src.UseCache = false
+	src.Budget = 5 * time.Second
+	return src
+}
+
+// TestGetImageArchivedVersion covers the lazy image path end to end: the first
+// request downloads and caches every image of the version, later requests hit
+// the cache, and the original EMF name still finds the converted PNG.
+func TestGetImageArchivedVersion(t *testing.T) {
+	d := setupTestDB(t)
+	seedImages(t, d)
+	var calls atomic.Int32
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		calls.Add(1)
+		return []db.Image{{Name: "figure1.png", MIMEType: "image/png", Data: []byte("archived-png"), LLMReadable: true}}, nil
+	})
+	handler := HandleGetImage(src)
+
+	for _, name := range []string{"figure1.png", "figure1.emf"} {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID:  "TS 23.501",
+			Name:    name,
+			Version: "19.5.0",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("GetImage(%s): unexpected error result: %s", name, getTextContent(result))
+		}
+		ic, ok := result.Content[0].(*mcp.ImageContent)
+		if !ok {
+			t.Fatalf("expected ImageContent, got %T", result.Content[0])
+		}
+		if string(ic.Data) != "archived-png" {
+			t.Errorf("unexpected image data: %q", string(ic.Data))
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("image fetcher called %d times, want 1", got)
+	}
+
+	// The database version must keep answering from the database.
+	result, _, err := handler(context.Background(), nil, GetImageInput{SpecID: "TS 23.501", Name: "image1.png"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", getTextContent(result))
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("image fetcher ran for the database version (%d calls)", got)
+	}
+}
+
+// TestListImagesArchivedVersion checks listing and the empty-result message on
+// the archived path.
+func TestListImagesArchivedVersion(t *testing.T) {
+	d := setupTestDB(t)
+	seedImages(t, d)
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return []db.Image{{Name: "figure1.png", MIMEType: "image/png", Data: []byte("x"), LLMReadable: true}}, nil
+	})
+	handler := HandleListImages(src)
+
+	result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 23.501", Version: "19.5.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", getTextContent(result))
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, "figure1.png") || !strings.Contains(text, `"count":1`) {
+		t.Errorf("expected the archived image listed, got: %s", text)
+	}
+	if strings.Contains(text, "image1.png") {
+		t.Errorf("archived listing leaked database images: %s", text)
+	}
+}
+
+func TestListImagesArchivedVersionEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return nil, nil
+	})
+	handler := HandleListImages(src)
+
+	result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 23.501", Version: "19.5.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", getTextContent(result))
+	}
+	if text := getTextContent(result); !strings.Contains(text, "No images found for TS 23.501 v19.5.0") {
+		t.Errorf("expected a versioned no-images message, got: %s", text)
+	}
+}
+
+// TestGetImageArchivedInProgress checks that an image fetch exceeding the
+// budget returns a retry hint rather than a tool error.
+func TestGetImageArchivedInProgress(t *testing.T) {
+	d := setupTestDB(t)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		<-release
+		return nil, nil
+	})
+	src.Budget = 20 * time.Millisecond
+	handler := HandleGetImage(src)
+
+	// Prime the section cache so only the image fetch is outstanding.
+	if err := src.Store.Ensure(context.Background(), "TS 23.501", "19.5.0", &pipeline.SpecVersion{SpecID: "23.501", Version: "j50", Release: 19}, time.Minute); err != nil {
+		t.Fatalf("prime section cache: %v", err)
+	}
+
+	result, _, err := handler(context.Background(), nil, GetImageInput{
+		SpecID:  "TS 23.501",
+		Name:    "figure1.png",
+		Version: "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Error("an image fetch that is still running should not be reported as a tool error")
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, "Images for TS 23.501 v19.5.0 are being downloaded") || !strings.Contains(text, "Call the same tool again") {
+		t.Errorf("message = %q, want an image retry hint", text)
+	}
+}
+
+// TestGetImageArchivedNonReadable checks the error for an archived EMF/WMF
+// image that could not be converted.
+func TestGetImageArchivedNonReadable(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return []db.Image{{Name: "figure1.emf", MIMEType: "image/x-emf", Data: []byte("emf")}}, nil
+	})
+	handler := HandleGetImage(src)
+
+	result, _, err := handler(context.Background(), nil, GetImageInput{
+		SpecID:  "TS 23.501",
+		Name:    "figure1.emf",
+		Version: "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result for an unconverted EMF image")
+	}
+	if text := getTextContent(result); !strings.Contains(text, "soffice") {
+		t.Errorf("expected a LibreOffice hint, got: %s", text)
+	}
 }

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -2,6 +2,9 @@ package tools
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -359,6 +362,69 @@ func TestGetImageArchivedInProgress(t *testing.T) {
 	if !strings.Contains(text, "Images for TS 23.501 v19.5.0 are being downloaded") || !strings.Contains(text, "Call the same tool again") {
 		t.Errorf("message = %q, want an image retry hint", text)
 	}
+}
+
+// TestGetImageArchivedFetchError checks that a failed image download surfaces
+// as a version-unavailable error result.
+func TestGetImageArchivedFetchError(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return nil, errors.New("download blew up")
+	})
+	handler := HandleGetImage(src)
+
+	result, _, err := handler(context.Background(), nil, GetImageInput{
+		SpecID:  "TS 23.501",
+		Name:    "figure1.png",
+		Version: "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result for a failed image fetch")
+	}
+	if text := getTextContent(result); !strings.Contains(text, "download blew up") {
+		t.Errorf("expected the fetch failure reason, got: %s", text)
+	}
+}
+
+// TestListImagesArchivedReResolveFails covers the cached fast path: the
+// version's sections are already cached (so resolve carries no archive entry)
+// and the archive listing has become unreachable, which must fail the image
+// call with a version-unavailable error rather than a panic or a silent miss.
+func TestListImagesArchivedReResolveFails(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		t.Error("image fetcher must not run when the archive entry cannot be resolved")
+		return nil, nil
+	})
+	if err := src.Store.Ensure(context.Background(), "TS 23.501", "19.5.0", &pipeline.SpecVersion{SpecID: "23.501", Version: "j50", Release: 19}, time.Minute); err != nil {
+		t.Fatalf("prime section cache: %v", err)
+	}
+	src.Client = unreachableArchiveClient(t)
+	handler := HandleListImages(src)
+
+	result, _, err := handler(context.Background(), nil, ListImagesInput{SpecID: "TS 23.501", Version: "19.5.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when the archive listing is unreachable")
+	}
+	if text := getTextContent(result); !strings.Contains(text, "not available") {
+		t.Errorf("expected a version-unavailable message, got: %s", text)
+	}
+}
+
+// unreachableArchiveClient serves 404 for every archive request.
+func unreachableArchiveClient(t *testing.T) *http.Client {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(ts.Close)
+	return &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
 }
 
 // TestGetImageArchivedNonReadable checks the error for an archived EMF/WMF

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -271,6 +271,22 @@ func TestGetImageArchivedVersion(t *testing.T) {
 		t.Errorf("image fetcher called %d times, want 1", got)
 	}
 
+	// A name the version does not hold is a not-found error naming the version.
+	missing, _, err := handler(context.Background(), nil, GetImageInput{
+		SpecID:  "TS 23.501",
+		Name:    "missing.png",
+		Version: "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !missing.IsError {
+		t.Fatal("expected an error result for a missing archived image")
+	}
+	if text := getTextContent(missing); !strings.Contains(text, "not found in TS 23.501 v19.5.0") {
+		t.Errorf("expected a versioned not-found message, got: %s", text)
+	}
+
 	// The database version must keep answering from the database.
 	result, _, err := handler(context.Background(), nil, GetImageInput{SpecID: "TS 23.501", Name: "image1.png"})
 	if err != nil {

--- a/tools/list_images.go
+++ b/tools/list_images.go
@@ -11,30 +11,33 @@ import (
 )
 
 type ListImagesInput struct {
-	SpecID string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+	SpecID  string `json:"spec_id" jsonschema:"required,Specification ID (e.g. TS 23.501)"`
+	Version string `json:"version,omitempty" jsonschema:"Specification version to read (e.g. 18.6.0). Also accepts an archive token (i60) or a release selector (Rel-18). Defaults to the version in the database. Use list_versions to see what exists."`
 }
 
 var ListImagesTool = &mcp.Tool{
 	Name:        "list_images",
-	Description: "List embedded images in a 3GPP specification. Returns image names, MIME types, and whether they are viewable by LLMs. Use get_image to retrieve a specific image.",
+	Description: "List embedded images in a 3GPP specification. Returns image names, MIME types, and whether they are viewable by LLMs. Use get_image to retrieve a specific image. Pass `version` to list a past version's images; the images of an archived version are downloaded on first use, which takes up to a few minutes.",
 }
 
-func HandleListImages(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input ListImagesInput) (*mcp.CallToolResult, any, error) {
+func HandleListImages(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input ListImagesInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ListImagesInput) (*mcp.CallToolResult, any, error) {
 		if input.SpecID == "" {
 			return errorResult("spec_id is required"), nil, nil
 		}
 
-		images, err := d.ListImages(input.SpecID, "")
+		images, res, err := src.ListImages(ctx, input.SpecID, input.Version)
 		if err != nil {
-			return errorResult(fmt.Sprintf("failed to list images: %v", err)), nil, nil
+			return versionErrorResult(err, "failed to list images"), nil, nil
 		}
 
 		if len(images) == 0 {
-			if parts, partsErr := d.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
-				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+			if !res.archived {
+				if parts, partsErr := src.DB.FindSpecIDsByFamily(input.SpecID); partsErr == nil && len(parts) > 0 {
+					return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
+				}
 			}
-			return textResult(fmt.Sprintf("No images found for %s", input.SpecID)), nil, nil
+			return textResult(fmt.Sprintf("No images found for %s%s", input.SpecID, versionSuffix(res))), nil, nil
 		}
 
 		data, err := json.Marshal(struct {

--- a/tools/source.go
+++ b/tools/source.go
@@ -38,10 +38,16 @@ func NewSource(d *db.DB) *Source {
 type errFetchInProgress struct {
 	specID  string
 	version string
+	// images marks a fetch of a version's images rather than its text.
+	images bool
 }
 
 func (e *errFetchInProgress) Error() string {
-	return fmt.Sprintf("%s v%s is being downloaded and converted. This takes up to a few minutes for a large specification. Call the same tool again to get the content.", e.specID, e.version)
+	subject := fmt.Sprintf("%s v%s is", e.specID, e.version)
+	if e.images {
+		subject = fmt.Sprintf("Images for %s v%s are", e.specID, e.version)
+	}
+	return subject + " being downloaded and converted. This takes up to a few minutes for a large specification. Call the same tool again to get the content."
 }
 
 // errVersionUnavailable is returned when a requested version cannot be served,
@@ -66,9 +72,13 @@ type resolution struct {
 	// version is the canonical dotted version that was resolved.
 	version string
 	// archived is true when the content comes from the on-demand cache rather
-	// than the prebuilt database, meaning images and cross-references for it
-	// were never imported.
+	// than the prebuilt database. Images for such a version are fetched lazily
+	// on first use; cross-references were never imported.
 	archived bool
+	// sv is the archive entry the version resolved to. It is nil on the cached
+	// fast path, which skips the archive listing — callers that need the entry
+	// must re-resolve it themselves.
+	sv *pipeline.SpecVersion
 }
 
 // resolve locates a requested version, fetching it on demand when needed. An
@@ -147,7 +157,7 @@ func (s *Source) resolve(ctx context.Context, specID, request string) (resolutio
 			reason:  err.Error(),
 		}
 	}
-	return resolution{version: canonical, archived: true}, nil
+	return resolution{version: canonical, archived: true, sv: sv}, nil
 }
 
 // GetSection returns a section from whichever source holds the version.
@@ -176,6 +186,83 @@ func (s *Source) GetTOC(ctx context.Context, specID, version string) ([]db.Secti
 	}
 	sections, err := s.DB.GetTOC(specID, res.version)
 	return sections, res, err
+}
+
+// GetImage returns an image from whichever source holds the version. For an
+// archived version the version's images are downloaded on first use; a nil
+// image with a nil error means the version holds no image of that name.
+func (s *Source) GetImage(ctx context.Context, specID, version, name string) (*db.Image, resolution, error) {
+	res, err := s.resolve(ctx, specID, version)
+	if err != nil {
+		return nil, res, err
+	}
+	if res.archived {
+		if err := s.ensureImages(ctx, specID, res); err != nil {
+			return nil, res, err
+		}
+		img, err := s.Store.GetImage(specID, res.version, name)
+		return img, res, err
+	}
+	img, err := s.DB.GetImage(specID, res.version, name)
+	return img, res, err
+}
+
+// ListImages returns image metadata from whichever source holds the version.
+// For an archived version the version's images are downloaded on first use.
+func (s *Source) ListImages(ctx context.Context, specID, version string) ([]db.ImageInfo, resolution, error) {
+	res, err := s.resolve(ctx, specID, version)
+	if err != nil {
+		return nil, res, err
+	}
+	if res.archived {
+		if err := s.ensureImages(ctx, specID, res); err != nil {
+			return nil, res, err
+		}
+		infos, err := s.Store.ListImages(specID, res.version)
+		return infos, res, err
+	}
+	infos, err := s.DB.ListImages(specID, res.version)
+	return infos, res, err
+}
+
+// ensureImages makes an archived version's images available in the cache. The
+// resolution's archive entry is nil when the version came from the cached fast
+// path, so the entry may have to be resolved again before fetching.
+func (s *Source) ensureImages(ctx context.Context, specID string, res resolution) error {
+	fetched, err := s.Store.HasImages(specID, res.version)
+	if err != nil {
+		return err
+	}
+	if fetched {
+		return nil
+	}
+
+	sv := res.sv
+	if sv == nil {
+		resolved, available, err := pipeline.ResolveVersion(ctx, s.Client, specID, res.version, s.UseCache)
+		if err != nil {
+			return &errVersionUnavailable{
+				specID:    specID,
+				version:   res.version,
+				reason:    err.Error(),
+				available: versionLabels(available),
+			}
+		}
+		sv = resolved
+	}
+
+	switch err := s.Store.EnsureImages(ctx, specID, res.version, sv, s.Budget); {
+	case err == nil:
+		return nil
+	case errors.Is(err, versionstore.ErrInProgress):
+		return &errFetchInProgress{specID: specID, version: res.version, images: true}
+	default:
+		return &errVersionUnavailable{
+			specID:  specID,
+			version: res.version,
+			reason:  err.Error(),
+		}
+	}
 }
 
 // versionLabels renders archive entries as dotted versions for error messages.

--- a/tools/source.go
+++ b/tools/source.go
@@ -201,6 +201,11 @@ func (s *Source) GetImage(ctx context.Context, specID, version, name string) (*d
 			return nil, res, err
 		}
 		img, err := s.Store.GetImage(specID, res.version, name)
+		if err == nil && img == nil {
+			if err := s.imagesStillCached(specID, res); err != nil {
+				return nil, res, err
+			}
+		}
 		return img, res, err
 	}
 	img, err := s.DB.GetImage(specID, res.version, name)
@@ -219,10 +224,30 @@ func (s *Source) ListImages(ctx context.Context, specID, version string) ([]db.I
 			return nil, res, err
 		}
 		infos, err := s.Store.ListImages(specID, res.version)
+		if err == nil && len(infos) == 0 {
+			if err := s.imagesStillCached(specID, res); err != nil {
+				return nil, res, err
+			}
+		}
 		return infos, res, err
 	}
 	infos, err := s.DB.ListImages(specID, res.version)
 	return infos, res, err
+}
+
+// imagesStillCached distinguishes "the version holds no such images" from "the
+// version was evicted between ensureImages and the read": a concurrent fetch's
+// eviction can drop it in that window, and answering a definitive not-found
+// then would hide content a retry recovers.
+func (s *Source) imagesStillCached(specID string, res resolution) error {
+	fetched, err := s.Store.HasImages(specID, res.version)
+	if err != nil {
+		return err
+	}
+	if !fetched {
+		return &errFetchInProgress{specID: specID, version: res.version, images: true}
+	}
+	return nil
 }
 
 // ensureImages makes an archived version's images available in the cache. The

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -148,7 +148,7 @@ func TestHandleGetSectionArchivedHeader(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	text := getTextContent(result)
-	want := "[Source: TS 23.501 v19.5.0 (Rel-19) — Section 5.1 (archived version; cross-references unavailable)]"
+	want := "[Source: TS 23.501 v19.5.0 (Rel-19) — Section 5.1 (archived version; cross-references unavailable; pass this version to get_image/list_images)]"
 	if !strings.HasPrefix(text, want) {
 		t.Errorf("header = %q, want prefix %q", text, want)
 	}

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -133,7 +133,7 @@ func TestGetSectionFetchesArchivedVersion(t *testing.T) {
 }
 
 // TestHandleGetSectionArchivedHeader checks that the provenance line names the
-// version and warns that images and references are missing, on every page.
+// version and warns that references are missing, on every page.
 func TestHandleGetSectionArchivedHeader(t *testing.T) {
 	d := setupTestDB(t)
 	src := sourceWithStore(t, d, cannedFetcher)
@@ -148,7 +148,7 @@ func TestHandleGetSectionArchivedHeader(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	text := getTextContent(result)
-	want := "[Source: TS 23.501 v19.5.0 (Rel-19) — Section 5.1 (archived version; images and cross-references unavailable)]"
+	want := "[Source: TS 23.501 v19.5.0 (Rel-19) — Section 5.1 (archived version; cross-references unavailable)]"
 	if !strings.HasPrefix(text, want) {
 		t.Errorf("header = %q, want prefix %q", text, want)
 	}

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -1,0 +1,288 @@
+package versionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
+	"github.com/higebu/3gpp-mcp/db"
+)
+
+// fakeImages builds an image set of roughly size bytes of data each.
+func fakeImages(size int) []db.Image {
+	return []db.Image{{
+		SpecID:      "ignored",
+		Version:     "ignored",
+		Name:        "image1.png",
+		MIMEType:    "image/png",
+		Data:        []byte(strings.Repeat("p", size)),
+		LLMReadable: true,
+	}, {
+		SpecID:   "ignored",
+		Version:  "ignored",
+		Name:     "image2.emf",
+		MIMEType: "image/x-emf",
+		Data:     []byte(strings.Repeat("e", size)),
+	}}
+}
+
+// openImageStore creates a store whose section fetcher returns a small canned
+// spec, with the given image fetcher.
+func openImageStore(t *testing.T, limit int64, imageFetcher ImageFetcher) *Store {
+	t.Helper()
+	s, err := Open(Options{
+		Path:       filepath.Join(t.TempDir(), "versions.db"),
+		LimitBytes: limit,
+		Fetcher: func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+			spec, sections := fakeSpec("placeholder", "placeholder", 16)
+			return spec, sections, nil
+		},
+		ImageFetcher: imageFetcher,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// ensureVersion caches one version's sections so image calls have an entry to
+// attach to.
+func ensureVersion(t *testing.T, s *Store, specID, version string) {
+	t.Helper()
+	if err := s.Ensure(context.Background(), specID, version, entry(specID), time.Minute); err != nil {
+		t.Fatalf("Ensure %s v%s: %v", specID, version, err)
+	}
+}
+
+func TestEnsureImagesAndRead(t *testing.T) {
+	var calls atomic.Int32
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		calls.Add(1)
+		return fakeImages(32), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || fetched {
+		t.Fatalf("HasImages before fetch = %v, %v; want false, nil", fetched, err)
+	}
+
+	for range 3 {
+		if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+			t.Fatalf("EnsureImages: %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("image fetcher called %d times, want 1", got)
+	}
+
+	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || !fetched {
+		t.Fatalf("HasImages after fetch = %v, %v; want true, nil", fetched, err)
+	}
+
+	// The caller's spec ID and version win over whatever the fetcher returned.
+	img, err := s.GetImage("TS 23.501", "18.6.0", "image1.png")
+	if err != nil || img == nil {
+		t.Fatalf("GetImage = %+v, %v; want an image", img, err)
+	}
+	if img.SpecID != "TS 23.501" || img.Version != "18.6.0" {
+		t.Errorf("image identity = %s v%s, want TS 23.501 v18.6.0", img.SpecID, img.Version)
+	}
+	if !img.LLMReadable || img.MIMEType != "image/png" {
+		t.Errorf("image = %+v, want a readable PNG", img)
+	}
+
+	missing, err := s.GetImage("TS 23.501", "18.6.0", "nonexistent.png")
+	if err != nil || missing != nil {
+		t.Errorf("GetImage(missing) = %+v, %v; want nil, nil", missing, err)
+	}
+
+	infos, err := s.ListImages("TS 23.501", "18.6.0")
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+	if len(infos) != 2 || infos[0].Name != "image1.png" || infos[1].Name != "image2.emf" {
+		t.Fatalf("ListImages = %+v, want image1.png and image2.emf", infos)
+	}
+}
+
+// TestEnsureImagesRemembersEmptyResult checks that a spec without figures does
+// not re-download its archive on every image call.
+func TestEnsureImagesRemembersEmptyResult(t *testing.T) {
+	var calls atomic.Int32
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		calls.Add(1)
+		return nil, nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	for range 2 {
+		if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+			t.Fatalf("EnsureImages: %v", err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("image fetcher called %d times, want 1", got)
+	}
+	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || !fetched {
+		t.Errorf("HasImages = %v, %v; want true after an empty fetch", fetched, err)
+	}
+}
+
+// TestGetImageBaseNameFallback checks that a lookup by the original EMF/WMF
+// name finds the converted PNG: cached section Markdown keeps the original
+// filename while conversion renames the stored image.
+func TestGetImageBaseNameFallback(t *testing.T) {
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return []db.Image{{Name: "image1.png", MIMEType: "image/png", Data: []byte("png"), LLMReadable: true}}, nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+
+	img, err := s.GetImage("TS 23.501", "18.6.0", "image1.emf")
+	if err != nil || img == nil {
+		t.Fatalf("GetImage(image1.emf) = %+v, %v; want the converted PNG", img, err)
+	}
+	if img.Name != "image1.png" {
+		t.Errorf("Name = %q, want image1.png", img.Name)
+	}
+
+	// The fallback must not treat LIKE metacharacters in the name as wildcards.
+	if img, err := s.GetImage("TS 23.501", "18.6.0", "image_.emf"); err != nil || img != nil {
+		t.Errorf("GetImage(image_.emf) = %+v, %v; want nil, nil", img, err)
+	}
+}
+
+// TestEnsureImagesBudgetExceeded checks that a slow image fetch yields
+// ErrInProgress and still completes in the background.
+func TestEnsureImagesBudgetExceeded(t *testing.T) {
+	release := make(chan struct{})
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		<-release
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), 20*time.Millisecond)
+	if !errors.Is(err, ErrInProgress) {
+		t.Fatalf("EnsureImages = %v, want ErrInProgress", err)
+	}
+
+	close(release)
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages after budget: %v", err)
+	}
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); !fetched {
+		t.Error("images did not land after the background fetch completed")
+	}
+}
+
+// TestImageBytesCountTowardLimit checks that image blobs join the eviction
+// account and that an evicted version takes its images with it.
+func TestImageBytesCountTowardLimit(t *testing.T) {
+	const size = 4096
+	// Sections are tiny next to the images, so a limit of roughly one image set
+	// forces the older of two versions out once both hold images.
+	s := openImageStore(t, 3*size, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return fakeImages(size), nil
+	})
+
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+	ensureVersion(t, s, "TS 23.502", "18.6.0")
+	if err := s.EnsureImages(context.Background(), "TS 23.502", "18.6.0", entry("23.502"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+
+	if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+		t.Error("TS 23.501 should have been evicted once image bytes exceeded the limit")
+	}
+	if img, err := s.GetImage("TS 23.501", "18.6.0", "image1.png"); err != nil || img != nil {
+		t.Errorf("evicted version still serves images: %+v, %v", img, err)
+	}
+	if has, _ := s.Has("TS 23.502", "18.6.0"); !has {
+		t.Error("the most recently fetched version should be kept")
+	}
+	if img, err := s.GetImage("TS 23.502", "18.6.0", "image1.png"); err != nil || img == nil {
+		t.Errorf("kept version lost its images: %+v, %v", img, err)
+	}
+}
+
+// TestPutImagesAfterEviction checks that an image fetch whose version was
+// evicted mid-flight fails without leaving orphaned blobs behind.
+func TestPutImagesAfterEviction(t *testing.T) {
+	var s *Store
+	s = openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		// Simulate the LRU dropping this version while its images download.
+		if err := s.delete("TS 23.501", "18.6.0"); err != nil {
+			t.Errorf("delete: %v", err)
+		}
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "evicted") {
+		t.Fatalf("EnsureImages = %v, want an eviction error", err)
+	}
+	if img, err := s.GetImage("TS 23.501", "18.6.0", "image1.png"); err != nil || img != nil {
+		t.Errorf("orphaned image survived: %+v, %v", img, err)
+	}
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); fetched {
+		t.Error("HasImages reports true for a version that is gone")
+	}
+}
+
+// TestOpenMigratesPreImageCache checks that a cache file created before images
+// were cached opens cleanly and gains the images_fetched column.
+func TestOpenMigratesPreImageCache(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "versions.db")
+	const oldSchema = db.SpecTablesSchema + `
+CREATE TABLE IF NOT EXISTS cache_entries (
+    spec_id TEXT NOT NULL,
+    version TEXT NOT NULL,
+    bytes INTEGER NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    last_used_at INTEGER NOT NULL,
+    PRIMARY KEY (spec_id, version)
+);
+`
+	conn, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open old cache: %v", err)
+	}
+	if _, err := conn.Exec(oldSchema); err != nil {
+		t.Fatalf("create old schema: %v", err)
+	}
+	if _, err := conn.Exec(
+		"INSERT INTO cache_entries (spec_id, version, bytes, fetched_at, last_used_at) VALUES ('TS 23.501', '18.6.0', 8, 1, 1)",
+	); err != nil {
+		t.Fatalf("seed old cache: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close old cache: %v", err)
+	}
+
+	s, err := Open(Options{Path: path, LimitBytes: DefaultLimitBytes})
+	if err != nil {
+		t.Fatalf("Open on a pre-image cache: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	if has, err := s.Has("TS 23.501", "18.6.0"); err != nil || !has {
+		t.Errorf("Has = %v, %v; want the migrated entry", has, err)
+	}
+	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || fetched {
+		t.Errorf("HasImages = %v, %v; want false for a migrated entry", fetched, err)
+	}
+}

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -167,6 +167,55 @@ func TestGetImageBaseNameFallback(t *testing.T) {
 	}
 }
 
+// TestGetImageFallbackPrefersReadable checks that when several cached images
+// share a base name, the fallback deterministically picks the readable one.
+func TestGetImageFallbackPrefersReadable(t *testing.T) {
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return []db.Image{
+			{Name: "image1.emf", MIMEType: "image/x-emf", Data: []byte("emf")},
+			{Name: "image1.png", MIMEType: "image/png", Data: []byte("png"), LLMReadable: true},
+		}, nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+
+	img, err := s.GetImage("TS 23.501", "18.6.0", "image1.wmf")
+	if err != nil || img == nil {
+		t.Fatalf("GetImage(image1.wmf) = %+v, %v; want a fallback match", img, err)
+	}
+	if img.Name != "image1.png" || !img.LLMReadable {
+		t.Errorf("fallback picked %q, want the readable image1.png", img.Name)
+	}
+}
+
+// TestPutClearsStaleImages checks that re-caching a version's sections drops
+// image rows from an earlier life of the entry: the REPLACE of cache_entries
+// resets images_fetched, so keeping the blobs would corrupt the account.
+func TestPutClearsStaleImages(t *testing.T) {
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+
+	// Another process re-caching the same version calls put directly.
+	spec, sections := fakeSpec("TS 23.501", "18.6.0", 16)
+	if err := s.put(spec, sections); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); fetched {
+		t.Error("images_fetched survived a re-put; the flag must reset with the entry")
+	}
+	if img, err := s.GetImage("TS 23.501", "18.6.0", "image1.png"); err != nil || img != nil {
+		t.Errorf("stale image row survived a re-put: %+v, %v", img, err)
+	}
+}
+
 // TestEnsureImagesSingleflight checks that concurrent callers for the same
 // version share one image download.
 func TestEnsureImagesSingleflight(t *testing.T) {

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -185,6 +185,58 @@ func TestEnsureImagesBudgetExceeded(t *testing.T) {
 	}
 }
 
+// TestEnsureImagesSurvivesCallerCancellation checks that a cancelled request
+// does not throw away the image download it started.
+func TestEnsureImagesSurvivesCallerCancellation(t *testing.T) {
+	started := make(chan struct{})
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		close(started)
+		time.Sleep(30 * time.Millisecond)
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+	if err := s.EnsureImages(ctx, "TS 23.501", "18.6.0", entry("23.501"), time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("EnsureImages = %v, want context.Canceled", err)
+	}
+
+	// The detached fetch should still land in the cache. A zero budget also
+	// exercises the default-budget fallback.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); fetched {
+			if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), 0); err != nil {
+				t.Fatalf("EnsureImages after completion: %v", err)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("image fetch did not complete after the caller was cancelled")
+}
+
+// TestEnsureImagesPropagatesFetchError checks that a failed fetch reaches the
+// caller and leaves the version marked as not fetched.
+func TestEnsureImagesPropagatesFetchError(t *testing.T) {
+	want := errors.New("boom")
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		return nil, want
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); !errors.Is(err, want) {
+		t.Errorf("EnsureImages = %v, want %v", err, want)
+	}
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); fetched {
+		t.Error("a failed fetch must not mark images as fetched")
+	}
+}
+
 // TestImageBytesCountTowardLimit checks that image blobs join the eviction
 // account and that an evicted version takes its images with it.
 func TestImageBytesCountTowardLimit(t *testing.T) {

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -158,6 +159,48 @@ func TestGetImageBaseNameFallback(t *testing.T) {
 	// The fallback must not treat LIKE metacharacters in the name as wildcards.
 	if img, err := s.GetImage("TS 23.501", "18.6.0", "image_.emf"); err != nil || img != nil {
 		t.Errorf("GetImage(image_.emf) = %+v, %v; want nil, nil", img, err)
+	}
+
+	// A name without an extension has nothing to fall back on.
+	if img, err := s.GetImage("TS 23.501", "18.6.0", "image1"); err != nil || img != nil {
+		t.Errorf("GetImage(image1) = %+v, %v; want nil, nil", img, err)
+	}
+}
+
+// TestEnsureImagesSingleflight checks that concurrent callers for the same
+// version share one image download.
+func TestEnsureImagesSingleflight(t *testing.T) {
+	release := make(chan struct{})
+	var calls atomic.Int32
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		calls.Add(1)
+		<-release
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	const callers = 4
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute)
+		}()
+	}
+	// Give every caller a chance to join the same in-flight fetch.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: %v", i, err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("image fetcher called %d times, want 1", got)
 	}
 }
 
@@ -336,5 +379,18 @@ CREATE TABLE IF NOT EXISTS cache_entries (
 	}
 	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || fetched {
 		t.Errorf("HasImages = %v, %v; want false for a migrated entry", fetched, err)
+	}
+
+	// Reopening an already-migrated cache must tolerate the existing column.
+	if err := s.Close(); err != nil {
+		t.Fatalf("close migrated cache: %v", err)
+	}
+	reopened, err := Open(Options{Path: path, LimitBytes: DefaultLimitBytes})
+	if err != nil {
+		t.Fatalf("Open on an already-migrated cache: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if has, err := reopened.Has("TS 23.501", "18.6.0"); err != nil || !has {
+		t.Errorf("Has after reopen = %v, %v; want the entry intact", has, err)
 	}
 }

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,15 +47,19 @@ const maxFetchDuration = 30 * time.Minute
 // DefaultFileName is the cache file created inside the XDG cache directory.
 const DefaultFileName = "versions.db"
 
-// schema mirrors the spec and section tables of the main database, without the
-// full-text index: cached versions must never appear in search results.
-const schema = db.SpecTablesSchema + `
+// schema mirrors the spec, section and image tables of the main database,
+// without the full-text index: cached versions must never appear in search
+// results. images_fetched distinguishes "images fetched, none found" from
+// "never fetched", so a figure-less version does not re-download its ZIP on
+// every image call.
+const schema = db.SpecTablesSchema + db.ImagesTableSchema + `
 CREATE TABLE IF NOT EXISTS cache_entries (
     spec_id TEXT NOT NULL,
     version TEXT NOT NULL,
     bytes INTEGER NOT NULL,
     fetched_at INTEGER NOT NULL,
     last_used_at INTEGER NOT NULL,
+    images_fetched INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (spec_id, version)
 );
 
@@ -63,11 +68,12 @@ CREATE INDEX IF NOT EXISTS idx_cache_lru ON cache_entries(last_used_at);
 
 // Store is a size-bounded cache of converted spec versions.
 type Store struct {
-	conn       *sql.DB
-	limitBytes int64
-	client     *http.Client
-	timeout    time.Duration
-	fetcher    Fetcher
+	conn         *sql.DB
+	limitBytes   int64
+	client       *http.Client
+	timeout      time.Duration
+	fetcher      Fetcher
+	imageFetcher ImageFetcher
 
 	mu       sync.Mutex
 	inflight map[string]*fetch
@@ -76,6 +82,10 @@ type Store struct {
 // Fetcher downloads and converts one archive entry. Only tests set it; the
 // zero value uses the real pipeline.
 type Fetcher func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error)
+
+// ImageFetcher downloads one archive entry's images. Only tests set it; the
+// zero value uses the real pipeline.
+type ImageFetcher func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error)
 
 // fetch tracks one in-progress download so concurrent callers asking for the
 // same version share a single download instead of racing.
@@ -100,6 +110,8 @@ type Options struct {
 	Timeout time.Duration
 	// Fetcher replaces the download-and-convert step. Only tests set it.
 	Fetcher Fetcher
+	// ImageFetcher replaces the image download step. Only tests set it.
+	ImageFetcher ImageFetcher
 }
 
 // DefaultPath returns the cache file location inside the XDG cache directory.
@@ -156,14 +168,22 @@ func Open(opts Options) (*Store, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("create version cache schema: %w", err)
 	}
+	// Cache files created before images were cached lack this column; the
+	// CREATE TABLE above is IF NOT EXISTS and does not add it.
+	if _, err := conn.Exec("ALTER TABLE cache_entries ADD COLUMN images_fetched INTEGER NOT NULL DEFAULT 0"); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column name") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("migrate version cache schema: %w", err)
+	}
 
 	return &Store{
-		conn:       conn,
-		limitBytes: opts.LimitBytes,
-		client:     opts.Client,
-		timeout:    opts.Timeout,
-		fetcher:    opts.Fetcher,
-		inflight:   map[string]*fetch{},
+		conn:         conn,
+		limitBytes:   opts.LimitBytes,
+		client:       opts.Client,
+		timeout:      opts.Timeout,
+		fetcher:      opts.Fetcher,
+		imageFetcher: opts.ImageFetcher,
+		inflight:     map[string]*fetch{},
 	}, nil
 }
 
@@ -185,6 +205,23 @@ func (s *Store) Has(specID, version string) (bool, error) {
 		return false, fmt.Errorf("check version cache: %w", err)
 	}
 	return true, nil
+}
+
+// HasImages reports whether a cached version's images have been fetched. False
+// with a nil error also covers a version that is not cached at all.
+func (s *Store) HasImages(specID, version string) (bool, error) {
+	var fetched int
+	err := s.conn.QueryRow(
+		"SELECT images_fetched FROM cache_entries WHERE spec_id = ? AND version = ?",
+		specID, version,
+	).Scan(&fetched)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check image cache: %w", err)
+	}
+	return fetched != 0, nil
 }
 
 // CachedVersions returns the versions of a spec held in the cache, newest
@@ -257,6 +294,68 @@ func (s *Store) GetSection(specID, version, number string, includeSubsections bo
 		)
 	}
 	return s.querySections(projection+" AND s.number = ?", specID, version, number)
+}
+
+// GetImage returns a cached image, or nil when the version holds no image of
+// that name. EMF/WMF images are renamed to .png when they are converted during
+// the fetch, while cached section Markdown keeps naming the original file, so
+// a missed exact match falls back to matching the name without its extension.
+func (s *Store) GetImage(specID, version, name string) (*db.Image, error) {
+	s.touch(specID, version)
+	const projection = "SELECT spec_id, version, name, mime_type, data, llm_readable FROM images WHERE spec_id = ? AND version = ?"
+
+	var img db.Image
+	err := s.conn.QueryRow(projection+" AND name = ?", specID, version, name).
+		Scan(&img.SpecID, &img.Version, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
+	if err == nil {
+		return &img, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("get cached image: %w", err)
+	}
+
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	if base == "" || base == name {
+		return nil, nil
+	}
+	err = s.conn.QueryRow(
+		projection+" AND name LIKE ? ESCAPE '\\' LIMIT 1",
+		specID, version, db.EscapeLikePattern(base)+".%",
+	).Scan(&img.SpecID, &img.Version, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cached image: %w", err)
+	}
+	return &img, nil
+}
+
+// ListImages returns metadata for a cached version's images, without the
+// binary data.
+func (s *Store) ListImages(specID, version string) ([]db.ImageInfo, error) {
+	s.touch(specID, version)
+	rows, err := s.conn.Query(
+		"SELECT spec_id, version, name, mime_type, llm_readable FROM images WHERE spec_id = ? AND version = ? ORDER BY name",
+		specID, version,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list cached images: %w", err)
+	}
+	defer rows.Close()
+
+	var infos []db.ImageInfo
+	for rows.Next() {
+		var info db.ImageInfo
+		if err := rows.Scan(&info.SpecID, &info.Version, &info.Name, &info.MIMEType, &info.LLMReadable); err != nil {
+			return nil, fmt.Errorf("scan cached image info: %w", err)
+		}
+		infos = append(infos, info)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list cached images: iterate: %w", err)
+	}
+	return infos, nil
 }
 
 func (s *Store) querySections(query string, args ...any) ([]db.Section, error) {
@@ -439,6 +538,157 @@ func (s *Store) put(spec db.Spec, sections []db.Section) error {
 	return nil
 }
 
+// EnsureImages makes a cached version's images available, downloading them when
+// necessary. The version's sections must already be cached — image fetching is
+// only reachable through a resolved version — and like Ensure, a fetch that
+// outlives budget keeps running detached and reports ErrInProgress, so
+// repeating the call later returns the cached images.
+func (s *Store) EnsureImages(ctx context.Context, specID, version string, sv *pipeline.SpecVersion, budget time.Duration) error {
+	fetched, err := s.HasImages(specID, version)
+	if err != nil {
+		return err
+	}
+	if fetched {
+		return nil
+	}
+	if budget <= 0 {
+		budget = DefaultBudget
+	}
+
+	// The "#" keeps this key disjoint from Ensure's section keys, so a section
+	// fetch and an image fetch of the same version never share an entry.
+	key := specID + "@" + version + "#images"
+	s.mu.Lock()
+	f, running := s.inflight[key]
+	if !running {
+		// Re-check under the lock: a fetch that completed between the HasImages
+		// call above and here has already been removed from inflight, and
+		// starting a fresh download for it would repeat minutes of work.
+		if fetched, err := s.HasImages(specID, version); err != nil || fetched {
+			s.mu.Unlock()
+			return err
+		}
+		f = &fetch{done: make(chan struct{})}
+		s.inflight[key] = f
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), maxFetchDuration)
+		go func() {
+			defer cancel()
+			s.runImages(fetchCtx, key, specID, version, sv, f)
+		}()
+	}
+	s.mu.Unlock()
+
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-f.done:
+		return f.err
+	case <-timer.C:
+		return fmt.Errorf("%w: images for %s v%s", ErrInProgress, specID, version)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// runImages performs one image fetch and publishes its outcome to everyone
+// waiting on it.
+func (s *Store) runImages(ctx context.Context, key, specID, version string, sv *pipeline.SpecVersion, f *fetch) {
+	defer func() {
+		s.mu.Lock()
+		delete(s.inflight, key)
+		s.mu.Unlock()
+		close(f.done)
+	}()
+
+	images, err := s.fetchImages(ctx, sv)
+	if err != nil {
+		f.err = err
+		return
+	}
+	for i := range images {
+		images[i].SpecID = specID
+		images[i].Version = version
+	}
+	if err := s.putImages(specID, version, images); err != nil {
+		f.err = err
+	}
+}
+
+// fetchImages downloads one archive entry's images. It is a field so tests can
+// supply images without reaching the network.
+func (s *Store) fetchImages(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+	if s.imageFetcher != nil {
+		return s.imageFetcher(ctx, sv)
+	}
+	return pipeline.FetchVersionImages(ctx, s.client, sv, s.timeout)
+}
+
+// putImages writes a version's images into the cache and enforces the size
+// limit. Image bytes count against the same cache entry as the sections, so
+// eviction drops a version's text and figures as one unit.
+func (s *Store) putImages(specID, version string, images []db.Image) error {
+	tx, err := s.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin cache transaction: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
+	// Replacing an earlier image set must not leave its bytes in the account.
+	var oldBytes int64
+	if err := tx.QueryRow(
+		"SELECT COALESCE(SUM(LENGTH(data) + LENGTH(name)), 0) FROM images WHERE spec_id = ? AND version = ?",
+		specID, version,
+	).Scan(&oldBytes); err != nil {
+		return fmt.Errorf("measure cached images: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM images WHERE spec_id = ? AND version = ?", specID, version); err != nil {
+		return fmt.Errorf("clear cached images: %w", err)
+	}
+
+	stmt, err := tx.Prepare(
+		"INSERT INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, ?)",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare image insert: %w", err)
+	}
+	defer stmt.Close()
+
+	var bytes int64
+	for _, img := range images {
+		if _, err := stmt.Exec(img.SpecID, img.Version, img.Name, img.MIMEType, img.Data, img.LLMReadable); err != nil {
+			return fmt.Errorf("cache image: %w", err)
+		}
+		bytes += int64(len(img.Data)) + int64(len(img.Name))
+	}
+
+	res, err := tx.Exec(
+		"UPDATE cache_entries SET bytes = bytes + ?, images_fetched = 1 WHERE spec_id = ? AND version = ?",
+		bytes-oldBytes, specID, version,
+	)
+	if err != nil {
+		return fmt.Errorf("record image bytes: %w", err)
+	}
+	if n, err := res.RowsAffected(); err != nil {
+		return fmt.Errorf("record image bytes: %w", err)
+	} else if n == 0 {
+		// The version was evicted while its images downloaded. Committing would
+		// orphan the blobs and break the invariant that a cache entry always
+		// accompanies cached rows, so give up; the next call re-fetches the
+		// sections first.
+		return fmt.Errorf("%s v%s was evicted while its images downloaded; call the tool again", specID, version)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit cache transaction: %w", err)
+	}
+	// The images are cached and readable at this point, so an eviction failure
+	// must not be reported as a failed fetch: it only costs cache size accuracy.
+	if err := s.evict(specID, version); err != nil {
+		log.Printf("warning: version cache eviction failed: %v", err)
+	}
+	return nil
+}
+
 // evict drops least-recently-used versions until the cache fits its limit. The
 // entry named by keepSpecID/keepVersion is never dropped: it was just fetched,
 // and evicting it would make the fetch pointless when a single spec is larger
@@ -486,6 +736,7 @@ func (s *Store) delete(specID, version string) error {
 
 	for _, q := range []string{
 		"DELETE FROM sections WHERE spec_id = ? AND version = ?",
+		"DELETE FROM images WHERE spec_id = ? AND version = ?",
 		"DELETE FROM specs WHERE id = ? AND version = ?",
 		"DELETE FROM cache_entries WHERE spec_id = ? AND version = ?",
 	} {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -318,8 +318,10 @@ func (s *Store) GetImage(specID, version, name string) (*db.Image, error) {
 	if base == "" || base == name {
 		return nil, nil
 	}
+	// Prefer a readable row, then order by name, so several images sharing a
+	// base name resolve the same way on every call.
 	err = s.conn.QueryRow(
-		projection+" AND name LIKE ? ESCAPE '\\' LIMIT 1",
+		projection+" AND name LIKE ? ESCAPE '\\' ORDER BY llm_readable DESC, name LIMIT 1",
 		specID, version, db.EscapeLikePattern(base)+".%",
 	).Scan(&img.SpecID, &img.Version, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -501,6 +503,13 @@ func (s *Store) put(spec db.Spec, sections []db.Section) error {
 
 	if _, err := tx.Exec("DELETE FROM sections WHERE spec_id = ? AND version = ?", spec.ID, spec.Version); err != nil {
 		return fmt.Errorf("clear cached sections: %w", err)
+	}
+	// The REPLACE of cache_entries below resets images_fetched to zero, so any
+	// image rows from an earlier life of this version — possible when several
+	// processes share the cache file — must go with it, or their bytes would
+	// escape the account and the flag would deny they exist.
+	if _, err := tx.Exec("DELETE FROM images WHERE spec_id = ? AND version = ?", spec.ID, spec.Version); err != nil {
+		return fmt.Errorf("clear cached images: %w", err)
 	}
 	stmt, err := tx.Prepare(
 		"INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES (?, ?, ?, ?, ?, ?, ?)",


### PR DESCRIPTION
## Summary

The on-demand version fetch deliberately dropped images, so `get_image` and `list_images` could only answer about the version the database was built with. This adds a lazy image path: images of an archived version are downloaded on their own first use, cached, and served from then on.

- Add `pipeline.FetchVersionImages`: downloads the version's ZIP, extracts all embedded images, and converts EMF/WMF figures to PNG when LibreOffice (`soffice`) is available at runtime
- Add an `images` table and `EnsureImages` to `versionstore`, reusing the existing single-flight / budget / detached-fetch machinery with a separate inflight key; image bytes count against the LRU limit and a version's text and images are evicted as one unit; existing cache files gain the `images_fetched` column on open
- Add an optional `version` parameter to `get_image` / `list_images` and rebind them from `*db.DB` to `*tools.Source`; behavior without `version` is unchanged
- `Store.GetImage` falls back to a base-name match so the original `image1.emf` named in cached section Markdown still finds the converted `image1.png`
- Update the archived `get_section` header (only cross-references remain unavailable), server instructions, README, and AGENTS.md

## Notes

- Fetching a single image still costs a full ZIP download (the archive offers no partial download), so all images of the version are cached from that one download; requesting images of an archived version is a second download on top of the section fetch
- Without `soffice` on the server, archived EMF/WMF figures return the same "cannot be displayed" style error as an unconverted prebuilt database

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test -race ./...` all pass
- New tests cover single-flight image fetch, budget-exceeded retry, base-name fallback, LIKE-metacharacter safety, byte accounting and unit eviction, eviction-during-fetch, empty-result memoization, old cache migration, and the tool-level archived paths