### PR TITLE
feat(web): spec header tabs for Document, Versions and Compare

### DIFF
--- a/web/compare.go
+++ b/web/compare.go
@@ -52,7 +52,9 @@ func (h *handler) handleCompare(w http.ResponseWriter, r *http.Request) {
 		NewParam:   q.Get("new"),
 		Section:    q.Get("section"),
 		OldSection: q.Get("old_section"),
-		Header:     specHeader{SpecID: specID, Active: "compare"},
+		// Carrying the old version keeps the tabs on the version being
+		// compared: Document opens it, Compare keeps it selected.
+		Header: specHeader{SpecID: specID, Active: "compare", Version: q.Get("old")},
 	}
 
 	// Without an old version there is nothing to compare yet; show the form.

--- a/web/compare.go
+++ b/web/compare.go
@@ -39,6 +39,7 @@ type compareData struct {
 	DiffLines                    []diffLine
 	Identical                    bool
 	Notice                       string
+	Header                       specHeader
 }
 
 func (h *handler) handleCompare(w http.ResponseWriter, r *http.Request) {
@@ -51,6 +52,7 @@ func (h *handler) handleCompare(w http.ResponseWriter, r *http.Request) {
 		NewParam:   q.Get("new"),
 		Section:    q.Get("section"),
 		OldSection: q.Get("old_section"),
+		Header:     specHeader{SpecID: specID, Active: "compare"},
 	}
 
 	// Without an old version there is nothing to compare yet; show the form.

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -46,6 +46,21 @@ type indexData struct {
 	HasNext    bool
 }
 
+// specHeader drives the header bar shared by every spec-scoped page: the
+// spec's identity plus the Document / Versions / Compare tabs.
+type specHeader struct {
+	SpecID string
+	Active string // "document" | "versions" | "compare"
+	// Version is carried on the Document and Compare tabs when browsing an
+	// archived version, so the tabs stay on that version.
+	Version string
+	// DisplayVersion/Release/Archived describe the version being read; an
+	// empty DisplayVersion hides the version line.
+	DisplayVersion string
+	Release        string
+	Archived       bool
+}
+
 type specData struct {
 	Spec       *db.Spec
 	TOC        []db.Section
@@ -59,6 +74,7 @@ type specData struct {
 	// database version so canonical URLs stay stable.
 	Version  string
 	Archived bool
+	Header   specHeader
 }
 
 // fetchingData drives the "download in progress" page shown while an archived
@@ -71,6 +87,7 @@ type fetchingData struct {
 
 type versionsData struct {
 	SpecID   string
+	Header   specHeader
 	Versions []tools.VersionInfo
 	// ArchiveErr warns that the archive listing failed, so the table may
 	// only cover the cache and the database.
@@ -342,6 +359,14 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, r *http.Request, specID,
 		Next:       next,
 		Version:    urlVersion,
 		Archived:   res.Archived,
+		Header: specHeader{
+			SpecID:         specID,
+			Active:         "document",
+			Version:        urlVersion,
+			DisplayVersion: toc[0].Version,
+			Release:        toc[0].Release,
+			Archived:       res.Archived,
+		},
 	}
 
 	if err := h.tmpls.ExecuteTemplate(w, "layout.html", layoutData{Page: "spec", Data: data, NavSpecID: specID}); err != nil {
@@ -392,6 +417,7 @@ func (h *handler) handleVersions(w http.ResponseWriter, r *http.Request) {
 
 	data := versionsData{
 		SpecID:   specID,
+		Header:   specHeader{SpecID: specID, Active: "versions"},
 		Versions: versions,
 	}
 	if archiveErr != nil {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -28,6 +28,13 @@
             tocSidebar.classList.toggle('open');
         });
 
+        const tocClose = document.getElementById('toc-close');
+        if (tocClose) {
+            tocClose.addEventListener('click', function () {
+                tocSidebar.classList.remove('open');
+            });
+        }
+
         // Close TOC when clicking a link (mobile)
         tocSidebar.querySelectorAll('a').forEach(function (link) {
             link.addEventListener('click', function () {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -343,6 +343,66 @@ mark {
     grid-column: 1 / -1;
 }
 
+/* === Spec header (identity + Document/Versions/Compare tabs) === */
+.spec-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 1.25rem;
+    padding-top: 4px;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.spec-header-id {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding-bottom: 8px;
+}
+
+.spec-header-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+
+.spec-header-version {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.spec-tabs {
+    display: flex;
+    gap: 2px;
+    margin-left: auto;
+}
+
+.spec-tab {
+    padding: 6px 14px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    /* The active underline sits on the header's own border. */
+    margin-bottom: -1px;
+    border-bottom: 2px solid transparent;
+}
+
+.spec-tab:hover {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.spec-tab:focus-visible {
+    outline: 2px solid var(--link);
+    outline-offset: -2px;
+    border-radius: var(--radius);
+}
+
+.spec-tab.active {
+    color: var(--link);
+    border-bottom-color: var(--link);
+    font-weight: 600;
+}
+
 /* === TOC Sidebar === */
 .toc-sidebar {
     background: var(--sidebar-bg);
@@ -357,6 +417,32 @@ mark {
 .toc-header {
     padding: 12px 16px;
     border-bottom: 1px solid var(--border);
+    /* Keep the label and the drawer's close button visible while the
+       section list scrolls. */
+    position: sticky;
+    top: 0;
+    background: var(--sidebar-bg);
+    z-index: 1;
+}
+
+.toc-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+}
+
+.toc-close {
+    display: none;
+    float: right;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 4px 8px;
+    cursor: pointer;
 }
 
 .toc-header h3 {
@@ -748,11 +834,6 @@ mark {
     color: var(--text-secondary);
 }
 
-.toc-links {
-    margin-top: 0.35rem;
-    font-size: 0.85rem;
-}
-
 /* === Compare page === */
 .compare-page {
     max-width: 1000px;
@@ -914,20 +995,27 @@ mark {
         display: block;
     }
 
+    /* Full-screen drawer above the navbar: the mobile navbar wraps to an
+       arbitrary height, so anchoring below it would hide the drawer's
+       header (and the way to close it) behind the navbar. */
     .toc-sidebar {
         display: none;
         position: fixed;
-        top: 48px;
+        top: 0;
         left: 0;
         right: 0;
         bottom: 0;
         max-height: none;
         border-radius: 0;
-        z-index: 50;
+        z-index: 200;
         border: none;
     }
 
     .toc-sidebar.open {
+        display: block;
+    }
+
+    .toc-close {
         display: block;
     }
 
@@ -960,11 +1048,21 @@ mark {
     .section-nav-next {
         text-align: left;
     }
+
+    .spec-tabs {
+        margin-left: 0;
+        width: 100%;
+    }
+
+    .spec-tab {
+        flex: 1;
+        text-align: center;
+    }
 }
 
 /* === Print === */
 @media print {
-    .navbar, .toc-sidebar, .toc-toggle, .theme-toggle, .pagination, .filter-form, .section-nav {
+    .navbar, .toc-sidebar, .toc-toggle, .theme-toggle, .pagination, .filter-form, .section-nav, .spec-tabs {
         display: none;
     }
 

--- a/web/templates/compare.html
+++ b/web/templates/compare.html
@@ -1,10 +1,6 @@
 {{define "compare.html"}}
+{{template "spec-header" .Header}}
 <div class="compare-page">
-    <div class="page-header">
-        <h1>Compare {{.SpecID}}</h1>
-        <p class="subtitle"><a href="{{specURL .SpecID}}/versions">Versions</a> &middot; <a href="{{specURL .SpecID}}">Back to the specification</a></p>
-    </div>
-
     <form class="filter-form" method="get" action="{{specURL .SpecID}}/compare">
         <label for="old">Old version:</label>
         <input type="text" name="old" id="old" value="{{.OldParam}}" placeholder="e.g. 17.9.0">

--- a/web/templates/spec.html
+++ b/web/templates/spec.html
@@ -1,14 +1,12 @@
 {{define "spec.html"}}
+{{template "spec-header" .Header}}
 <div class="spec-layout">
-    <button class="toc-toggle" id="toc-toggle" aria-label="Toggle table of contents">&#9776; TOC</button>
+    <button class="toc-toggle" id="toc-toggle" aria-label="Toggle contents">&#9776; Contents</button>
 
     <aside class="toc-sidebar" id="toc-sidebar">
         <div class="toc-header">
-            <h3>{{.Spec.ID}}</h3>
-            {{if .Spec.Version}}
-            <p class="toc-version">v{{.Spec.Version}}{{with releaseLabel .Spec.Release}} ({{.}}){{end}}{{if .Archived}} <span class="badge badge-cached">archived</span>{{end}}</p>
-            {{end}}
-            <p class="toc-links"><a href="{{specURL .Spec.ID}}/versions">Versions</a> &middot; <a href="{{specURL .Spec.ID}}/compare{{if .Version}}?old={{queryEscape .Version}}{{end}}">Compare</a></p>
+            <button class="toc-close" id="toc-close" aria-label="Close contents">&#10005;</button>
+            <p class="toc-label">Contents</p>
         </div>
         <nav class="toc-nav">
             <ul class="toc-list">

--- a/web/templates/specheader.html
+++ b/web/templates/specheader.html
@@ -1,0 +1,16 @@
+{{define "spec-header"}}
+<header class="spec-header">
+    <div class="spec-header-id">
+        <h1 class="spec-header-title">{{.SpecID}}</h1>
+        {{if .DisplayVersion}}
+        <span class="spec-header-version">v{{.DisplayVersion}}{{with releaseLabel .Release}} ({{.}}){{end}}</span>
+        {{if .Archived}}<span class="badge badge-cached">archived</span>{{end}}
+        {{end}}
+    </div>
+    <nav class="spec-tabs" aria-label="Specification pages">
+        <a class="spec-tab{{if eq .Active "document"}} active{{end}}"{{if eq .Active "document"}} aria-current="page"{{end}} href="{{specURL .SpecID}}{{if .Version}}?version={{queryEscape .Version}}{{end}}">Document</a>
+        <a class="spec-tab{{if eq .Active "versions"}} active{{end}}"{{if eq .Active "versions"}} aria-current="page"{{end}} href="{{specURL .SpecID}}/versions">Versions</a>
+        <a class="spec-tab{{if eq .Active "compare"}} active{{end}}"{{if eq .Active "compare"}} aria-current="page"{{end}} href="{{specURL .SpecID}}/compare{{if .Version}}?old={{queryEscape .Version}}{{end}}">Compare</a>
+    </nav>
+</header>
+{{end}}

--- a/web/templates/versions.html
+++ b/web/templates/versions.html
@@ -1,10 +1,6 @@
 {{define "versions.html"}}
+{{template "spec-header" .Header}}
 <div class="versions-page">
-    <div class="page-header">
-        <h1>{{.SpecID}} — Versions</h1>
-        <p class="subtitle"><a href="{{specURL .SpecID}}">Back to the specification</a></p>
-    </div>
-
     {{if .ArchiveErr}}
     <p class="search-error">{{.ArchiveErr}}</p>
     {{end}}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1586,3 +1586,23 @@ func TestSpecHeaderTabs_ArchivedVersionCarried(t *testing.T) {
 		t.Errorf("expected the Compare tab to preset the version, got:\n%s", body)
 	}
 }
+
+// TestSpecHeaderTabs_CompareKeepsOldVersion keeps the compared old version in
+// the header tabs: Document opens it, Compare keeps it selected.
+func TestSpecHeaderTabs_CompareKeepsOldVersion(t *testing.T) {
+	ts, _ := setupVersionedServer(t, cannedFetcher, nil)
+
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/compare?old=19.5.0")
+	if err != nil {
+		t.Fatalf("GET compare: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if !strings.Contains(body, `?version=19.5.0">Document</a>`) {
+		t.Errorf("expected the Document tab to open the compared version, got:\n%s", body)
+	}
+	if !strings.Contains(body, `/compare?old=19.5.0">Compare</a>`) {
+		t.Errorf("expected the Compare tab to keep the old version, got:\n%s", body)
+	}
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -264,8 +264,8 @@ func TestHandleSpec(t *testing.T) {
 	if !strings.Contains(body, `name="spec_id" value="TS 23.501"`) {
 		t.Errorf("expected navbar search to be pre-filled with the current spec ID, got:\n%s", body)
 	}
-	if !strings.Contains(body, `<p class="toc-version">v18.6.0 (Rel-18)</p>`) {
-		t.Errorf("expected the TOC header to name the spec version, got:\n%s", body)
+	if !strings.Contains(body, `<span class="spec-header-version">v18.6.0 (Rel-18)</span>`) {
+		t.Errorf("expected the spec header to name the spec version, got:\n%s", body)
 	}
 }
 
@@ -1523,5 +1523,66 @@ func TestHandleCompare_UnknownNewVersion(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestSpecHeaderTabs verifies the Document / Versions / Compare tabs are on
+// every spec-scoped page with the current page marked, and that only the
+// document page carries the contents drawer.
+func TestSpecHeaderTabs(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	pages := []struct {
+		path       string
+		hasDrawer  bool
+		activeName string
+	}{
+		{"/specs/TS 23.501/sections/5.1", true, ">Document</a>"},
+		{"/specs/TS 23.501/versions", false, ">Versions</a>"},
+		{"/specs/TS 23.501/compare", false, ">Compare</a>"},
+	}
+	for _, p := range pages {
+		resp, err := http.Get(ts.URL + p.path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p.path, err)
+		}
+		body := readBody(t, resp)
+		resp.Body.Close()
+
+		if !strings.Contains(body, `class="spec-tabs"`) {
+			t.Errorf("%s: expected the spec tabs, got:\n%s", p.path, body)
+		}
+		if !strings.Contains(body, `aria-current="page"`+" "+p.activeName) &&
+			!strings.Contains(body, `aria-current="page" href`) {
+			t.Errorf("%s: expected an active tab, got:\n%s", p.path, body)
+		}
+		for _, item := range []string{">Document</a>", ">Versions</a>", ">Compare</a>"} {
+			if !strings.Contains(body, item) {
+				t.Errorf("%s: expected tab %s, got:\n%s", p.path, item, body)
+			}
+		}
+		if got := strings.Contains(body, `id="toc-close"`); got != p.hasDrawer {
+			t.Errorf("%s: drawer close button present = %v, want %v", p.path, got, p.hasDrawer)
+		}
+	}
+}
+
+// TestSpecHeaderTabs_ArchivedVersionCarried keeps the tabs on the archived
+// version: Document and Compare carry the version being browsed.
+func TestSpecHeaderTabs_ArchivedVersionCarried(t *testing.T) {
+	ts, _ := setupVersionedServer(t, cannedFetcher, nil)
+
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/sections/5.1?version=19.5.0")
+	if err != nil {
+		t.Fatalf("GET archived section: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	if !strings.Contains(body, `?version=19.5.0">Document</a>`) {
+		t.Errorf("expected the Document tab to carry the version, got:\n%s", body)
+	}
+	if !strings.Contains(body, `/compare?old=19.5.0">Compare</a>`) {
+		t.Errorf("expected the Compare tab to preset the version, got:\n%s", body)
 	}
 }


### PR DESCRIPTION
## Summary

Restructures spec-scoped navigation. The Versions/Compare links used to live inside the TOC sidebar, which on mobile was hidden behind the navbar bug below — and mixed page navigation into a contents list.

### Spec header with tabs
- New shared partial (`templates/specheader.html`): spec identity (`TS 23.501 v20.2.0 (Rel-20)`, `archived` badge when browsing a past version) plus **Document / Versions / Compare** tabs (`<nav>` + `aria-current="page"`, underline active style)
- Rendered on all three spec-scoped pages; tabs carry `?version=` / `?old=` when browsing an archived version
- On mobile the tabs are full-width and always visible — no drawer needed to switch pages

### Sidebar becomes a pure contents list
- Spec name/version/menu removed from the sidebar; it is now a "CONTENTS" label + section list only, toggled by a `☰ Contents` button
- Fixes the mobile drawer: it was anchored `top: 48px` below a navbar that wraps to ~148px on small screens, hiding the drawer header (and any way to close it). The drawer is now full-screen above the navbar with a close button, and its header is sticky while the list scrolls

### Versions / Compare pages
- Simplified to a single column under the shared header; duplicate page titles and "Back to ..." links removed

## Testing
- New tests: `TestSpecHeaderTabs` (tabs + active state on all three pages; contents drawer only on the document page), `TestSpecHeaderTabs_ArchivedVersionCarried`
- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test -race ./...` all green
- Verified visually in headless Chromium at 390px and 1280px: header tabs, full-screen contents drawer with sticky header and close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019zxBgKMoGDmQazPevG8BNh)_