### PR TITLE
feat: fence Diameter definitions and highlight them in the web viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,22 @@ conversion-pair extensions (`.emf`/`.wmf`/`.pcz`/`.png`) and alt spelling
 never count as a content change; other extension changes stay visible. The web viewer
 serves an SVG placeholder for formats a browser cannot render (EMF/WMF).
 
+### Code fences
+
+The converter emits two tagged fences, both syntax-highlighted by the web
+viewer through custom Chroma lexers (`web/asn1lexer.go`, `web/diameterlexer.go`):
+` ```asn1 ` for ASN.1 modules between the `-- ASN1START`/`-- ASN1STOP` markers,
+and ` ```diameter ` for Diameter command/grouped-AVP definitions (RFC 6733
+Command Code Format). Diameter definitions carry no code style or font in the
+source documents, so they are detected by content (`::= < Diameter|AVP
+Header:` starts a block, AVP reference lines continue it). Monospace-styled
+paragraphs outside these two notations become bare ` ``` ` fences.
+
 The version cache stamps `PRAGMA user_version`
 (`versionstore.cacheSchemaVersion`); opening a cache from another generation
-wipes it. Databases built before the unified notation are incompatible with
-the compare normalization — rebuild them (`make build-db`).
+wipes it. Databases built before the unified notation or the Diameter
+code-fence change are incompatible with the compare normalization —
+rebuild them (`make build-db`).
 
 ### MCP Tools
 

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -28,6 +28,19 @@ var (
 	// convention) never matches.
 	asn1StartRE = regexp.MustCompile(`^--\s*(?:/[^/]*/\s*)?ASN1START\b`)
 	asn1StopRE  = regexp.MustCompile(`^--\s*(?:/[^/]*/\s*)?ASN1STOP\b`)
+
+	// Diameter Command Code Format (RFC 6733 clause 3.2) definition header:
+	//   < Update-Location-Request> ::=	< Diameter Header: 316, REQ, PXY, 16777251 >
+	//   Subscription-Data ::= <AVP header: 1400 10415>
+	//   MIP6-Agent-Info ::=< AVP Header: 486 >
+	// Case and spacing vary between specs. Requiring "< Diameter|AVP Header:"
+	// after "::=" keeps ASN.1 value assignments and prose that merely contains
+	// "::=" from matching.
+	diameterDefRE = regexp.MustCompile(`(?i)::=\s*<\s*(?:diameter|avp)\s+header\s*:`)
+	// One AVP reference line of a definition: an optional multiplicity
+	// qualifier (RFC 6733 qual: [min] "*" [max]) followed by exactly one
+	// fixed < >, mandatory { } or optional [ ] AVP reference.
+	diameterAVPLineRE = regexp.MustCompile(`^[ \t]*(?:\d+\*\d*|\*\d*|\d+)?[ \t]*(?:<[^<>]+>|\{[^{}]+\}|\[[^\][]+\])[ \t]*$`)
 )
 
 // matchASN1Marker reports whether the paragraph is an ASN.1 extraction marker.
@@ -36,6 +49,23 @@ var (
 func matchASN1Marker(re *regexp.Regexp, info paragraphInfo) bool {
 	text := strings.ReplaceAll(codeLineText(info), "\u00a0", " ")
 	return re.MatchString(strings.TrimSpace(text))
+}
+
+// matchDiameterStart reports whether the paragraph is a Diameter command or
+// grouped-AVP definition header. Diameter specs style these as plain body
+// paragraphs (no code font or style), so detection is content-based like the
+// ASN.1 markers. NBSP is normalized for the same reason as matchASN1Marker.
+func matchDiameterStart(info paragraphInfo) bool {
+	text := strings.ReplaceAll(codeLineText(info), "\u00a0", " ")
+	return diameterDefRE.MatchString(text)
+}
+
+// matchDiameterLine reports whether the paragraph continues a Diameter
+// definition: an AVP reference line, or another definition header (so that
+// consecutive grouped-AVP definitions in one clause merge into one block).
+func matchDiameterLine(info paragraphInfo) bool {
+	text := strings.ReplaceAll(codeLineText(info), "\u00a0", " ")
+	return diameterAVPLineRE.MatchString(text) || diameterDefRE.MatchString(text)
 }
 
 // bodyElement represents a top-level element in the document body.
@@ -271,12 +301,36 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 		asn1Buffer = nil
 	}
 
+	// Accumulates Diameter command/grouped-AVP definitions into one
+	// ```diameter fence. Their paragraphs carry no code style or font in the
+	// source documents, so capture is triggered by content: a definition
+	// header starts it, AVP reference lines continue it, and the first
+	// paragraph that is neither ends it (see matchDiameterStart/Line).
+	var diameterBuffer []string
+	inDiameter := false
+	flushDiameter := func() {
+		inDiameter = false
+		if len(diameterBuffer) == 0 || currentSection == nil {
+			diameterBuffer = nil
+			return
+		}
+		for len(diameterBuffer) > 0 && strings.TrimSpace(diameterBuffer[len(diameterBuffer)-1]) == "" {
+			diameterBuffer = diameterBuffer[:len(diameterBuffer)-1]
+		}
+		if len(diameterBuffer) > 0 {
+			currentSection.Content = append(currentSection.Content,
+				"```diameter\n"+strings.Join(diameterBuffer, "\n")+"\n```")
+		}
+		diameterBuffer = nil
+	}
+
 	for _, elem := range elements {
 		switch elem.Tag {
 		case "tbl":
 			// A table while capturing ASN.1 means a missing ASN1STOP; flush
 			// what was collected rather than swallowing the table.
 			flushASN1()
+			flushDiameter()
 			flushCodeBlock()
 			html := tableToHTML(elem.Table, imageContext{relMap: relMap, images: images})
 			if html != "" && currentSection != nil {
@@ -301,6 +355,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				// A heading while capturing ASN.1 means a missing ASN1STOP;
 				// flush so headings are never swallowed into a code block.
 				flushASN1()
+				flushDiameter()
 				flushCodeBlock()
 				// Normalize text
 				text := strings.ReplaceAll(info.Text, "\u00a0", " ")
@@ -384,9 +439,34 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					continue
 				}
 				if matchASN1Marker(asn1StartRE, info) {
+					flushDiameter()
 					flushCodeBlock()
 					inASN1 = true
 					asn1Buffer = append(asn1Buffer, codeLineText(info))
+					continue
+				}
+				if inDiameter {
+					switch {
+					case info.Text == "" && len(info.Images) == 0:
+						// Preserve blank lines inside a pending block;
+						// trailing ones are trimmed at flush.
+						diameterBuffer = append(diameterBuffer, "")
+						continue
+					case matchDiameterLine(info) && len(info.Images) == 0:
+						diameterBuffer = append(diameterBuffer, codeLineText(info))
+						continue
+					default:
+						// First non-matching paragraph ends the block and is
+						// handled normally below.
+						flushDiameter()
+					}
+				}
+				if matchDiameterStart(info) && len(info.Images) == 0 && currentSection != nil {
+					// Before the isCodePara path so a code-styled definition
+					// starts a tagged fence instead of a bare one.
+					flushCodeBlock()
+					inDiameter = true
+					diameterBuffer = append(diameterBuffer, codeLineText(info))
 					continue
 				}
 				isCodePara := (info.IsCode || isCodeStyleName(styleName) || codeStyles[info.StyleID]) && len(info.Images) == 0
@@ -420,6 +500,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 	}
 
 	flushASN1()
+	flushDiameter()
 	flushCodeBlock()
 
 	return sections

--- a/converter/docx/parser_test.go
+++ b/converter/docx/parser_test.go
@@ -980,6 +980,223 @@ func TestParseSections_ASN1UnterminatedFlushedByTable(t *testing.T) {
 	}
 }
 
