### PR TITLE
feat: enhance full-text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ database, so:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search` | Full-text search across all specs | `query` (required), `spec_ids` (optional), `limit` |
+| `search` | Full-text search across all specs | `query` (required), `spec_ids` (optional), `limit`, `offset` |
 
 The `search` tool supports [SQLite FTS5](https://www.sqlite.org/fts5.html) query syntax:
 
@@ -257,6 +257,14 @@ The `search` tool supports [SQLite FTS5](https://www.sqlite.org/fts5.html) query
 - Prefix matching: `handov*`
 - Column filter: `title:authentication`, `content:handover`
 - Proximity: `NEAR(AMF UE, 5)`
+
+Results come as `{results, total_count, limit, offset}`; use `limit` (default
+10, max 200) and `offset` to page through everything beyond the first page.
+Section-title matches rank above body matches, and the snippet is taken from
+whichever column matched best. The index uses porter stemming, so inflected
+English forms match each other (`handover` finds `handovers`). The tokenizer
+applies when the database is created, so a database built before this change
+keeps unstemmed search until rebuilt.
 
 ### Cross-references
 

--- a/db/db.go
+++ b/db/db.go
@@ -172,6 +172,14 @@ type ListSpecsResult struct {
 	Offset     int    `json:"offset"`
 }
 
+// SearchResults holds one page of search hits plus the total match count.
+type SearchResults struct {
+	Results    []SearchResult `json:"results"`
+	TotalCount int            `json:"total_count"`
+	Limit      int            `json:"limit"`
+	Offset     int            `json:"offset"`
+}
+
 // SpecTablesSchema defines the tables that hold a specification's text, keyed
 // by (spec_id, version). The version cache reuses it verbatim; the main
 // database adds full-text search and the remaining tables on top.
@@ -1002,12 +1010,15 @@ func sanitizeFTS5Query(query string) string {
 	return strings.Join(result, " ")
 }
 
-func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, error) {
+func (d *DB) Search(query string, specIDs []string, limit, offset int) (*SearchResults, error) {
 	if limit <= 0 {
 		limit = DefaultSearchLimit
 	}
 	if limit > MaxSearchLimit {
 		limit = MaxSearchLimit
+	}
+	if offset < 0 {
+		offset = 0
 	}
 
 	query = sanitizeFTS5Query(query)
@@ -1015,9 +1026,8 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 	// sections_fts has no version column, so the version comes from the backing
 	// sections row (sections_fts.rowid is sections.id). Joining specs on the
 	// pair keeps one row per hit even when a database holds several versions.
-	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
-		"FROM sections_fts JOIN sections s ON s.id = sections_fts.rowid LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE sections_fts MATCH ?"
-	args := []any{query}
+	fromWhere := "FROM sections_fts JOIN sections s ON s.id = sections_fts.rowid LEFT JOIN specs p ON p.id = s.spec_id AND p.version = s.version WHERE sections_fts MATCH ?"
+	filterArgs := []any{query}
 
 	if len(specIDs) > 0 {
 		// Each spec ID also matches its split multi-file parts (e.g. "TS 38.101"
@@ -1026,12 +1036,21 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 		conds := make([]string, len(specIDs))
 		for i, id := range specIDs {
 			conds[i] = "sections_fts.spec_id = ? OR sections_fts.spec_id LIKE ? ESCAPE '\\'"
-			args = append(args, id, EscapeLikePattern(id)+"-%")
+			filterArgs = append(filterArgs, id, EscapeLikePattern(id)+"-%")
 		}
-		sqlQuery += " AND (" + strings.Join(conds, " OR ") + ")"
+		fromWhere += " AND (" + strings.Join(conds, " OR ") + ")"
 	}
-	sqlQuery += " ORDER BY sections_fts.rank LIMIT ?"
-	args = append(args, limit)
+
+	// A window count(*) OVER () cannot report the total when offset lands past
+	// the last row, so the total comes from its own query sharing the filter.
+	var totalCount int
+	if err := d.conn.QueryRow("SELECT count(*) "+fromWhere, filterArgs...).Scan(&totalCount); err != nil {
+		return nil, fmt.Errorf("invalid search query %q: %w", query, err)
+	}
+
+	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
+		fromWhere + " ORDER BY sections_fts.rank LIMIT ? OFFSET ?"
+	args := append(append([]any{}, filterArgs...), limit, offset)
 
 	rows, err := d.conn.Query(sqlQuery, args...)
 	if err != nil {
@@ -1039,7 +1058,7 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 	}
 	defer rows.Close()
 
-	var results []SearchResult
+	results := []SearchResult{}
 	for rows.Next() {
 		var r SearchResult
 		if err := rows.Scan(&r.SpecID, &r.Number, &r.Title, &r.Snippet, &r.Version, &r.Release); err != nil {
@@ -1050,7 +1069,7 @@ func (d *DB) Search(query string, specIDs []string, limit int) ([]SearchResult, 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("search: iterate: %w", err)
 	}
-	return results, nil
+	return &SearchResults{Results: results, TotalCount: totalCount, Limit: limit, Offset: offset}, nil
 }
 
 // Direction constants for GetReferences.

--- a/db/db.go
+++ b/db/db.go
@@ -1064,8 +1064,10 @@ func (d *DB) Search(query string, specIDs []string, limit, offset int) (*SearchR
 
 	// Column -1 lets FTS5 pick the best-matching column for the snippet, so a
 	// title-only hit shows the marked title instead of an unmarked content head.
+	// The rowid tie-breaker keeps equal-scoring rows in a stable order, so
+	// paging with OFFSET never duplicates or drops a hit.
 	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, -1, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
-		fromWhere + " ORDER BY " + bm25Weights + " LIMIT ? OFFSET ?"
+		fromWhere + " ORDER BY " + bm25Weights + ", sections_fts.rowid LIMIT ? OFFSET ?"
 	args := append(append([]any{}, filterArgs...), limit, offset)
 
 	rows, err := d.conn.Query(sqlQuery, args...)

--- a/db/db.go
+++ b/db/db.go
@@ -1010,6 +1010,14 @@ func sanitizeFTS5Query(query string) string {
 	return strings.Join(result, " ")
 }
 
+// bm25Weights orders search hits: title matches dominate, spec_id barely
+// counts (a spec-number query matches the spec_id column of every section of
+// that spec, which would otherwise flood the ranking). Column order is
+// spec_id, number, title, content. bm25() returns negative scores, smaller =
+// better, so ORDER BY stays ascending. Weighting must happen in the query:
+// setting the table's rank option needs a write, and serve opens read-only.
+const bm25Weights = "bm25(sections_fts, 0.5, 1.0, 5.0, 1.0)"
+
 func (d *DB) Search(query string, specIDs []string, limit, offset int) (*SearchResults, error) {
 	if limit <= 0 {
 		limit = DefaultSearchLimit
@@ -1048,8 +1056,10 @@ func (d *DB) Search(query string, specIDs []string, limit, offset int) (*SearchR
 		return nil, fmt.Errorf("invalid search query %q: %w", query, err)
 	}
 
-	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, 3, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
-		fromWhere + " ORDER BY sections_fts.rank LIMIT ? OFFSET ?"
+	// Column -1 lets FTS5 pick the best-matching column for the snippet, so a
+	// title-only hit shows the marked title instead of an unmarked content head.
+	sqlQuery := "SELECT sections_fts.spec_id, sections_fts.number, sections_fts.title, snippet(sections_fts, -1, '<mark>', '</mark>', '...', 32), s.version, COALESCE(p.release, '') " +
+		fromWhere + " ORDER BY " + bm25Weights + " LIMIT ? OFFSET ?"
 	args := append(append([]any{}, filterArgs...), limit, offset)
 
 	rows, err := d.conn.Query(sqlQuery, args...)

--- a/db/db.go
+++ b/db/db.go
@@ -235,12 +235,18 @@ CREATE INDEX IF NOT EXISTS idx_images_spec ON images(spec_id, version);
 // A build imports one version per spec, so the FTS index covers exactly that
 // version. Versions fetched on demand are stored in a separate cache database
 // that has no FTS tables, keeping cross-release rows out of search results.
+//
+// Porter stemming folds inflected forms together (handover matches
+// handovers); spec_id and number tokenize to unstemmed digit runs, which
+// porter leaves untouched. The DDL is IF NOT EXISTS, so the tokenizer applies
+// to newly created databases only.
 const Schema = SpecTablesSchema + ImagesTableSchema + `
 
 CREATE VIRTUAL TABLE IF NOT EXISTS sections_fts USING fts5(
     spec_id, number, title, content,
     content=sections,
-    content_rowid=id
+    content_rowid=id,
+    tokenize='porter unicode61'
 );
 
 CREATE TRIGGER IF NOT EXISTS sections_ai AFTER INSERT ON sections BEGIN

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -661,6 +661,28 @@ Body text without the probe term.');`); err != nil {
 	}
 }
 
