### PR TITLE
fix(web): avoid dark mode flash and add ASN.1 syntax highlighting

### DIFF
--- a/web/asn1lexer.go
+++ b/web/asn1lexer.go
@@ -1,0 +1,83 @@
+package web
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// Chroma ships no ASN.1 lexer, so the ```asn1 fences the DOCX converter emits
+// (from the -- ASN1START / -- ASN1STOP extraction markers) would fall back to
+// unhighlighted text. This registers one under the "asn1" alias; the existing
+// light/dark .chroma stylesheets then cover it like any other language.
+func init() {
+	lexers.Register(chroma.MustNewLexer(
+		&chroma.Config{
+			Name:      "ASN.1",
+			Aliases:   []string{"asn1"},
+			Filenames: []string{"*.asn", "*.asn1"},
+			MimeTypes: []string{"text/x-asn1"},
+		},
+		asn1Rules,
+	))
+}
+
+// asn1Rules covers the X.680 notation as used in 3GPP specifications.
+// Keyword alternations reject a trailing hyphen so hyphenated identifiers
+// (e.g. SEQUENCE-like type names such as SetupRelease-r16) are never split;
+// chroma.Words sorts alternatives longest-first, so multi-word reserved names
+// like NOT-A-NUMBER win over their prefixes.
+func asn1Rules() chroma.Rules {
+	kw := func(words ...string) string {
+		return chroma.Words(`\b`, `\b(?!-)`, words...)
+	}
+	rule := func(pattern string, typ chroma.TokenType, mutator chroma.Mutator) chroma.Rule {
+		return chroma.Rule{Pattern: pattern, Type: typ, Mutator: mutator}
+	}
+	return chroma.Rules{
+		"root": {
+			rule(`\s+`, chroma.TextWhitespace, nil),
+			// A "--" comment ends at the next "--" or at end of line.
+			rule(`--(?:[^\n-]|-(?!-))*(?:--)?`, chroma.CommentSingle, nil),
+			rule(`/\*`, chroma.CommentMultiline, chroma.Push("comment")),
+			rule(`"(?:[^"]|"")*"`, chroma.LiteralString, nil),
+			rule(`'[01 \t]*'B`, chroma.LiteralNumberBin, nil),
+			rule(`'[0-9A-Fa-f \t]*'H`, chroma.LiteralNumberHex, nil),
+			rule(`::=`, chroma.Operator, nil),
+			rule(`\.\.\.?`, chroma.Operator, nil),
+			rule(kw("DEFINITIONS", "BEGIN", "END", "IMPORTS", "EXPORTS", "FROM",
+				"CLASS", "INSTANCE", "SYNTAX"), chroma.KeywordDeclaration, nil),
+			rule(kw("BOOLEAN", "INTEGER", "REAL", "ENUMERATED", "SEQUENCE", "SET",
+				"CHOICE", "BIT", "OCTET", "STRING", "OBJECT", "IDENTIFIER",
+				"CHARACTER", "EXTERNAL", "EMBEDDED", "PDV", "RELATIVE-OID-IRI",
+				"RELATIVE-OID", "OID-IRI", "TIME-OF-DAY", "DATE-TIME", "DATE",
+				"TIME", "DURATION", "BMPString", "GeneralString",
+				"GraphicString", "IA5String", "ISO646String", "NumericString",
+				"PrintableString", "T61String", "TeletexString",
+				"UniversalString", "UTF8String", "VideotexString",
+				"VisibleString", "GeneralizedTime", "UTCTime",
+				"ObjectDescriptor"), chroma.KeywordType, nil),
+			rule(kw("TRUE", "FALSE", "NULL", "MIN", "MAX", "PLUS-INFINITY",
+				"MINUS-INFINITY", "NOT-A-NUMBER"), chroma.KeywordConstant, nil),
+			rule(kw("ABSENT", "ABSTRACT-SYNTAX", "ALL", "APPLICATION", "AUTOMATIC",
+				"BY", "COMPONENTS", "COMPONENT", "CONSTRAINED", "CONTAINING",
+				"DEFAULT", "ENCODED", "EXCEPT", "EXPLICIT", "EXTENSIBILITY",
+				"IMPLICIT", "IMPLIED", "INCLUDES", "INSTRUCTIONS",
+				"INTERSECTION", "OF", "OPTIONAL", "PATTERN", "PRESENT",
+				"PRIVATE", "SETTINGS", "SIZE", "TAGS", "TYPE-IDENTIFIER",
+				"UNION", "UNIQUE", "UNIVERSAL", "WITH"), chroma.Keyword, nil),
+			rule(`&[A-Za-z][A-Za-z0-9-]*`, chroma.NameAttribute, nil),
+			rule(`[A-Z][A-Za-z0-9-]*`, chroma.NameClass, nil),
+			rule(`[a-z][A-Za-z0-9-]*`, chroma.Name, nil),
+			rule(`-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?`, chroma.LiteralNumber, nil),
+			rule(`[{}\[\]().,;:|@!^<>]`, chroma.Punctuation, nil),
+			rule(`.`, chroma.Text, nil),
+		},
+		// X.680 block comments nest.
+		"comment": {
+			rule(`[^*/]+`, chroma.CommentMultiline, nil),
+			rule(`/\*`, chroma.CommentMultiline, chroma.Push()),
+			rule(`\*/`, chroma.CommentMultiline, chroma.Pop(1)),
+			rule(`[*/]`, chroma.CommentMultiline, nil),
+		},
+	}
+}

