### PR TITLE
fix(web): add missing dark theme colors for chroma tokens

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1174,6 +1174,10 @@ mark {
 /* NameException */ [data-theme="dark"] .chroma .ne { color: #f0883e; font-weight: bold }
 /* NameLabel */ [data-theme="dark"] .chroma .nl { color: #79c0ff; font-weight: bold }
 /* NameNamespace */ [data-theme="dark"] .chroma .nn { color: #ff7b72 }
+/* NameAttribute */ [data-theme="dark"] .chroma .na { color: #79c0ff }
+/* NameOther */ [data-theme="dark"] .chroma .nx { color: #e6edf3 }
+/* NameBuiltin */ [data-theme="dark"] .chroma .nb { color: #d2a8ff }
+/* NameBuiltinPseudo */ [data-theme="dark"] .chroma .bp { color: #8b949e }
 /* NameProperty */ [data-theme="dark"] .chroma .py { color: #79c0ff }
 /* NameTag */ [data-theme="dark"] .chroma .nt { color: #7ee787 }
 /* NameVariable */ [data-theme="dark"] .chroma .nv { color: #79c0ff }
@@ -1208,6 +1212,7 @@ mark {
 /* LiteralNumberOct */ [data-theme="dark"] .chroma .mo { color: #a5d6ff }
 /* Operator */ [data-theme="dark"] .chroma .o { color: #ff7b72; font-weight: bold }
 /* OperatorWord */ [data-theme="dark"] .chroma .ow { color: #ff7b72; font-weight: bold }
+/* Punctuation */ [data-theme="dark"] .chroma .p { color: #e6edf3 }
 /* Comment */ [data-theme="dark"] .chroma .c { color: #8b949e; font-style: italic }
 /* CommentHashbang */ [data-theme="dark"] .chroma .ch { color: #8b949e; font-style: italic }
 /* CommentMultiline */ [data-theme="dark"] .chroma .cm { color: #8b949e; font-style: italic }


### PR DESCRIPTION
## Summary

The light-theme chroma styles define `.p` (Punctuation), `.na`, `.nx` as `#1f2328` and `.nb` as `#6639ba` without dark-theme overrides, so braces, commas, and parentheses were nearly invisible on the dark background (e.g. in ASN.1 sections). Add the missing `[data-theme="dark"]` overrides (`.p`, `.na`, `.nx`, `.nb`, `.bp`) using the GitHub dark palette. Every token class styled for light now has a dark counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVsgrty79RHQ1RcDr8gYz3)_