### PR TITLE
fix: unify image notation and normalize refs in compare_versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,8 @@ filename differs between paths — `image3.png` after `--convert-image`
 `image3.emf` otherwise; `GetImage` resolves either spelling (the version cache
 falls back to a basename match). `compare_versions` and the web compare page
 normalize references (`structdiff.NormalizeImageRefs`) before diffing so the
-extension and alt spelling never count as a content change. The web viewer
+conversion-pair extensions (`.emf`/`.wmf`/`.pcz`/`.png`) and alt spelling
+never count as a content change; other extension changes stay visible. The web viewer
 serves an SVG placeholder for formats a browser cannot render (EMF/WMF).
 
 The version cache stamps `PRAGMA user_version`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,24 @@ version alongside its sections (image bytes count against the same LRU limit,
 and a version's text and images are evicted as one unit). OpenAPI YAML and
 cross-references remain prebuilt-only.
 
+### Image notation
+
+Every conversion path emits the same image reference regardless of format:
+`![Figure](image://NAME?w=&h=)` in body text and
+`<img src="image://NAME?w=&h=" alt="Figure" ...>` in table cells. Only the
+filename differs between paths — `image3.png` after `--convert-image`
+(`UpdateImagePlaceholders` renames references post-conversion), the original
+`image3.emf` otherwise; `GetImage` resolves either spelling (the version cache
+falls back to a basename match). `compare_versions` and the web compare page
+normalize references (`structdiff.NormalizeImageRefs`) before diffing so the
+extension and alt spelling never count as a content change. The web viewer
+serves an SVG placeholder for formats a browser cannot render (EMF/WMF).
+
+The version cache stamps `PRAGMA user_version`
+(`versionstore.cacheSchemaVersion`); opening a cache from another generation
+wipes it. Databases built before the unified notation are incompatible with
+the compare normalization — rebuild them (`make build-db`).
+
 ### MCP Tools
 
 Eleven tools are exposed via MCP:

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -89,19 +89,15 @@ func ConvertResultImages(ctx context.Context, result *ParseResult) int {
 	return n
 }
 
-// placeholderRE matches non-LLM-readable image placeholders in section content,
-// with optional dimension suffix like ", 576x432".
-var placeholderRE = regexp.MustCompile(`\[Figure:\s*(.+?)\s*\(([^,]+),\s*use get_image to retrieve(?:,\s*(\d+)x(\d+))?\)\]`)
-
-// imageRefRE matches the filename in an image:// reference (e.g. inside an HTML
-// <img src="image://image1.wmf?w=..&h=.."> tag or a Markdown image link),
-// capturing only the filename portion up to any query string or delimiter.
+// imageRefRE matches the filename in an image:// reference (a Markdown image
+// link or an HTML <img src="image://image1.wmf?w=..&h=.."> tag emitted for
+// table images), capturing only the filename portion up to any query string or
+// delimiter.
 var imageRefRE = regexp.MustCompile(`image://([^?"')\s]+)`)
 
-// UpdateImagePlaceholders replaces non-LLM-readable image placeholders in
-// section content with LLM-readable image links after image conversion, and
-// rewrites image:// references (e.g. HTML <img> tags emitted for table images)
-// to point at the converted PNG filenames.
+// UpdateImagePlaceholders rewrites image:// references in section content to
+// point at the converted PNG filenames after EMF/WMF conversion. Only the
+// filename is replaced; alt text and any ?w=&h= suffix are kept.
 func UpdateImagePlaceholders(result *ParseResult) {
 	converted := make(map[string]string) // base name (without ext) → new PNG name
 	for _, img := range result.Images {
@@ -117,31 +113,7 @@ func UpdateImagePlaceholders(result *ParseResult) {
 
 	for _, section := range result.Sections {
 		for i, content := range section.Content {
-			content = placeholderRE.ReplaceAllStringFunc(content, func(match string) string {
-				sub := placeholderRE.FindStringSubmatch(match)
-				if len(sub) < 3 {
-					return match
-				}
-				alt, filename := sub[1], sub[2]
-				base := strings.TrimSuffix(filename, filepath.Ext(filename))
-				newName, ok := converted[base]
-				if !ok {
-					return match
-				}
-				if alt == filename {
-					alt = "Figure"
-				}
-				dimSuffix := ""
-				if len(sub) >= 5 && sub[3] != "" && sub[4] != "" {
-					dimSuffix = fmt.Sprintf("?w=%s&h=%s", sub[3], sub[4])
-				}
-				return fmt.Sprintf("![%s](image://%s%s)", alt, newName, dimSuffix)
-			})
-
-			// Rewrite remaining image:// references (e.g. HTML <img> tags in
-			// table content) whose original filename was renamed during PNG
-			// conversion. Only the filename is replaced; any ?w=&h= suffix is kept.
-			content = imageRefRE.ReplaceAllStringFunc(content, func(match string) string {
+			section.Content[i] = imageRefRE.ReplaceAllStringFunc(content, func(match string) string {
 				sub := imageRefRE.FindStringSubmatch(match)
 				if len(sub) < 2 {
 					return match
@@ -154,8 +126,6 @@ func UpdateImagePlaceholders(result *ParseResult) {
 				}
 				return "image://" + newName
 			})
-
-			section.Content[i] = content
 		}
 	}
 }

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -69,9 +69,9 @@ func TestUpdateImagePlaceholders(t *testing.T) {
 				Level:  3,
 				Content: []string{
 					"Some text before",
-					"[Figure: Network Topology (image1.emf, use get_image to retrieve)]",
-					"[Figure: image2.wmf (image2.wmf, use get_image to retrieve)]",
-					"[Figure: image3.emf (image3.emf, use get_image to retrieve)]",
+					"![Network Topology](image://image1.emf)",
+					"![Figure](image://image2.wmf)",
+					"![Figure](image://image3.emf)",
 				},
 			},
 		},
@@ -95,8 +95,8 @@ func TestUpdateImagePlaceholders(t *testing.T) {
 	if content[2] != "![Figure](image://image2.png)" {
 		t.Errorf("expected converted placeholder without alt text, got %q", content[2])
 	}
-	if !strings.Contains(content[3], "use get_image to retrieve") {
-		t.Errorf("unconverted image should keep placeholder, got %q", content[3])
+	if content[3] != "![Figure](image://image3.emf)" {
+		t.Errorf("unconverted image should keep its original filename, got %q", content[3])
 	}
 }
 
@@ -108,8 +108,8 @@ func TestUpdateImagePlaceholders_WithDimensions(t *testing.T) {
 				Title:  "Test",
 				Level:  3,
 				Content: []string{
-					"[Figure: Network (image1.emf, use get_image to retrieve, 600x400)]",
-					"[Figure: image2.wmf (image2.wmf, use get_image to retrieve)]",
+					"![Network](image://image1.emf?w=600&h=400)",
+					"![Figure](image://image2.wmf)",
 				},
 			},
 		},
@@ -336,7 +336,7 @@ func TestUpdateImagePlaceholders_TableImageRef(t *testing.T) {
 				Number: "6.4.1.3.1.1",
 				Content: []string{
 					`<table><tr><td><img src="image://image1.wmf?w=100&h=50" alt="Figure"></td></tr></table>`,
-					"[Figure: Figure (image2.emf, use get_image to retrieve)]",
+					"![Figure](image://image2.emf)",
 					`<table><tr><td><img src="image://image3.png" alt="Figure"></td></tr></table>`,
 				},
 			},

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -195,21 +195,14 @@ func imagePlaceholder(relMap map[string]string, images map[string]*EmbeddedImage
 	if ref.WidthPx > 0 && ref.HeightPx > 0 {
 		dimSuffix = fmt.Sprintf("?w=%d&h=%d", ref.WidthPx, ref.HeightPx)
 	}
-	if img.LLMReadable {
-		alt := "Figure"
-		if ref.AltText != "" {
-			alt = ref.AltText
-		}
-		return fmt.Sprintf("![%s](image://%s%s)", alt, img.Name, dimSuffix)
-	}
-	alt := img.Name
+	// Every format gets the same markdown link, EMF/WMF included, so the two
+	// conversion paths (prebuilt DB and on-demand archive fetch) emit
+	// byte-identical section text and compare_versions sees no notation noise.
+	alt := "Figure"
 	if ref.AltText != "" {
 		alt = ref.AltText
 	}
-	if dimSuffix != "" {
-		return fmt.Sprintf("[Figure: %s (%s, use get_image to retrieve, %dx%d)]", alt, img.Name, ref.WidthPx, ref.HeightPx)
-	}
-	return fmt.Sprintf("[Figure: %s (%s, use get_image to retrieve)]", alt, img.Name)
+	return fmt.Sprintf("![%s](image://%s%s)", alt, img.Name, dimSuffix)
 }
 
 // diagramPlaceholder returns a markdown placeholder for a grouped vector

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -979,3 +979,38 @@ func TestParseSections_ASN1UnterminatedFlushedByTable(t *testing.T) {
 		t.Errorf("expected fence before table content, got %v", sections[0].Content)
 	}
 }
+
+func TestImagePlaceholder_UnifiedNotation(t *testing.T) {
+	relMap := map[string]string{"rId1": "media/image1.emf"}
+	images := map[string]*EmbeddedImage{
+		"media/image1.emf": {Name: "image1.emf", MIMEType: "image/x-emf", LLMReadable: false},
+	}
+	tests := []struct {
+		name string
+		ref  imageRef
+		want string
+	}{
+		{
+			name: "non-readable with dimensions",
+			ref:  imageRef{RID: "rId1", WidthPx: 612, HeightPx: 208},
+			want: "![Figure](image://image1.emf?w=612&h=208)",
+		},
+		{
+			name: "non-readable without dimensions",
+			ref:  imageRef{RID: "rId1"},
+			want: "![Figure](image://image1.emf)",
+		},
+		{
+			name: "alt text kept",
+			ref:  imageRef{RID: "rId1", AltText: "Network Topology", WidthPx: 10, HeightPx: 20},
+			want: "![Network Topology](image://image1.emf?w=10&h=20)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imagePlaceholder(relMap, images, tt.ref); got != tt.want {
+				t.Errorf("imagePlaceholder() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -303,11 +303,9 @@ func imageHTML(ctx imageContext, ref imageRef) string {
 		dimSuffix = fmt.Sprintf("?w=%d&h=%d", ref.WidthPx, ref.HeightPx)
 		dimAttrs = fmt.Sprintf(` width="%d" height="%d"`, ref.WidthPx, ref.HeightPx)
 	}
-	alt := img.Name
+	alt := "Figure"
 	if ref.AltText != "" {
 		alt = ref.AltText
-	} else if img.LLMReadable {
-		alt = "Figure"
 	}
 	return fmt.Sprintf(`<img src="image://%s%s" alt="%s"%s>`,
 		img.Name, dimSuffix, htmlpkg.EscapeString(alt), dimAttrs)

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -332,3 +332,37 @@ func TestTableToHTML_ImageInCell(t *testing.T) {
 		t.Errorf("expected <img> tag with image:// src in cell, got: %s", html)
 	}
 }
+
+// TestTableToHTML_NonReadableImageInCell verifies that a non-LLM-readable
+// image (EMF) in a cell gets the same alt="Figure" default as readable ones,
+// so both conversion paths emit identical table HTML.
+func TestTableToHTML_NonReadableImageInCell(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+		xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+		xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+		xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+		<w:tr><w:tc>
+			<w:p><w:r>
+				<w:drawing>
+					<wp:inline>
+						<wp:extent cx="952500" cy="952500"/>
+						<a:graphic><a:graphicData>
+							<a:blip r:embed="rId7"/>
+						</a:graphicData></a:graphic>
+					</wp:inline>
+				</w:drawing>
+			</w:r></w:p>
+		</w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	ctx := imageContext{
+		relMap: map[string]string{"rId7": "media/image1.emf"},
+		images: map[string]*EmbeddedImage{
+			"media/image1.emf": {Name: "image1.emf", LLMReadable: false},
+		},
+	}
+	html := tableToHTML(info, ctx)
+	if !strings.Contains(html, `<img src="image://image1.emf?w=100&h=100" alt="Figure" width="100" height="100">`) {
+		t.Errorf("expected <img> tag with alt=Figure for EMF cell image, got: %s", html)
+	}
+}

--- a/internal/structdiff/imageref.go
+++ b/internal/structdiff/imageref.go
@@ -1,0 +1,56 @@
+package structdiff
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// The prebuilt database stores converted image references (image3.png) while
+// an on-demand archive fetch keeps the original filenames (image3.emf), so
+// the same section text differs only in image reference spelling. These
+// regexes fold both the Markdown link form and the HTML <img> form (table
+// cells) to a canonical shape for diff comparison.
+var (
+	mdImageRE    = regexp.MustCompile(`!\[([^\]]*)\]\(image://([^?)\s]+)(\?[^)]*)?\)`)
+	htmlImgTagRE = regexp.MustCompile(`<img\s[^>]*?\bsrc="image://([^"?]+)(\?[^"]*)?"[^>]*?>`)
+	htmlImgAltRE = regexp.MustCompile(`\balt="([^"]*)"`)
+)
+
+// NormalizeImageRefs returns line with every image reference folded to a
+// canonical form: the filename loses its extension (a converted PNG and its
+// EMF/WMF original compare equal) and a redundant alt text (empty or just the
+// filename) becomes "Figure". Dimensions are kept — a resized figure is a
+// real change. The result is a comparison key for diffing only, never for
+// display or storage.
+func NormalizeImageRefs(line string) string {
+	if !strings.Contains(line, "image://") {
+		return line
+	}
+	line = mdImageRE.ReplaceAllStringFunc(line, func(m string) string {
+		sub := mdImageRE.FindStringSubmatch(m)
+		base := strings.TrimSuffix(sub[2], path.Ext(sub[2]))
+		return "![" + foldAlt(sub[1], base) + "](image://" + base + sub[3] + ")"
+	})
+	line = htmlImgTagRE.ReplaceAllStringFunc(line, func(m string) string {
+		sub := htmlImgTagRE.FindStringSubmatch(m)
+		base := strings.TrimSuffix(sub[1], path.Ext(sub[1]))
+		alt := ""
+		if a := htmlImgAltRE.FindStringSubmatch(m); a != nil {
+			alt = a[1]
+		}
+		// Width/height attributes mirror the ?w=&h= query, so the canonical
+		// tag keeps only the query and the folded alt.
+		return `<img src="image://` + base + sub[2] + `" alt="` + foldAlt(alt, base) + `">`
+	})
+	return line
+}
+
+// foldAlt maps an alt text that adds no information beyond the filename to
+// the "Figure" default the converter uses.
+func foldAlt(alt, base string) string {
+	if alt == "" || strings.TrimSuffix(alt, path.Ext(alt)) == base {
+		return "Figure"
+	}
+	return alt
+}

--- a/internal/structdiff/imageref.go
+++ b/internal/structdiff/imageref.go
@@ -18,38 +18,50 @@ var (
 )
 
 // NormalizeImageRefs returns line with every image reference folded to a
-// canonical form: the filename loses its extension (a converted PNG and its
-// EMF/WMF original compare equal) and a redundant alt text (empty or just the
-// filename) becomes "Figure". Dimensions are kept — a resized figure is a
-// real change. The result is a comparison key for diffing only, never for
-// display or storage.
+// canonical form: a conversion-pair extension (EMF/WMF/PCZ source or PNG
+// target) is dropped so a converted figure and its original compare equal,
+// and a redundant alt text (empty or just the filename) becomes "Figure".
+// Other extensions are kept — image3.jpg vs image3.png is a real reference
+// change, not conversion spelling. Dimensions are kept too: a resized figure
+// is a real change. The result is a comparison key for diffing only, never
+// for display or storage.
 func NormalizeImageRefs(line string) string {
 	if !strings.Contains(line, "image://") {
 		return line
 	}
 	line = mdImageRE.ReplaceAllStringFunc(line, func(m string) string {
 		sub := mdImageRE.FindStringSubmatch(m)
-		base := strings.TrimSuffix(sub[2], path.Ext(sub[2]))
-		return "![" + foldAlt(sub[1], base) + "](image://" + base + sub[3] + ")"
+		return "![" + foldAlt(sub[1], sub[2]) + "](image://" + foldName(sub[2]) + sub[3] + ")"
 	})
 	line = htmlImgTagRE.ReplaceAllStringFunc(line, func(m string) string {
 		sub := htmlImgTagRE.FindStringSubmatch(m)
-		base := strings.TrimSuffix(sub[1], path.Ext(sub[1]))
 		alt := ""
 		if a := htmlImgAltRE.FindStringSubmatch(m); a != nil {
 			alt = a[1]
 		}
 		// Width/height attributes mirror the ?w=&h= query, so the canonical
 		// tag keeps only the query and the folded alt.
-		return `<img src="image://` + base + sub[2] + `" alt="` + foldAlt(alt, base) + `">`
+		return `<img src="image://` + foldName(sub[1]) + sub[2] + `" alt="` + foldAlt(alt, sub[1]) + `">`
 	})
 	return line
 }
 
+// foldName drops the filename extension when it belongs to the EMF/WMF/PCZ →
+// PNG conversion the pipeline performs; any other extension is meaningful and
+// kept.
+func foldName(name string) string {
+	switch strings.ToLower(path.Ext(name)) {
+	case ".emf", ".wmf", ".pcz", ".png":
+		return strings.TrimSuffix(name, path.Ext(name))
+	}
+	return name
+}
+
 // foldAlt maps an alt text that adds no information beyond the filename to
 // the "Figure" default the converter uses.
-func foldAlt(alt, base string) string {
-	if alt == "" || strings.TrimSuffix(alt, path.Ext(alt)) == base {
+func foldAlt(alt, name string) string {
+	if alt == "" || alt == name ||
+		strings.TrimSuffix(alt, path.Ext(alt)) == strings.TrimSuffix(name, path.Ext(name)) {
 		return "Figure"
 	}
 	return alt

--- a/internal/structdiff/imageref_test.go
+++ b/internal/structdiff/imageref_test.go
@@ -1,0 +1,87 @@
+package structdiff
+
+import "testing"
+
+func TestNormalizeImageRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		same bool
+	}{
+		{
+			name: "extension difference folds",
+			a:    "![Figure](image://image3.png?w=612&h=208)",
+			b:    "![Figure](image://image3.emf?w=612&h=208)",
+			same: true,
+		},
+		{
+			name: "filename alt folds to Figure",
+			a:    "![image3.emf](image://image3.emf?w=612&h=208)",
+			b:    "![Figure](image://image3.png?w=612&h=208)",
+			same: true,
+		},
+		{
+			name: "table cell img extension and alt fold",
+			a:    `<td><img src="image://image1.emf?w=100&h=50" alt="image1.emf" width="100" height="50"></td>`,
+			b:    `<td><img src="image://image1.png?w=100&h=50" alt="Figure" width="100" height="50"></td>`,
+			same: true,
+		},
+		{
+			name: "different dimensions stay different",
+			a:    "![Figure](image://image3.png?w=612&h=208)",
+			b:    "![Figure](image://image3.emf?w=600&h=200)",
+			same: false,
+		},
+		{
+			name: "different basenames stay different",
+			a:    "![Figure](image://image3.png)",
+			b:    "![Figure](image://image4.png)",
+			same: false,
+		},
+		{
+			name: "real alt text change stays different",
+			a:    "![Network Topology](image://image3.png)",
+			b:    "![Attach Procedure](image://image3.png)",
+			same: false,
+		},
+		{
+			name: "real alt text survives extension fold",
+			a:    "![Network Topology](image://image3.emf?w=10&h=20)",
+			b:    "![Network Topology](image://image3.png?w=10&h=20)",
+			same: true,
+		},
+		{
+			name: "multiple refs on one line",
+			a:    "see ![Figure](image://image1.emf) and ![Figure](image://image2.emf)",
+			b:    "see ![Figure](image://image1.png) and ![Figure](image://image2.png)",
+			same: true,
+		},
+		{
+			name: "surrounding text still compared",
+			a:    "old text ![Figure](image://image1.emf)",
+			b:    "new text ![Figure](image://image1.png)",
+			same: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ka, kb := NormalizeImageRefs(tt.a), NormalizeImageRefs(tt.b)
+			if (ka == kb) != tt.same {
+				t.Errorf("NormalizeImageRefs equality = %v, want %v\n key a: %q\n key b: %q", ka == kb, tt.same, ka, kb)
+			}
+		})
+	}
+}
+
+func TestNormalizeImageRefs_NoImageUnchanged(t *testing.T) {
+	for _, line := range []string{
+		"",
+		"plain text with no images",
+		"a [Figure: diagram not extracted — see the original document] placeholder",
+		"markdown link [text](https://example.com)",
+	} {
+		if got := NormalizeImageRefs(line); got != line {
+			t.Errorf("line without image refs changed: %q -> %q", line, got)
+		}
+	}
+}

--- a/internal/structdiff/imageref_test.go
+++ b/internal/structdiff/imageref_test.go
@@ -39,6 +39,24 @@ func TestNormalizeImageRefs(t *testing.T) {
 			same: false,
 		},
 		{
+			name: "non-conversion extension change stays different",
+			a:    "![Figure](image://image3.jpg)",
+			b:    "![Figure](image://image3.png)",
+			same: false,
+		},
+		{
+			name: "same non-conversion extension compares equal",
+			a:    "![image3.jpg](image://image3.jpg?w=10&h=20)",
+			b:    "![Figure](image://image3.jpg?w=10&h=20)",
+			same: true,
+		},
+		{
+			name: "pcz source folds with png target",
+			a:    "![Figure](image://image7.pcz)",
+			b:    "![Figure](image://image7.png)",
+			same: true,
+		},
+		{
 			name: "real alt text change stays different",
 			a:    "![Network Topology](image://image3.png)",
 			b:    "![Attach Procedure](image://image3.png)",

--- a/internal/structdiff/structdiff.go
+++ b/internal/structdiff/structdiff.go
@@ -64,7 +64,7 @@ func Diff(oldSecs, newSecs []db.Section) Result {
 		// The leading markdown heading restates number and title, so it is
 		// stripped before comparing: a pure retitle must not also count as a
 		// content change.
-		bodyChanged := stripHeadingLine(o.Content) != stripHeadingLine(n.Content)
+		bodyChanged := bodyKey(o.Content) != bodyKey(n.Content)
 		if o.Title != n.Title {
 			d.Retitled = append(d.Retitled, Retitle{n.Number, o.Title, n.Title})
 		}
@@ -134,7 +134,7 @@ func (d *Result) promoteRenumbered() {
 			moved[n.Number] = true
 			// A renumbered section may have been edited too; that must not
 			// hide behind the move.
-			if stripHeadingLine(o.Content) != stripHeadingLine(n.Content) {
+			if bodyKey(o.Content) != bodyKey(n.Content) {
 				d.ContentChanged = append(d.ContentChanged, ContentChange{
 					Number:    n.Number,
 					OldNumber: o.Number,
@@ -156,6 +156,21 @@ func (d *Result) promoteRenumbered() {
 		}
 	}
 	d.Added = added
+}
+
+// bodyKey is the comparison key of a section body: the heading stripped, and
+// image references normalized so the two conversion paths' spellings of the
+// same figure do not count as a content change.
+func bodyKey(content string) string {
+	content = stripHeadingLine(content)
+	if !strings.Contains(content, "image://") {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	for i, l := range lines {
+		lines[i] = NormalizeImageRefs(l)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // stripHeadingLine removes the leading markdown heading of a section body.

--- a/internal/structdiff/structdiff_test.go
+++ b/internal/structdiff/structdiff_test.go
@@ -119,3 +119,28 @@ func TestSectionLines(t *testing.T) {
 		}
 	}
 }
+
+// TestDiffImageNotationIsNotAContentChange checks that sections whose bodies
+// differ only in image reference spelling (converted PNG vs original EMF,
+// filename alt vs "Figure") classify as unchanged, while a real edit next to
+// such a difference still counts.
+func TestDiffImageNotationIsNotAContentChange(t *testing.T) {
+	oldSecs := []db.Section{
+		{Number: "1", Title: "Arch", Content: "# 1 Arch\nIntro.\n![Figure](image://image3.emf?w=612&h=208)\nOutro."},
+		{Number: "2", Title: "Cells", Content: "# 2 Cells\n<table><tr><td><img src=\"image://image1.emf?w=100&h=50\" alt=\"image1.emf\" width=\"100\" height=\"50\"></td></tr></table>"},
+		{Number: "3", Title: "Edited", Content: "# 3 Edited\nOld sentence.\n![Figure](image://image5.emf?w=10&h=20)"},
+	}
+	newSecs := []db.Section{
+		{Number: "1", Title: "Arch", Content: "# 1 Arch\nIntro.\n![Figure](image://image3.png?w=612&h=208)\nOutro."},
+		{Number: "2", Title: "Cells", Content: "# 2 Cells\n<table><tr><td><img src=\"image://image1.png?w=100&h=50\" alt=\"Figure\" width=\"100\" height=\"50\"></td></tr></table>"},
+		{Number: "3", Title: "Edited", Content: "# 3 Edited\nNew sentence.\n![Figure](image://image5.png?w=10&h=20)"},
+	}
+
+	d := Diff(oldSecs, newSecs)
+	if d.Unchanged != 2 {
+		t.Errorf("Unchanged = %d, want 2 (image notation only)", d.Unchanged)
+	}
+	if len(d.ContentChanged) != 1 || d.ContentChanged[0].Number != "3" {
+		t.Errorf("ContentChanged = %+v, want section 3 alone", d.ContentChanged)
+	}
+}

--- a/internal/textdiff/textdiff.go
+++ b/internal/textdiff/textdiff.go
@@ -31,11 +31,23 @@ const dCap = 1024
 // the edit distance exceeded the search limit and the script is a full
 // replacement rather than a minimal diff.
 func Diff(a, b []string) (edits []Edit, capped bool) {
+	return DiffKeyed(a, b, nil)
+}
+
+// DiffKeyed is Diff comparing lines by key(line) while reporting original
+// lines, so cosmetic per-line differences (e.g. image reference notation) can
+// be ignored without altering what the caller displays. A nil key compares
+// lines verbatim. Equal edits carry the b-side original: when two lines match
+// only by key, the newer spelling is the one worth showing.
+func DiffKeyed(a, b []string, key func(string) string) (edits []Edit, capped bool) {
 	// Interned lines let the Myers loop compare ints instead of strings.
 	ids := make(map[string]int, len(a)+len(b))
 	intern := func(lines []string) []int {
 		out := make([]int, len(lines))
 		for i, l := range lines {
+			if key != nil {
+				l = key(l)
+			}
 			id, ok := ids[l]
 			if !ok {
 				id = len(ids)
@@ -60,7 +72,7 @@ func Diff(a, b []string) (edits []Edit, capped bool) {
 
 	edits = make([]Edit, 0, len(a)+len(b))
 	for i := 0; i < prefix; i++ {
-		edits = append(edits, Edit{Equal, a[i]})
+		edits = append(edits, Edit{Equal, b[i]})
 	}
 
 	ma, mb := ia[prefix:len(ia)-suffix], ib[prefix:len(ib)-suffix]
@@ -78,7 +90,7 @@ func Diff(a, b []string) (edits []Edit, capped bool) {
 		for _, op := range ops {
 			switch op {
 			case Equal:
-				edits = append(edits, Edit{Equal, a[ai]})
+				edits = append(edits, Edit{Equal, b[bi]})
 				ai++
 				bi++
 			case Delete:
@@ -91,8 +103,8 @@ func Diff(a, b []string) (edits []Edit, capped bool) {
 		}
 	}
 
-	for i := len(a) - suffix; i < len(a); i++ {
-		edits = append(edits, Edit{Equal, a[i]})
+	for i := len(b) - suffix; i < len(b); i++ {
+		edits = append(edits, Edit{Equal, b[i]})
 	}
 	return edits, capped
 }
@@ -193,10 +205,16 @@ func Stats(edits []Edit) (del, ins int) {
 // Unified renders the diff between a and b as unified-diff hunks with the
 // given number of context lines. Identical inputs render as an empty string.
 func Unified(a, b []string, context int) string {
+	return UnifiedKeyed(a, b, context, nil)
+}
+
+// UnifiedKeyed is Unified comparing lines by key(line); see DiffKeyed. Inputs
+// whose lines all match by key render as an empty string.
+func UnifiedKeyed(a, b []string, context int, key func(string) string) string {
 	if context < 0 {
 		context = 0
 	}
-	edits, capped := Diff(a, b)
+	edits, capped := DiffKeyed(a, b, key)
 
 	// keep marks the lines that appear in some hunk: every change plus its
 	// surrounding context. Adjacent hunks closer than a context apart merge by

--- a/internal/textdiff/textdiff_test.go
+++ b/internal/textdiff/textdiff_test.go
@@ -180,3 +180,47 @@ func TestDiffLargeButLocalChange(t *testing.T) {
 		t.Errorf("Stats = (%d, %d), want (1, 1)", del, ins)
 	}
 }
+
+func TestDiffKeyedNilMatchesDiff(t *testing.T) {
+	a := []string{"one", "two", "three"}
+	b := []string{"one", "2", "three"}
+	got, gotCapped := DiffKeyed(a, b, nil)
+	want, wantCapped := Diff(a, b)
+	if gotCapped != wantCapped || len(got) != len(want) {
+		t.Fatalf("DiffKeyed(nil) = %v/%v, want %v/%v", got, gotCapped, want, wantCapped)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("edit %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestUnifiedKeyedFoldsKeyEqualLines(t *testing.T) {
+	key := func(l string) string { return strings.TrimSuffix(l, ".emf") }
+	a := []string{"text", "figure.emf", "more"}
+	b := []string{"text", "figure", "more"}
+	if got := UnifiedKeyed(a, b, 3, key); got != "" {
+		t.Errorf("key-equal inputs should render empty, got %q", got)
+	}
+}
+
+func TestUnifiedKeyedShowsNewSideContext(t *testing.T) {
+	key := func(l string) string { return strings.TrimSuffix(l, ".emf") }
+	a := []string{"figure.emf", "old line", "tail.emf"}
+	b := []string{"figure", "new line", "tail"}
+	got := UnifiedKeyed(a, b, 1, key)
+	want := "@@ -1,3 +1,3 @@\n figure\n-old line\n+new line\n tail"
+	if got != want {
+		t.Errorf("UnifiedKeyed = %q, want %q", got, want)
+	}
+}
+
+func TestDiffKeyedStats(t *testing.T) {
+	key := func(l string) string { return strings.TrimSuffix(l, ".emf") }
+	edits, _ := DiffKeyed([]string{"same.emf", "gone"}, []string{"same", "here"}, key)
+	del, ins := Stats(edits)
+	if del != 1 || ins != 1 {
+		t.Errorf("Stats = %d/%d, want 1/1", del, ins)
+	}
+}

--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -140,7 +140,7 @@ func compareSection(ctx context.Context, src *Source, input CompareVersionsInput
 	}
 
 	header := compareHeader(input.SpecID, input.SectionNumber, oldLabel, newLabel)
-	diff := textdiff.Unified(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), ctxLines)
+	diff := textdiff.UnifiedKeyed(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), ctxLines, structdiff.NormalizeImageRefs)
 	if diff == "" {
 		msg := fmt.Sprintf("Section %s is identical between %s and %s.", input.SectionNumber, oldLabel, newLabel)
 		return prependLine(header, textResult(msg))

--- a/tools/compare_versions_test.go
+++ b/tools/compare_versions_test.go
@@ -305,3 +305,94 @@ func TestCompareVersionsBothFetchesInProgress(t *testing.T) {
 }
 
 // The structural diff classification itself is tested in internal/structdiff.
+
+// seedImageNotationSections adds a section pair whose bodies differ only in
+// image reference spelling (on-demand EMF vs prebuilt PNG), and a pair with a
+// real edit next to such a difference.
+func seedImageNotationSections(t *testing.T, d *db.DB) {
+	t.Helper()
+	err := d.ExecScript(`
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '17.9.0', '8', 'Figures', 1, NULL, '# 8 Figures
+Intro text.
+![Figure](image://image3.emf?w=612&h=208)
+<table><tr><td><img src="image://image4.emf?w=100&h=50" alt="image4.emf" width="100" height="50"></td></tr></table>'),
+    ('TS 23.501', '18.6.0', '8', 'Figures', 1, NULL, '# 8 Figures
+Intro text.
+![Figure](image://image3.png?w=612&h=208)
+<table><tr><td><img src="image://image4.png?w=100&h=50" alt="Figure" width="100" height="50"></td></tr></table>'),
+    ('TS 23.501', '17.9.0', '9', 'Edited figures', 1, NULL, '# 9 Edited figures
+Old sentence.
+![Figure](image://image5.emf?w=10&h=20)'),
+    ('TS 23.501', '18.6.0', '9', 'Edited figures', 1, NULL, '# 9 Edited figures
+New sentence.
+![Figure](image://image5.png?w=10&h=20)');
+`)
+	if err != nil {
+		t.Fatalf("seed image notation sections: %v", err)
+	}
+}
+
+// TestCompareVersionsImageNotationNoise checks that image reference spelling
+// differences between the prebuilt and on-demand conversion paths do not
+// surface as content changes or diff lines.
+func TestCompareVersionsImageNotationNoise(t *testing.T) {
+	d := setupTestDB(t)
+	seedOldVersion(t, d)
+	seedImageNotationSections(t, d)
+	handler := HandleCompareVersions(NewSource(d))
+
+	// Structural summary: section 8 (notation only) must not be listed as
+	// changed; section 9 (real edit) must be.
+	result, _, err := handler(context.Background(), nil, CompareVersionsInput{
+		SpecID:     "TS 23.501",
+		OldVersion: "17.9.0",
+		NewVersion: "18.6.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := getTextContent(result)
+	if strings.Contains(text, "- 8 Figures") {
+		t.Errorf("image-notation-only section reported as changed:\n%s", text)
+	}
+	if !strings.Contains(text, "- 9 Edited figures") {
+		t.Errorf("really edited section missing from summary:\n%s", text)
+	}
+
+	// Section 8 diff: identical.
+	result, _, err = handler(context.Background(), nil, CompareVersionsInput{
+		SpecID:        "TS 23.501",
+		OldVersion:    "17.9.0",
+		NewVersion:    "18.6.0",
+		SectionNumber: "8",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text := getTextContent(result); !strings.Contains(text, "Section 8 is identical") {
+		t.Errorf("notation-only section not reported identical: %q", text)
+	}
+
+	// Section 9 diff: the edited sentence appears, the image line does not.
+	result, _, err = handler(context.Background(), nil, CompareVersionsInput{
+		SpecID:        "TS 23.501",
+		OldVersion:    "17.9.0",
+		NewVersion:    "18.6.0",
+		SectionNumber: "9",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text = getTextContent(result)
+	if !strings.Contains(text, "-Old sentence.") || !strings.Contains(text, "+New sentence.") {
+		t.Errorf("real edit missing from diff:\n%s", text)
+	}
+	if strings.Contains(text, "-![Figure](image://image5.emf") || strings.Contains(text, "+![Figure](image://image5.png") {
+		t.Errorf("image notation difference leaked into diff:\n%s", text)
+	}
+	// The context line shows the new-side spelling.
+	if !strings.Contains(text, " ![Figure](image://image5.png?w=10&h=20)") {
+		t.Errorf("context line should show the new-side image reference:\n%s", text)
+	}
+}

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -21,7 +21,7 @@ type GetSectionInput struct {
 
 var GetSectionTool = &mcp.Tool{
 	Name:        "get_section",
-	Description: "Get the markdown content of a specific section in a 3GPP specification. This tool is for reading specification document text (architecture, procedures, requirements). For API details such as HTTP request/response bodies, paths, and data models of 5G service-based interfaces (TS 29.xxx series), use get_openapi instead. Specify the section number with the `section_number` parameter (e.g. 5.1.2). Pass `version` to read a past version, which is downloaded and converted on first use; call list_versions first to see which versions exist. Large sections are paginated (default 200 lines). Use offset and max_lines to navigate.",
+	Description: "Get the markdown content of a specific section in a 3GPP specification. This tool is for reading specification document text (architecture, procedures, requirements). For API details such as HTTP request/response bodies, paths, and data models of 5G service-based interfaces (TS 29.xxx series), use get_openapi instead. Specify the section number with the `section_number` parameter (e.g. 5.1.2). Figures appear as `![...](image://NAME)` links; fetch one with get_image and that NAME. Pass `version` to read a past version, which is downloaded and converted on first use; call list_versions first to see which versions exist. Large sections are paginated (default 200 lines). Use offset and max_lines to navigate.",
 }
 
 func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionInput) (*mcp.CallToolResult, any, error) {

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -387,11 +387,14 @@ func TestPutImagesAfterEviction(t *testing.T) {
 	}
 }
 
-// TestOpenMigratesPreImageCache checks that a cache file created before images
-// were cached opens cleanly and gains the images_fetched column.
-func TestOpenMigratesPreImageCache(t *testing.T) {
+// TestOpenWipesOldGenerationCache checks that a cache file from an earlier
+// schema generation (its content stored in an incompatible format, e.g. the
+// pre-unification image notation) is dropped and recreated on open, while a
+// current-generation cache survives a reopen intact.
+func TestOpenWipesOldGenerationCache(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "versions.db")
-	const oldSchema = db.SpecTablesSchema + `
+	// An old-generation file: same tables, but user_version is 0.
+	oldSchema := db.SpecTablesSchema + `
 CREATE TABLE IF NOT EXISTS cache_entries (
     spec_id TEXT NOT NULL,
     version TEXT NOT NULL,
@@ -419,24 +422,25 @@ CREATE TABLE IF NOT EXISTS cache_entries (
 
 	s, err := Open(Options{Path: path, LimitBytes: DefaultLimitBytes})
 	if err != nil {
-		t.Fatalf("Open on a pre-image cache: %v", err)
+		t.Fatalf("Open on an old-generation cache: %v", err)
 	}
-	t.Cleanup(func() { _ = s.Close() })
-
-	if has, err := s.Has("TS 23.501", "18.6.0"); err != nil || !has {
-		t.Errorf("Has = %v, %v; want the migrated entry", has, err)
-	}
-	if fetched, err := s.HasImages("TS 23.501", "18.6.0"); err != nil || fetched {
-		t.Errorf("HasImages = %v, %v; want false for a migrated entry", fetched, err)
+	if has, err := s.Has("TS 23.501", "18.6.0"); err != nil || has {
+		t.Errorf("Has = %v, %v; want the old-generation entry wiped", has, err)
 	}
 
-	// Reopening an already-migrated cache must tolerate the existing column.
+	// Seed an entry through the store, then reopen: a current-generation
+	// cache must keep its content.
+	if err := s.put(db.Spec{ID: "TS 23.501", Version: "18.6.0"}, []db.Section{
+		{Number: "1", Title: "Scope", Content: "# 1 Scope\nBody."},
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
 	if err := s.Close(); err != nil {
-		t.Fatalf("close migrated cache: %v", err)
+		t.Fatalf("close cache: %v", err)
 	}
 	reopened, err := Open(Options{Path: path, LimitBytes: DefaultLimitBytes})
 	if err != nil {
-		t.Fatalf("Open on an already-migrated cache: %v", err)
+		t.Fatalf("Open on a current-generation cache: %v", err)
 	}
 	t.Cleanup(func() { _ = reopened.Close() })
 	if has, err := reopened.Has("TS 23.501", "18.6.0"); err != nil || !has {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -171,28 +171,9 @@ func Open(opts Options) (*Store, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("ping version cache: %w", err)
 	}
-	var generation int
-	if err := conn.QueryRow("PRAGMA user_version").Scan(&generation); err != nil {
+	if err := initSchema(conn); err != nil {
 		_ = conn.Close()
-		return nil, fmt.Errorf("read version cache generation: %w", err)
-	}
-	if generation != cacheSchemaVersion {
-		// A fresh file reads 0 and has nothing to drop; an older-generation
-		// file holds content in an incompatible format and starts over.
-		for _, table := range []string{"cache_entries", "images", "sections", "specs"} {
-			if _, err := conn.Exec("DROP TABLE IF EXISTS " + table); err != nil {
-				_ = conn.Close()
-				return nil, fmt.Errorf("reset version cache: %w", err)
-			}
-		}
-		if _, err := conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", cacheSchemaVersion)); err != nil {
-			_ = conn.Close()
-			return nil, fmt.Errorf("stamp version cache generation: %w", err)
-		}
-	}
-	if _, err := conn.Exec(schema); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("create version cache schema: %w", err)
+		return nil, err
 	}
 
 	return &Store{
@@ -204,6 +185,55 @@ func Open(opts Options) (*Store, error) {
 		imageFetcher: opts.ImageFetcher,
 		inflight:     map[string]*fetch{},
 	}, nil
+}
+
+// initSchema checks the cache generation and creates the schema in a single
+// immediate transaction: several processes may share the file, and taking the
+// write lock before reading user_version means each one sees either the
+// complete old generation (and wipes it) or the complete, already-stamped new
+// one — never the half-dropped state in between.
+func initSchema(conn *sql.DB) error {
+	ctx := context.Background()
+	c, err := conn.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("init version cache: %w", err)
+	}
+	defer c.Close()
+
+	if _, err := c.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("lock version cache: %w", err)
+	}
+	if err := migrateAndCreate(ctx, c); err != nil {
+		_, _ = c.ExecContext(ctx, "ROLLBACK")
+		return err
+	}
+	if _, err := c.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit version cache schema: %w", err)
+	}
+	return nil
+}
+
+func migrateAndCreate(ctx context.Context, c *sql.Conn) error {
+	var generation int
+	if err := c.QueryRowContext(ctx, "PRAGMA user_version").Scan(&generation); err != nil {
+		return fmt.Errorf("read version cache generation: %w", err)
+	}
+	if generation != cacheSchemaVersion {
+		// A fresh file reads 0 and has nothing to drop; an older-generation
+		// file holds content in an incompatible format and starts over.
+		for _, table := range []string{"cache_entries", "images", "sections", "specs"} {
+			if _, err := c.ExecContext(ctx, "DROP TABLE IF EXISTS "+table); err != nil {
+				return fmt.Errorf("reset version cache: %w", err)
+			}
+		}
+		if _, err := c.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", cacheSchemaVersion)); err != nil {
+			return fmt.Errorf("stamp version cache generation: %w", err)
+		}
+	}
+	if _, err := c.ExecContext(ctx, schema); err != nil {
+		return fmt.Errorf("create version cache schema: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) Close() error {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -47,6 +47,13 @@ const maxFetchDuration = 30 * time.Minute
 // DefaultFileName is the cache file created inside the XDG cache directory.
 const DefaultFileName = "versions.db"
 
+// cacheSchemaVersion is stamped into PRAGMA user_version. Opening a cache
+// file with a different generation drops every table and starts over: entries
+// are re-downloadable, so a wipe is cheaper than migrating. Bump it when the
+// stored content becomes incompatible — generation 2 unified the image
+// reference notation (![Figure](image://...) for every format).
+const cacheSchemaVersion = 2
+
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search
 // results. images_fetched distinguishes "images fetched, none found" from
@@ -164,16 +171,28 @@ func Open(opts Options) (*Store, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("ping version cache: %w", err)
 	}
+	var generation int
+	if err := conn.QueryRow("PRAGMA user_version").Scan(&generation); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("read version cache generation: %w", err)
+	}
+	if generation != cacheSchemaVersion {
+		// A fresh file reads 0 and has nothing to drop; an older-generation
+		// file holds content in an incompatible format and starts over.
+		for _, table := range []string{"cache_entries", "images", "sections", "specs"} {
+			if _, err := conn.Exec("DROP TABLE IF EXISTS " + table); err != nil {
+				_ = conn.Close()
+				return nil, fmt.Errorf("reset version cache: %w", err)
+			}
+		}
+		if _, err := conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", cacheSchemaVersion)); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("stamp version cache generation: %w", err)
+		}
+	}
 	if _, err := conn.Exec(schema); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("create version cache schema: %w", err)
-	}
-	// Cache files created before images were cached lack this column; the
-	// CREATE TABLE above is IF NOT EXISTS and does not add it.
-	if _, err := conn.Exec("ALTER TABLE cache_entries ADD COLUMN images_fetched INTEGER NOT NULL DEFAULT 0"); err != nil &&
-		!strings.Contains(err.Error(), "duplicate column name") {
-		_ = conn.Close()
-		return nil, fmt.Errorf("migrate version cache schema: %w", err)
 	}
 
 	return &Store{

--- a/web/compare.go
+++ b/web/compare.go
@@ -151,7 +151,7 @@ func (h *handler) compareSectionPage(w http.ResponseWriter, r *http.Request, dat
 		return
 	}
 
-	diff := textdiff.Unified(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), compareContextLines)
+	diff := textdiff.UnifiedKeyed(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), compareContextLines, structdiff.NormalizeImageRefs)
 	if diff == "" {
 		data.Identical = true
 		h.renderCompare(w, data)

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	htmlpkg "html"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -458,10 +459,28 @@ func (h *handler) handleImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Browsers cannot render EMF/WMF. Serve a placeholder instead of the raw
+	// bytes; no-store because a later fetch with LibreOffice available can
+	// replace the image with a renderable PNG.
+	if !img.LLMReadable {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Header().Set("Cache-Control", "no-store")
+		io.WriteString(w, nonRenderableImageSVG)
+		return
+	}
+
 	w.Header().Set("Content-Type", img.MIMEType)
 	w.Header().Set("Cache-Control", "public, max-age=86400")
 	w.Write(img.Data)
 }
+
+// nonRenderableImageSVG is served in place of image formats a browser cannot
+// display (EMF/WMF); converting them to PNG requires LibreOffice (soffice).
+const nonRenderableImageSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="360" height="80" viewBox="0 0 360 80">` +
+	`<rect width="359" height="79" x="0.5" y="0.5" fill="#f8f9fa" stroke="#adb5bd" stroke-dasharray="4 3"/>` +
+	`<text x="180" y="36" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#495057">Figure not converted (EMF/WMF)</text>` +
+	`<text x="180" y="56" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#868e96">converting requires LibreOffice (soffice)</text>` +
+	`</svg>`
 
 func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -21,7 +21,6 @@ import (
 
 var (
 	imageRE     = regexp.MustCompile(`!\[([^\]]*)\]\(image://([^?)]+)(?:\?w=(\d+)&h=(\d+))?\)`)
-	figureRE    = regexp.MustCompile(`\[Figure:\s*([^(]+?)\s*\(([^,]+),\s*use get_image to retrieve(?:,\s*(\d+)x(\d+))?\)\]`)
 	htmlImageRE = regexp.MustCompile(`(<img\s+[^>]*?\bsrc=")image://([^"?]+)(?:\?[^"]*)?("[^>]*>)`)
 	// mathRE matches LaTeX math emitted by the DOCX converter: display
 	// ($$...$$) is tried before inline ($...$). Inline math may not span lines.
@@ -91,18 +90,6 @@ func renderMarkdown(content, specID, version string, bracketMap map[string]strin
 		sub := htmlImageRE.FindStringSubmatch(match)
 		prefix, name, suffix := sub[1], sub[2], sub[3]
 		return prefix + imageURL(name) + suffix
-	})
-	content = figureRE.ReplaceAllStringFunc(content, func(match string) string {
-		sub := figureRE.FindStringSubmatch(match)
-		alt, name := sub[1], sub[2]
-		src := imageURL(name)
-		escapedAlt := htmlpkg.EscapeString(alt)
-		dimAttrs := ""
-		if len(sub) >= 5 && sub[3] != "" && sub[4] != "" {
-			dimAttrs = fmt.Sprintf(` width="%s" height="%s"`, sub[3], sub[4])
-		}
-		return fmt.Sprintf(`<figure><img src="%s" alt="%s"%s><figcaption>%s</figcaption></figure>`,
-			src, escapedAlt, dimAttrs, escapedAlt)
 	})
 
 	// Protect LaTeX math from goldmark, which would otherwise mangle backslash

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -33,22 +33,16 @@ func TestRenderMarkdown(t *testing.T) {
 			want:    `/specs/TS%2023.501/images/fig1.png`,
 		},
 		{
-			name:    "figure rewrite",
-			content: "[Figure: Network (image1.png, use get_image to retrieve)]",
+			name:    "non-readable image rewrite",
+			content: "![Figure](image://image3.emf?w=612&h=208)",
 			specID:  "TS 23.501",
-			want:    `/specs/TS%2023.501/images/image1.png`,
+			want:    `<img src="/specs/TS%2023.501/images/image3.emf" alt="Figure" width="612" height="208">`,
 		},
 		{
 			name:    "image with dimensions",
 			content: "![diagram](image://fig1.png?w=600&h=400)",
 			specID:  "TS 23.501",
 			want:    `<img src="/specs/TS%2023.501/images/fig1.png" alt="diagram" width="600" height="400">`,
-		},
-		{
-			name:    "figure with dimensions",
-			content: "[Figure: Network (image1.png, use get_image to retrieve, 576x432)]",
-			specID:  "TS 23.501",
-			want:    `width="576" height="432"`,
 		},
 		{
 			name:    "basic markdown",
@@ -674,6 +668,41 @@ func TestHandleImage(t *testing.T) {
 		}
 	})
 
+	t.Run("non-renderable format serves SVG placeholder", func(t *testing.T) {
+		if err := d.UpsertImage(db.Image{
+			SpecID:      "TS 23.501",
+			Version:     "18.6.0",
+			Name:        "fig2.emf",
+			MIMEType:    "image/x-emf",
+			Data:        []byte("emf-bytes"),
+			LLMReadable: false,
+		}); err != nil {
+			t.Fatalf("seed EMF image: %v", err)
+		}
+		resp, err := http.Get(ts.URL + "/specs/TS 23.501/images/fig2.emf")
+		if err != nil {
+			t.Fatalf("GET image error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "image/svg+xml" {
+			t.Errorf("Content-Type = %q, want image/svg+xml", ct)
+		}
+		if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store (a later fetch may convert the image)", cc)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "Figure not converted") {
+			t.Errorf("expected placeholder SVG, got: %s", body)
+		}
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		resp, err := http.Get(ts.URL + "/specs/TS 23.501/images/missing.png")
 		if err != nil {
@@ -739,18 +768,6 @@ func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
 	}
 	if !strings.Contains(got, `&#34;`) && !strings.Contains(got, `&quot;`) {
 		t.Errorf("expected escaped quotation mark in alt text, got:\n%s", got)
-	}
-}
-
-// TestRenderMarkdown_FigureAltEscaped exercises the figure-syntax alt escaping.
-func TestRenderMarkdown_FigureAltEscaped(t *testing.T) {
-	content := `[Figure: <script>x</script> Network (fig.png, use get_image to retrieve, 100x100)]`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
-	if strings.Contains(got, "<script>x</script> Network") {
-		t.Errorf("figure alt text should be escaped, got:\n%s", got)
-	}
-	if !strings.Contains(got, "&lt;script&gt;") {
-		t.Errorf("expected escaped <script> in figure alt, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`compare_versions` reported ~123 of 129 "Content changed" sections in a TS 23.401 Rel-19 → Rel-20 comparison that were pure noise: the prebuilt database spells figures as `[Figure](image://image3.png?w=612&h=208)` while the on-demand archive conversion emitted `[Figure: image3.emf (image3.emf, use get_image to retrieve, 612x208)]`.

## Changes

- **docx**: drop the `LLMReadable` branch — every format now emits `[Figure](image://name?w=&h=)`, and table cell `<img>` alt defaults to `Figure`. `UpdateImagePlaceholders` shrinks to renaming converted filenames only.
- **structdiff/textdiff**: new `NormalizeImageRefs` folds image references (extension, redundant alt) to a canonical key; `DiffKeyed`/`UnifiedKeyed` compare by key while showing original lines. Wired into the `compare_versions` tool and the web compare page — remaining `.emf`/`.png` spelling differences no longer count as content changes, while dimension and real alt changes still do.
- **versionstore**: stamp `PRAGMA user_version`; a cache from another generation is wiped on open, so old-notation `versions.db` entries are refetched.
- **web**: EMF/WMF now reach the browser as `<img>`, so `handleImage` serves an inline SVG placeholder for non-renderable formats (`no-store`); the bracketed-figure rendering path is removed.

## Breaking

Databases built before this change are incompatible with the unified notation — rebuild with `make build-db`.

## Testing

- `go test ./... -short -race`, `go vet`, `gofmt -l`, `golangci-lint run` all clean
- New tests: notation-only sections classify as unchanged and diff as identical; a real edit next to a notation difference still surfaces without image-line noise; old-generation cache wipe; SVG placeholder response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01La2fmZGxpjX2nVXVNTbytP)_