--- a/web/asn1lexer_test.go
+++ b/web/asn1lexer_test.go
@@ -1,0 +1,129 @@
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+func TestASN1LexerRegistered(t *testing.T) {
+	if lexers.Get("asn1") == nil {
+		t.Fatal("lexers.Get(\"asn1\") = nil, want the registered ASN.1 lexer")
+	}
+}
+
+func TestASN1LexerTokens(t *testing.T) {
+	src := `-- ASN1START
+RRCSetup-r15 ::= SEQUENCE {
+    rrc-TransactionIdentifier    RRC-TransactionIdentifier,
+    spare                        BIT STRING (SIZE (1)),
+    count                        INTEGER (0..maxNrofSCells) OPTIONAL, -- Need N
+    pattern                      '0110'B,
+    enabled                      TRUE
+}
+-- ASN1STOP`
+
+	lexer := lexers.Get("asn1")
+	it, err := lexer.Tokenise(nil, src)
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+
+	type tok struct {
+		typ   chroma.TokenType
+		value string
+	}
+	var tokens []tok
+	for _, tk := range it.Tokens() {
+		tokens = append(tokens, tok{tk.Type, tk.Value})
+	}
+
+	want := []tok{
+		{chroma.CommentSingle, "-- ASN1START"},
+		{chroma.NameClass, "RRCSetup-r15"},
+		{chroma.Operator, "::="},
+		{chroma.Keyword, "SEQUENCE"},
+		{chroma.Name, "rrc-TransactionIdentifier"},
+		{chroma.NameClass, "RRC-TransactionIdentifier"},
+		{chroma.Keyword, "BIT"},
+		{chroma.Keyword, "STRING"},
+		{chroma.Keyword, "SIZE"},
+		{chroma.LiteralNumber, "1"},
+		{chroma.Keyword, "INTEGER"},
+		{chroma.Operator, ".."},
+		{chroma.Name, "maxNrofSCells"},
+		{chroma.Keyword, "OPTIONAL"},
+		{chroma.CommentSingle, "-- Need N"},
+		{chroma.LiteralNumberBin, "'0110'B"},
+		{chroma.KeywordConstant, "TRUE"},
+		{chroma.CommentSingle, "-- ASN1STOP"},
+	}
+	i := 0
+	for _, w := range want {
+		found := false
+		for ; i < len(tokens); i++ {
+			if tokens[i].value == w.value {
+				found = true
+				// SEQUENCE etc. are KeywordType/Keyword subtypes; compare categories.
+				if tokens[i].typ.Category() != w.typ.Category() && tokens[i].typ != w.typ {
+					t.Errorf("token %q type = %v, want category %v", w.value, tokens[i].typ, w.typ)
+				}
+				i++
+				break
+			}
+		}
+		if !found {
+			t.Errorf("token %q (%v) not found in expected order; got tokens: %v", w.value, w.typ, tokens)
+			break
+		}
+	}
+}
+
+func TestASN1LexerCommentEndsAtDoubleDash(t *testing.T) {
+	lexer := lexers.Get("asn1")
+	it, err := lexer.Tokenise(nil, "INTEGER -- inline -- OPTIONAL\n")
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+	var comment string
+	sawOptional := false
+	for _, tk := range it.Tokens() {
+		if tk.Type == chroma.CommentSingle {
+			comment = tk.Value
+		}
+		if tk.Value == "OPTIONAL" && tk.Type.Category() == chroma.Keyword {
+			sawOptional = true
+		}
+	}
+	if comment != "-- inline --" {
+		t.Errorf("comment = %q, want %q", comment, "-- inline --")
+	}
+	if !sawOptional {
+		t.Error("OPTIONAL after a closed inline comment should lex as a keyword")
+	}
+}
+
+func TestASN1LexerHyphenatedIdentifierNotSplit(t *testing.T) {
+	lexer := lexers.Get("asn1")
+	it, err := lexer.Tokenise(nil, "SetupRelease-r16")
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+	tokens := it.Tokens()
+	if len(tokens) != 1 || tokens[0].Value != "SetupRelease-r16" || tokens[0].Type != chroma.NameClass {
+		t.Errorf("tokens = %v, want a single NameClass token %q", tokens, "SetupRelease-r16")
+	}
+}
+
+func TestRenderMarkdownHighlightsASN1(t *testing.T) {
+	content := "```asn1\nRRCSetup ::= SEQUENCE {}\n```"
+	got := renderMarkdown(content, "TS 38.331", "", nil)
+	if !strings.Contains(got, "chroma") {
+		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
+	}
+	if !strings.Contains(got, ">SEQUENCE</span>") {
+		t.Errorf("renderMarkdown() = %q, want SEQUENCE inside a token span", got)
+	}
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,15 +1,9 @@
 // Dark mode toggle
 (function () {
+    // The theme itself is initialized by an inline script in the <head> of
+    // layout.html, before the first paint; this only wires up the toggle.
     const toggle = document.getElementById('theme-toggle');
     const html = document.documentElement;
-
-    // Initialize theme
-    const saved = localStorage.getItem('theme');
-    if (saved) {
-        html.dataset.theme = saved;
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        html.dataset.theme = 'dark';
-    }
 
     if (toggle) {
         toggle.addEventListener('click', function () {

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{if .Refresh}}<meta http-equiv="refresh" content="{{.Refresh}}">{{end}}
     <title>3GPP Spec Viewer</title>
+    <script>
+        // Set the theme before the first paint so navigating in dark mode
+        // never flashes the light theme. Keep in sync with the toggle in
+        // /static/app.js, which stores the choice in localStorage.
+        (function () {
+            var theme;
+            try { theme = localStorage.getItem('theme'); } catch (e) { }
+            if (theme !== 'light' && theme !== 'dark') {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+            document.documentElement.dataset.theme = theme;
+        })();
+    </script>
     <link rel="stylesheet" href="/static/katex/katex.min.css">
     <link rel="stylesheet" href="/static/style.css">
 </head>


### PR DESCRIPTION
## Summary

- Fix the light-theme flash when navigating pages in dark mode: the theme was applied by `app.js` at the end of `<body>`, after the first paint. An inline script in `<head>` now sets `data-theme` from localStorage (or `prefers-color-scheme`) before the stylesheets load.
- Add an ASN.1 lexer for Chroma registered under the `asn1` alias. The DOCX converter already emits ```` ```asn1 ```` fences and the light/dark `.chroma` stylesheets already exist, but Chroma ships no ASN.1 lexer, so the fences rendered unhighlighted. The lexer covers X.680 notation as used in 3GPP specs: `--` comments ending at `--` or end of line, hyphenated identifiers (never split by keyword matching), bit/hex string literals, and nested `/* */` comments.

## Test plan

- `go test -short ./...`, `go vet ./...`, `gofmt -l .` all pass
- New tests: lexer registration, tokenization of a TS 38.331-style snippet, inline comment termination, hyphenated identifiers, and `renderMarkdown` output for an `asn1` fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVsgrty79RHQ1RcDr8gYz3)_