+func TestDiameterDefRegex(t *testing.T) {
+	tests := []struct {
+		text  string
+		start bool
+		line  bool
+	}{
+		// Header spelling variants observed across Diameter specs.
+		{"< Update-Location-Request> ::=\t< Diameter Header: 316, REQ, PXY, 16777251 >", true, true},
+		{"Subscription-Data ::= <AVP header: 1400 10415>", true, true},
+		{"MIP6-Agent-Info ::=< AVP Header: 486 >", true, true},
+		{"EPS-User-State ::= <AVP header:1495 10415>", true, true},
+		{" Supported-Services::= <AVP header: 3143 10415>", true, true},
+		// AVP reference lines.
+		{"< Session-Id >", false, true},
+		{"{ Origin-Host }", false, true},
+		{"[ DRMP ]", false, true},
+		{"*[ Supported-Features ]", false, true},
+		{"1*{ Proxy-Info }", false, true},
+		{"0*2[ Subscription-Data ]", false, true},
+		{"\t[ Destination-Host ]", false, true},
+		// ASN.1 and prose must match neither.
+		{"Foo ::= SEQUENCE {", false, false},
+		{"where X ::= Y denotes a production", false, false},
+		{"The AVP header is described in clause 4.", false, false},
+		{"plain text", false, false},
+		{"", false, false},
+	}
+	for _, tt := range tests {
+		info := paragraphInfo{Text: tt.text, Runs: []runInfo{{Text: tt.text}}}
+		if got := matchDiameterStart(info); got != tt.start {
+			t.Errorf("start match for %q = %v, want %v", tt.text, got, tt.start)
+		}
+		if got := matchDiameterLine(info); got != tt.line {
+			t.Errorf("line match for %q = %v, want %v", tt.text, got, tt.line)
+		}
+	}
+}
+
+func TestParseSections_DiameterCommandBlock(t *testing.T) {
+	para := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text}},
+		}}
+	}
+	elements := []bodyElement{
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: "6.1.1\tUser-Authorization-Request (UAR) Command",
+			Runs: []runInfo{{Text: "6.1.1\tUser-Authorization-Request (UAR) Command"}},
+		}},
+		para("Message Format"),
+		para("< User-Authorization-Request> ::=\t< Diameter Header: 300, REQ, PXY, 16777216 >"),
+		para("< Session-Id >"),
+		{Tag: "p", Paragraph: paragraphInfo{}}, // blank paragraph → blank line
+		para("{ Origin-Host }"),
+		// Bold runs (TS 29.229) must be captured without markdown markers.
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "*[ Supported-Features ]",
+			Runs: []runInfo{{Text: "*[ Supported-Features ]", Bold: true}},
+		}},
+		para("*[ AVP ]"),
+		para("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	want := "```diameter\n" +
+		"< User-Authorization-Request> ::=\t< Diameter Header: 300, REQ, PXY, 16777216 >\n" +
+		"< Session-Id >\n" +
+		"\n" +
+		"{ Origin-Host }\n" +
+		"*[ Supported-Features ]\n" +
+		"*[ AVP ]\n" +
+		"```"
+	var found bool
+	for _, c := range content {
+		if c == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected verbatim diameter fence %q; got content:\n%v", want, content)
+	}
+	if content[len(content)-1] != "Trailing prose." {
+		t.Errorf("expected trailing prose after the fence, got %q", content[len(content)-1])
+	}
+	joined := strings.Join(content, "\n")
+	if strings.Contains(joined, "**") {
+		t.Errorf("bold markers leaked into output:\n%v", content)
+	}
+}
+
+func TestParseSections_DiameterGroupedAVPVariants(t *testing.T) {
+	para := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text}},
+		}}
+	}
+	elements := []bodyElement{
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: "7.3.2\tGrouped AVPs",
+			Runs: []runInfo{{Text: "7.3.2\tGrouped AVPs"}},
+		}},
+		para("Subscription-Data ::= <AVP header: 1400 10415>"),
+		para("[ Subscriber-Status ]"),
+		{Tag: "p", Paragraph: paragraphInfo{}},
+		// Consecutive definitions merge into a single fence.
+		para("MIP6-Agent-Info ::=< AVP Header: 486 >"),
+		para("[ MIP-Home-Agent-Address ]"),
+		para("*[ AVP ]"),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 {
+		t.Fatalf("expected exactly 1 content entry, got %v", sections[0].Content)
+	}
+	c := sections[0].Content[0]
+	if !strings.HasPrefix(c, "```diameter\n") ||
+		!strings.Contains(c, "Subscription-Data ::= <AVP header: 1400 10415>") ||
+		!strings.Contains(c, "MIP6-Agent-Info ::=< AVP Header: 486 >") {
+		t.Errorf("expected one merged diameter fence with both definitions, got %q", c)
+	}
+}
+
+func TestParseSections_DiameterFlushedByHeadingAndTable(t *testing.T) {
+	para := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text}},
+		}}
+	}
+	heading := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: text, Runs: []runInfo{{Text: text}},
+		}}
+	}
+	elements := []bodyElement{
+		heading("1\tFirst"),
+		para("ULR ::= < Diameter Header: 316, REQ, PXY >"),
+		para("{ Origin-Host }"),
+		heading("2\tSecond"),
+		para("ULA ::= < Diameter Header: 316, PXY >"),
+		para("{ Result-Code }"),
+		{Tag: "tbl", Table: tableInfo{Rows: []tableRow{{Cells: []tableCell{{Paras: []paragraphInfo{{Text: "cell", Runs: []runInfo{{Text: "cell"}}}}}}}}}},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 || !strings.HasPrefix(sections[0].Content[0], "```diameter\n") {
+		t.Errorf("expected diameter fence flushed by heading in first section, got %v", sections[0].Content)
+	}
+	second := strings.Join(sections[1].Content, "\n")
+	if !strings.Contains(second, "```diameter\n") || !strings.Contains(second, "cell") {
+		t.Errorf("expected diameter fence flushed by table plus table content, got %v", sections[1].Content)
+	}
+	if strings.Index(second, "```diameter") > strings.Index(second, "cell") {
+		t.Errorf("expected fence before table content, got %v", sections[1].Content)
+	}
+}
+
+func TestParseSections_DiameterFalsePositiveProse(t *testing.T) {
+	elements := []bodyElement{
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: "1\tFirst",
+			Runs: []runInfo{{Text: "1\tFirst"}},
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "where X ::= Y denotes a production",
+			Runs: []runInfo{{Text: "where X ::= Y denotes a production"}},
+		}},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 || strings.Contains(sections[0].Content[0], "```") {
+		t.Errorf("expected plain prose paragraph, got %v", sections[0].Content)
+	}
+}
+
+func TestParseSections_DiameterAfterCodeStyledBlock(t *testing.T) {
+	elements := []bodyElement{
+		{Tag: "p", Paragraph: paragraphInfo{
+			StyleID: "Heading1", Text: "1\tFirst",
+			Runs: []runInfo{{Text: "1\tFirst"}},
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "yaml: sample", Runs: []runInfo{{Text: "yaml: sample"}}, IsCode: true,
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "CCR ::= < Diameter Header: 272, REQ, PXY >",
+			Runs: []runInfo{{Text: "CCR ::= < Diameter Header: 272, REQ, PXY >"}},
+		}},
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "{ Origin-Host }", Runs: []runInfo{{Text: "{ Origin-Host }"}},
+		}},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected a plain fence then a diameter fence, got %v", content)
+	}
+	if !strings.HasPrefix(content[0], "```\n") || !strings.Contains(content[0], "yaml: sample") {
+		t.Errorf("expected plain code fence first, got %q", content[0])
+	}
+	if !strings.HasPrefix(content[1], "```diameter\n") || !strings.Contains(content[1], "{ Origin-Host }") {
+		t.Errorf("expected diameter fence second, got %q", content[1])
+	}
+}
+
 func TestImagePlaceholder_UnifiedNotation(t *testing.T) {
 	relMap := map[string]string{"rId1": "media/image1.emf"}
 	images := map[string]*EmbeddedImage{

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -51,8 +51,9 @@ const DefaultFileName = "versions.db"
 // file with a different generation drops every table and starts over: entries
 // are re-downloadable, so a wipe is cheaper than migrating. Bump it when the
 // stored content becomes incompatible — generation 2 unified the image
-// reference notation (![Figure](image://...) for every format).
-const cacheSchemaVersion = 2
+// reference notation (![Figure](image://...) for every format), generation 3
+// fences Diameter command/AVP definitions (```diameter).
+const cacheSchemaVersion = 3
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search

--- a/web/diameterlexer.go
+++ b/web/diameterlexer.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// The DOCX converter emits Diameter Command Code Format definitions
+// (RFC 6733 clause 3.2) as ```diameter fences; Chroma ships no lexer for
+// that notation, so this registers one under the "diameter" alias. The
+// existing light/dark .chroma stylesheets cover the emitted token classes.
+func init() {
+	lexers.Register(chroma.MustNewLexer(
+		&chroma.Config{
+			Name:    "Diameter CCF",
+			Aliases: []string{"diameter"},
+		},
+		diameterRules,
+	))
+}
+
+// diameterRules covers the Command Code Format as printed in 3GPP Diameter
+// specifications: a `Name ::= < Diameter|AVP Header: ... >` line followed by
+// one AVP reference per line, each an optional multiplicity qualifier and a
+// fixed < >, mandatory { } or optional [ ] reference.
+func diameterRules() chroma.Rules {
+	rule := func(pattern string, typ chroma.TokenType, mutator chroma.Mutator) chroma.Rule {
+		return chroma.Rule{Pattern: pattern, Type: typ, Mutator: mutator}
+	}
+	return chroma.Rules{
+		"root": {
+			rule(`\s+`, chroma.TextWhitespace, nil),
+			rule(`::=`, chroma.Operator, nil),
+			// Before the name rule so the words never lex as AVP names.
+			rule(`(?i)\b(?:diameter|avp)[ \t]+header\b`, chroma.KeywordDeclaration, nil),
+			rule(`\b(?:REQ|PXY|ERR)\b`, chroma.KeywordConstant, nil),
+			// Multiplicity qualifier ([min] "*" [max]) — before the plain
+			// number rule so "1*" lexes as one token.
+			rule(`\d+\*\d*|\*\d*`, chroma.LiteralNumber, nil),
+			// Command code, application id, vendor id. `\b` after the digits
+			// keeps digit-leading AVP names (3GPP-Charging-Characteristics)
+			// falling through to the name rule below.
+			rule(`\b\d+\b`, chroma.LiteralNumber, nil),
+			// Fixed-position AVPs and the header delimiters.
+			rule(`[<>]`, chroma.Operator, nil),
+			// Mandatory AVPs — visually strongest.
+			rule(`[{}]`, chroma.Keyword, nil),
+			// Optional AVPs — neutral.
+			rule(`[\[\]]`, chroma.Punctuation, nil),
+			rule(`[A-Za-z0-9][A-Za-z0-9-]*`, chroma.NameClass, nil),
+			rule(`[,:;()]`, chroma.Punctuation, nil),
+			rule(`.`, chroma.Text, nil),
+		},
+	}
+}

--- a/web/diameterlexer_test.go
+++ b/web/diameterlexer_test.go
@@ -1,0 +1,98 @@
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+func TestDiameterLexerRegistered(t *testing.T) {
+	if lexers.Get("diameter") == nil {
+		t.Fatal("lexers.Get(\"diameter\") = nil, want the registered Diameter CCF lexer")
+	}
+}
+
+func TestDiameterLexerTokens(t *testing.T) {
+	src := `< Update-Location-Request> ::=	< Diameter Header: 316, REQ, PXY, 16777251 >
+< Session-Id >
+[ DRMP ]
+{ Origin-Host }
+*[ Supported-Features ]
+1*{ Proxy-Info }`
+
+	lexer := lexers.Get("diameter")
+	it, err := lexer.Tokenise(nil, src)
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+
+	type tok struct {
+		typ   chroma.TokenType
+		value string
+	}
+	var tokens []tok
+	for _, tk := range it.Tokens() {
+		tokens = append(tokens, tok{tk.Type, tk.Value})
+	}
+
+	want := []tok{
+		{chroma.NameClass, "Update-Location-Request"},
+		{chroma.Operator, "::="},
+		{chroma.KeywordDeclaration, "Diameter Header"},
+		{chroma.LiteralNumber, "316"},
+		{chroma.KeywordConstant, "REQ"},
+		{chroma.KeywordConstant, "PXY"},
+		{chroma.LiteralNumber, "16777251"},
+		{chroma.NameClass, "Session-Id"},
+		{chroma.NameClass, "DRMP"},
+		{chroma.Keyword, "{"},
+		{chroma.NameClass, "Origin-Host"},
+		{chroma.LiteralNumber, "*"},
+		{chroma.NameClass, "Supported-Features"},
+		{chroma.LiteralNumber, "1*"},
+		{chroma.NameClass, "Proxy-Info"},
+	}
+	i := 0
+	for _, w := range want {
+		found := false
+		for ; i < len(tokens); i++ {
+			if tokens[i].value == w.value {
+				found = true
+				if tokens[i].typ.Category() != w.typ.Category() && tokens[i].typ != w.typ {
+					t.Errorf("token %q type = %v, want category %v", w.value, tokens[i].typ, w.typ)
+				}
+				i++
+				break
+			}
+		}
+		if !found {
+			t.Errorf("token %q (%v) not found in expected order; got tokens: %v", w.value, w.typ, tokens)
+			break
+		}
+	}
+}
+
+func TestDiameterLexerDigitLeadingNameNotSplit(t *testing.T) {
+	lexer := lexers.Get("diameter")
+	it, err := lexer.Tokenise(nil, "3GPP-Charging-Characteristics")
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+	tokens := it.Tokens()
+	if len(tokens) != 1 || tokens[0].Value != "3GPP-Charging-Characteristics" || tokens[0].Type != chroma.NameClass {
+		t.Errorf("tokens = %v, want a single NameClass token %q", tokens, "3GPP-Charging-Characteristics")
+	}
+}
+
+func TestRenderMarkdownHighlightsDiameter(t *testing.T) {
+	content := "```diameter\n< Session-Id >\n{ Origin-Host }\n```"
+	got := renderMarkdown(content, "TS 29.272", "", nil)
+	if !strings.Contains(got, "chroma") {
+		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
+	}
+	if !strings.Contains(got, ">Origin-Host</span>") {
+		t.Errorf("renderMarkdown() = %q, want Origin-Host inside a token span", got)
+	}
+}


### PR DESCRIPTION
## Summary

Diameter CCF definitions (RFC 6733 Command Code Format) were emitted as plain paragraphs because the source docx paragraphs carry no code style or font, and bold runs corrupted the ABNF multiplicity markers in some specs (e.g. `***[ Supported-Features ]**` in TS 29.229).

- Detect definitions by content in the DOCX parser: a header line matching `::= < Diameter|AVP Header:` starts a block, AVP reference lines continue it, emitted as a ```` ```diameter ```` fence (raw run text, so bold markers no longer leak)
- Register a Chroma lexer for the `diameter` alias so the web viewer highlights the fences, modeled on the ASN.1 lexer; existing light/dark stylesheets cover the token classes
- Bump `versionstore.cacheSchemaVersion` (2 → 3) so on-demand cached versions re-convert
- Document the required `make build-db` rebuild in AGENTS.md

## Verification

- `go build` / `gofmt` / `go vet` / `go test -race ./...` pass (11 new tests)
- Imported TS 29.272 v19.5.0: §7.2.3 (ULR) becomes a single verbatim ```` ```diameter ```` fence; 83 sections gain fences. TS 29.229 §6.1.1 (UAR) likewise, with no `**` leakage
- Web viewer serves the section with a `chroma`-wrapped block: `::=` operator, `Diameter Header` declaration, `REQ`/`PXY` constants, AVP names colored in both themes