+func TestSearchStemming(t *testing.T) {
+	d := setupTestDB(t)
+
+	if err := d.ExecScript(`INSERT INTO specs (id, version, title) VALUES ('TS 90.003', '1.0.0', 'Stemming probe');
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 90.003', '1.0.0', '1', 'Mobility', 1, NULL, '# 1 Mobility
+Handovers between cells are described in this clause.');`); err != nil {
+		t.Fatalf("failed to insert test data: %v", err)
+	}
+
+	// Porter stemming folds inflected forms both ways.
+	for _, q := range []string{"handover", "handovers"} {
+		page, err := d.Search(q, []string{"TS 90.003"}, 10, 0)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", q, err)
+		}
+		if len(page.Results) != 1 {
+			t.Errorf("expected 1 result for %q, got %d", q, len(page.Results))
+		}
+	}
+}
+
 func TestFindSpecIDsByFamily(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -610,6 +610,57 @@ The guardband requirements are specified here.');`)
 	})
 }
 
+func TestSearchRanking(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Same term in one section's title and another section's body: the title
+	// hit must rank first under the weighted bm25 ordering.
+	if err := d.ExecScript(`INSERT INTO specs (id, version, title) VALUES ('TS 90.001', '1.0.0', 'Ranking probe');
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 90.001', '1.0.0', '1', 'Miscellaneous', 1, NULL, '# 1 Miscellaneous
+The rankprobe term appears in this body text only, nowhere else.'),
+    ('TS 90.001', '1.0.0', '2', 'Rankprobe overview', 1, NULL, '# 2 Overview
+This body says nothing relevant at all.');`); err != nil {
+		t.Fatalf("failed to insert test data: %v", err)
+	}
+
+	page, err := d.Search("rankprobe", nil, 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(page.Results))
+	}
+	if page.Results[0].Number != "2" {
+		t.Errorf("expected title hit (section 2) ranked first, got section %q", page.Results[0].Number)
+	}
+}
+
+func TestSearchSnippetColumn(t *testing.T) {
+	d := setupTestDB(t)
+
+	// A term that only appears in the title: the snippet must come from the
+	// title column and carry the match markers.
+	if err := d.ExecScript(`INSERT INTO specs (id, version, title) VALUES ('TS 90.002', '1.0.0', 'Snippet probe');
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 90.002', '1.0.0', '1', 'Snippetprobe requirements', 1, NULL, '# 1 Requirements
+Body text without the probe term.');`); err != nil {
+		t.Fatalf("failed to insert test data: %v", err)
+	}
+
+	page, err := d.Search("snippetprobe", nil, 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(page.Results))
+	}
+	snippet := page.Results[0].Snippet
+	if !strings.Contains(snippet, "<mark>") || !strings.Contains(snippet, "Snippetprobe") {
+		t.Errorf("expected marked title snippet, got %q", snippet)
+	}
+}
+
 func TestFindSpecIDsByFamily(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -433,20 +433,27 @@ func TestSearch(t *testing.T) {
 	d := setupTestDB(t)
 
 	t.Run("basic search", func(t *testing.T) {
-		results, err := d.Search("architecture", nil, 10)
+		page, err := d.Search("architecture", nil, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) == 0 {
+		if len(page.Results) == 0 {
 			t.Fatal("expected at least 1 result")
+		}
+		if page.TotalCount != len(page.Results) {
+			t.Errorf("expected total_count %d, got %d", len(page.Results), page.TotalCount)
+		}
+		if page.Limit != 10 || page.Offset != 0 {
+			t.Errorf("expected limit 10 / offset 0, got %d / %d", page.Limit, page.Offset)
 		}
 	})
 
 	t.Run("search with single spec filter", func(t *testing.T) {
-		results, err := d.Search("Scope", []string{"TS 29.510"}, 10)
+		page, err := d.Search("Scope", []string{"TS 29.510"}, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		results := page.Results
 		if len(results) != 1 {
 			t.Fatalf("expected 1 result, got %d", len(results))
 		}
@@ -459,22 +466,82 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("search with multiple spec filter", func(t *testing.T) {
-		results, err := d.Search("Scope", []string{"TS 23.501", "TS 29.510"}, 10)
+		page, err := d.Search("Scope", []string{"TS 23.501", "TS 29.510"}, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 2 {
-			t.Fatalf("expected 2 results, got %d", len(results))
+		if len(page.Results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(page.Results))
 		}
 	})
 
 	t.Run("no results", func(t *testing.T) {
-		results, err := d.Search("xyznonexistent", nil, 10)
+		page, err := d.Search("xyznonexistent", nil, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 0 {
-			t.Fatalf("expected 0 results, got %d", len(results))
+		if len(page.Results) != 0 {
+			t.Fatalf("expected 0 results, got %d", len(page.Results))
+		}
+		if page.TotalCount != 0 {
+			t.Errorf("expected total_count 0, got %d", page.TotalCount)
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		full, err := d.Search("Scope", []string{"TS 23.501", "TS 29.510"}, 10, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if full.TotalCount != 2 {
+			t.Fatalf("expected total_count 2, got %d", full.TotalCount)
+		}
+
+		first, err := d.Search("Scope", []string{"TS 23.501", "TS 29.510"}, 1, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		second, err := d.Search("Scope", []string{"TS 23.501", "TS 29.510"}, 1, 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(first.Results) != 1 || len(second.Results) != 1 {
+			t.Fatalf("expected 1 result per page, got %d and %d", len(first.Results), len(second.Results))
+		}
+		if first.TotalCount != 2 || second.TotalCount != 2 {
+			t.Errorf("expected total_count 2 on both pages, got %d and %d", first.TotalCount, second.TotalCount)
+		}
+		if first.Results[0].SpecID == second.Results[0].SpecID {
+			t.Errorf("expected different specs on each page, got %q twice", first.Results[0].SpecID)
+		}
+		if second.Offset != 1 {
+			t.Errorf("expected offset 1 echoed back, got %d", second.Offset)
+		}
+	})
+
+	t.Run("offset beyond total", func(t *testing.T) {
+		page, err := d.Search("Scope", []string{"TS 29.510"}, 10, 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Results) != 0 {
+			t.Fatalf("expected 0 results, got %d", len(page.Results))
+		}
+		if page.TotalCount != 1 {
+			t.Errorf("expected total_count 1, got %d", page.TotalCount)
+		}
+	})
+
+	t.Run("negative offset treated as zero", func(t *testing.T) {
+		page, err := d.Search("Scope", []string{"TS 29.510"}, 10, -5)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page.Results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(page.Results))
+		}
+		if page.Offset != 0 {
+			t.Errorf("expected offset normalized to 0, got %d", page.Offset)
 		}
 	})
 
@@ -487,10 +554,11 @@ This document covers IMS-AKA and sec-agree mechanisms.');`)
 		if err != nil {
 			t.Fatalf("failed to insert test data: %v", err)
 		}
-		results, err := d.Search("IMS-AKA", nil, 10)
+		page, err := d.Search("IMS-AKA", nil, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error for hyphenated search: %v", err)
 		}
+		results := page.Results
 		if len(results) == 0 {
 			t.Error("expected at least 1 result for IMS-AKA")
 		}
@@ -510,34 +578,34 @@ The guardband requirements are specified here.');`)
 			t.Fatalf("failed to insert test data: %v", err)
 		}
 
-		results, err := d.Search("guardband", []string{"TS 38.101"}, 10)
+		page, err := d.Search("guardband", []string{"TS 38.101"}, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(results))
+		if len(page.Results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(page.Results))
 		}
-		if results[0].SpecID != "TS 38.101-1" {
-			t.Errorf("expected spec_id 'TS 38.101-1', got %q", results[0].SpecID)
+		if page.Results[0].SpecID != "TS 38.101-1" {
+			t.Errorf("expected spec_id 'TS 38.101-1', got %q", page.Results[0].SpecID)
 		}
 
 		// An unrelated spec sharing the family's numeric prefix must not match.
-		results, err = d.Search("guardband", []string{"TS 38.10"}, 10)
+		page, err = d.Search("guardband", []string{"TS 38.10"}, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 0 {
-			t.Fatalf("expected 0 results for unrelated prefix, got %d", len(results))
+		if len(page.Results) != 0 {
+			t.Fatalf("expected 0 results for unrelated prefix, got %d", len(page.Results))
 		}
 
 		// "_" would otherwise act as a single-character LIKE wildcard and
 		// match "TS 38.101-1" via "TS 38_101".
-		results, err = d.Search("guardband", []string{"TS 38_101"}, 10)
+		page, err = d.Search("guardband", []string{"TS 38_101"}, 10, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 0 {
-			t.Fatalf("expected 0 results for literal underscore query, got %d", len(results))
+		if len(page.Results) != 0 {
+			t.Fatalf("expected 0 results for literal underscore query, got %d", len(page.Results))
 		}
 	})
 }
@@ -1304,11 +1372,11 @@ func TestUpsertSection_ReplacesContent(t *testing.T) {
 	}
 
 	// FTS should pick up the new token.
-	results, err := d.Search("zucchini", []string{"TS 23.501"}, 10)
+	page, err := d.Search("zucchini", []string{"TS 23.501"}, 10, 0)
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
-	if len(results) == 0 {
+	if len(page.Results) == 0 {
 		t.Error("expected FTS hit for zucchini after upsert")
 	}
 }
@@ -1486,11 +1554,11 @@ func TestInsertSpec_DropsSupersededVersions(t *testing.T) {
 	}
 
 	// The superseded version's sections must be gone from search too.
-	results, err := d.Search("supersededprobe", nil, 10)
+	page, err := d.Search("supersededprobe", nil, 10, 0)
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("expected exactly 1 search hit after supersede, got %d", len(results))
+	if len(page.Results) != 1 {
+		t.Errorf("expected exactly 1 search hit after supersede, got %d", len(page.Results))
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -532,6 +532,26 @@ func TestSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("limit zero uses default", func(t *testing.T) {
+		page, err := d.Search("Scope", nil, 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if page.Limit != DefaultSearchLimit {
+			t.Errorf("expected limit %d, got %d", DefaultSearchLimit, page.Limit)
+		}
+	})
+
+	t.Run("limit above max is clamped", func(t *testing.T) {
+		page, err := d.Search("Scope", nil, MaxSearchLimit+1, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if page.Limit != MaxSearchLimit {
+			t.Errorf("expected limit clamped to %d, got %d", MaxSearchLimit, page.Limit)
+		}
+	})
+
 	t.Run("negative offset treated as zero", func(t *testing.T) {
 		page, err := d.Search("Scope", []string{"TS 29.510"}, 10, -5)
 		if err != nil {
@@ -608,6 +628,17 @@ The guardband requirements are specified here.');`)
 			t.Fatalf("expected 0 results for literal underscore query, got %d", len(page.Results))
 		}
 	})
+}
+
+func TestSearchClosedDB(t *testing.T) {
+	d := setupTestDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := d.Search("architecture", nil, 10, 0); err == nil {
+		t.Error("expected error searching a closed database")
+	}
 }
 
 func TestSearchRanking(t *testing.T) {

--- a/tools/search.go
+++ b/tools/search.go
@@ -31,6 +31,10 @@ Query syntax:
 - Hyphenated or dotted terms (e.g. IMS-AKA, sec-agree, 38.101) are auto-quoted to avoid FTS5 syntax errors.
 - After a positive term, "-term" excludes that term (e.g. AMF -SMF), same as NOT. An exclusion cannot begin a query or immediately follow AND/OR.
 
+Stemming:
+- The index uses porter stemming: inflected English forms match each other (handover finds handovers).
+- Prefix and phrase queries operate on stemmed forms, so they can match a bit more broadly than the exact surface text.
+
 Pagination:
 - Results come as {results, total_count, limit, offset}; total_count is the full match count.
 - Use limit (default 10, max 200) and offset to page through matches beyond the first page.

--- a/tools/search.go
+++ b/tools/search.go
@@ -53,7 +53,7 @@ func HandleSearch(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 			specIDs = []string{input.SpecID}
 		}
 
-		results, err := d.Search(input.Query, specIDs, limit)
+		results, err := d.Search(input.Query, specIDs, limit, 0)
 		if err != nil {
 			return errorResult(fmt.Sprintf("search failed: %v", err)), nil, nil
 		}

--- a/tools/search.go
+++ b/tools/search.go
@@ -14,7 +14,8 @@ type SearchInput struct {
 	// Deprecated: use SpecIDs instead. Ignored when SpecIDs is non-empty.
 	SpecID  string   `json:"spec_id,omitempty" jsonschema:"Limit search to a single specification (e.g. TS 23.501). Ignored when spec_ids is provided."`
 	SpecIDs []string `json:"spec_ids,omitempty" jsonschema:"Limit search to one or more specifications (e.g. [\"TS 23.501\", \"TS 23.502\"]). Takes precedence over spec_id."`
-	Limit   int      `json:"limit,omitempty" jsonschema:"Maximum number of results (default: 10)"`
+	Limit   int      `json:"limit,omitempty" jsonschema:"Maximum number of results per page (default: 10, max: 200)"`
+	Offset  int      `json:"offset,omitempty" jsonschema:"Number of results to skip for pagination (default: 0). Combine with total_count in the response to page through all matches."`
 }
 
 var SearchTool = &mcp.Tool{
@@ -29,6 +30,10 @@ Query syntax:
 - Proximity:     NEAR(AMF UE, 5)
 - Hyphenated or dotted terms (e.g. IMS-AKA, sec-agree, 38.101) are auto-quoted to avoid FTS5 syntax errors.
 - After a positive term, "-term" excludes that term (e.g. AMF -SMF), same as NOT. An exclusion cannot begin a query or immediately follow AND/OR.
+
+Pagination:
+- Results come as {results, total_count, limit, offset}; total_count is the full match count.
+- Use limit (default 10, max 200) and offset to page through matches beyond the first page.
 
 Tips:
 - Use exact 3GPP terms (AMF, SMF, gNB, UE, NRF, PCF, etc.)
@@ -53,7 +58,12 @@ func HandleSearch(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, 
 			specIDs = []string{input.SpecID}
 		}
 
-		results, err := d.Search(input.Query, specIDs, limit, 0)
+		offset := input.Offset
+		if offset < 0 {
+			offset = 0
+		}
+
+		results, err := d.Search(input.Query, specIDs, limit, offset)
 		if err != nil {
 			return errorResult(fmt.Sprintf("search failed: %v", err)), nil, nil
 		}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -334,6 +334,23 @@ func TestHandleSearch(t *testing.T) {
 		if !strings.Contains(text, `"version": "18.6.0"`) || !strings.Contains(text, `"release": "18"`) {
 			t.Errorf("expected version/release in search results, got: %s", text)
 		}
+		if !strings.Contains(text, `"results"`) || !strings.Contains(text, `"total_count"`) {
+			t.Errorf("expected pagination envelope in search results, got: %s", text)
+		}
+	})
+
+	t.Run("offset pages through results", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, SearchInput{Query: "Scope", Limit: 1, Offset: 1})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected error result: %s", getTextContent(result))
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, `"offset": 1`) {
+			t.Errorf("expected offset echoed back, got: %s", text)
+		}
 	})
 }
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -352,6 +352,19 @@ func TestHandleSearch(t *testing.T) {
 			t.Errorf("expected offset echoed back, got: %s", text)
 		}
 	})
+
+	t.Run("negative offset treated as zero", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, SearchInput{Query: "Scope", Offset: -3})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected error result: %s", getTextContent(result))
+		}
+		if !strings.Contains(getTextContent(result), `"offset": 0`) {
+			t.Errorf("expected offset normalized to 0, got: %s", getTextContent(result))
+		}
+	})
 }
 
 func TestHandleListOpenAPI(t *testing.T) {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -290,11 +290,11 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		if specID != "" {
 			specIDs = []string{specID}
 		}
-		results, err := h.db.Search(query, specIDs, 50)
+		page, err := h.db.Search(query, specIDs, 50, 0)
 		if err != nil {
 			log.Printf("Search error: %v", err)
 		} else {
-			data.Results = results
+			data.Results = page.Results
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add offset pagination and total match count to the `search` tool: results now come as `{results, total_count, limit, offset}` (same envelope as `list_specs`) instead of a bare array
- Rank section-title matches above body matches via explicit bm25 column weights, and let `snippet()` pick the best-matching column so title-only hits show the marked title
- Switch the FTS tokenizer to `porter unicode61` so inflected English forms match each other (`handover` finds `handovers`); applies to newly created databases only

## Changes

- `db`: `Search(query, specIDs, limit, offset)` returns `*SearchResults` with `total_count` from a separate count query sharing the same filter; `ORDER BY bm25(sections_fts, 0.5, 1.0, 5.0, 1.0)` (spec_id barely counts to avoid spec-number queries flooding the ranking); `snippet(..., -1, ...)`; `tokenize='porter unicode61'` in the schema
- `tools`: `search` gains an `offset` parameter; tool description documents pagination and stemming
- `web`: follow the new `Search` signature (no UI changes)
- Tests: pagination (paging, offset past the end, negative offset), ranking, snippet column, stemming
- README: search output format, pagination and stemming notes

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXCG8NVX5ePDc4Yyycde7p)_