### PR TITLE
feat(converter): fence XML/DTD blocks by content detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,20 +129,27 @@ serves an SVG placeholder for formats a browser cannot render (EMF/WMF).
 
 ### Code fences
 
-The converter emits two tagged fences, both syntax-highlighted by the web
-viewer through custom Chroma lexers (`web/asn1lexer.go`, `web/diameterlexer.go`):
-` ```asn1 ` for ASN.1 modules between the `-- ASN1START`/`-- ASN1STOP` markers,
-and ` ```diameter ` for Diameter command/grouped-AVP definitions (RFC 6733
-Command Code Format). Diameter definitions carry no code style or font in the
-source documents, so they are detected by content (`::= < Diameter|AVP
-Header:` starts a block, AVP reference lines continue it). Monospace-styled
-paragraphs outside these two notations become bare ` ``` ` fences.
+The converter emits three tagged fences: ` ```asn1 ` for ASN.1 modules
+between the `-- ASN1START`/`-- ASN1STOP` markers, ` ```diameter ` for
+Diameter command/grouped-AVP definitions (RFC 6733 Command Code Format), and
+` ```xml ` for XML schemas, XML body examples and DTDs written as plain body
+paragraphs. The web viewer highlights the first two through custom Chroma
+lexers (`web/asn1lexer.go`, `web/diameterlexer.go`) and ` ```xml ` through
+Chroma's built-in XML lexer. Diameter definitions and XML/DTD blocks carry no
+code style or font in the source documents, so both are detected by content:
+`::= < Diameter|AVP Header:` starts a Diameter block and AVP reference lines
+continue it; an XML declaration or DOCTYPE starts an XML block on its own,
+ordinary tag/comment/DTD lines only in consecutive pairs (so prose quoting a
+single element never fences — see `converter/docx/xmlblock.go`). XML
+detection skips paragraphs already fenced via code style or font, which keep
+their bare ` ``` ` fences; monospace-styled paragraphs outside these
+notations become bare ` ``` ` fences as before.
 
 The version cache stamps `PRAGMA user_version`
 (`versionstore.cacheSchemaVersion`); opening a cache from another generation
-wipes it. Databases built before the unified notation or the Diameter
-code-fence change are incompatible with the compare normalization —
-rebuild them (`make build-db`).
+wipes it. Databases built before the unified notation, the Diameter
+code-fence change or the XML code-fence change are incompatible with the
+compare normalization — rebuild them (`make build-db`).
 
 ### MCP Tools
 

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -489,12 +489,16 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				sections = append(sections, section)
 				currentSection = section
 			} else {
+				// Computed before the XML pending/continuation checks: content
+				// detection must never capture an already code-styled
+				// paragraph — those keep their bare ``` fences.
+				isCodePara := (info.IsCode || isCodeStyleName(styleName) || codeStyles[info.StyleID]) && len(info.Images) == 0
 				if xmlPending != nil {
 					// The commit test deliberately ignores element depth
 					// (matchXMLLine, not matchXMLContinuation): a quoted
 					// "<userid>" opener in prose must not pull the following
 					// prose paragraph into a fence.
-					if len(info.Images) == 0 && matchXMLLine(info, &xmlTracker) {
+					if !isCodePara && len(info.Images) == 0 && matchXMLLine(info, &xmlTracker) {
 						// Second consecutive XML-looking paragraph: commit the
 						// held opener and the current line to an XML block.
 						flushCodeBlock()
@@ -534,14 +538,14 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 						// trimmed at flush.
 						xmlBuffer = append(xmlBuffer, "")
 						continue
-					case len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
+					case !isCodePara && len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
 						line := codeLineText(info)
 						xmlBuffer = append(xmlBuffer, line)
 						xmlTracker.observe(line)
 						continue
 					default:
-						// First non-matching paragraph ends the block and is
-						// handled normally below.
+						// First non-matching (or code-styled) paragraph ends
+						// the block and is handled normally below.
 						flushXML()
 					}
 				}
@@ -569,7 +573,6 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					diameterBuffer = append(diameterBuffer, codeLineText(info))
 					continue
 				}
-				isCodePara := (info.IsCode || isCodeStyleName(styleName) || codeStyles[info.StyleID]) && len(info.Images) == 0
 				// Content-based XML detection only applies to paragraphs the
 				// style/font paths would render as prose: specs whose XML is
 				// already code-styled keep their existing bare ``` fences.

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -324,6 +324,63 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 		diameterBuffer = nil
 	}
 
+	// emitParagraph renders a paragraph through the normal (non-code) path.
+	// Split out so an abandoned XML-opener candidate (see below) replays
+	// through exactly the same logic.
+	emitParagraph := func(info paragraphInfo, styleName string) {
+		flushCodeBlock()
+		if currentSection != nil {
+			blocks := paragraphToMarkdownBlocks(info, styleName, func(ref imageRef) string {
+				if relMap == nil {
+					return ""
+				}
+				return imagePlaceholder(relMap, images, ref)
+			})
+			currentSection.Content = append(currentSection.Content, blocks...)
+		}
+		// Surface any grouped vector diagram this converter couldn't render
+		// as an image (see issue #25), instead of silently dropping it.
+		if currentSection != nil && info.SkippedDiagramLabels != nil {
+			currentSection.Content = append(currentSection.Content, diagramPlaceholder(info.SkippedDiagramLabels))
+		}
+	}
+
+	// Accumulates XML/DTD blocks into one ```xml fence. Like the Diameter
+	// definitions these paragraphs carry no code style or font, so capture is
+	// content-based (see xmlblock.go): an XML declaration or DOCTYPE opens a
+	// block on its own, an ordinary tag/comment line only when the next
+	// paragraph also looks like XML — until then it is held in xmlPending and
+	// replayed as a normal paragraph if the second line never comes.
+	var xmlBuffer []string
+	var xmlTracker xmlLineTracker
+	var xmlPending *paragraphInfo
+	var xmlPendingStyle string
+	inXML := false
+	flushXML := func() {
+		inXML = false
+		xmlTracker = xmlLineTracker{}
+		if len(xmlBuffer) == 0 || currentSection == nil {
+			xmlBuffer = nil
+			return
+		}
+		for len(xmlBuffer) > 0 && strings.TrimSpace(xmlBuffer[len(xmlBuffer)-1]) == "" {
+			xmlBuffer = xmlBuffer[:len(xmlBuffer)-1]
+		}
+		if len(xmlBuffer) > 0 {
+			currentSection.Content = append(currentSection.Content,
+				"```xml\n"+strings.Join(xmlBuffer, "\n")+"\n```")
+		}
+		xmlBuffer = nil
+	}
+	abandonXMLPending := func() {
+		if xmlPending == nil {
+			return
+		}
+		emitParagraph(*xmlPending, xmlPendingStyle)
+		xmlPending = nil
+		xmlTracker = xmlLineTracker{}
+	}
+
 	for _, elem := range elements {
 		switch elem.Tag {
 		case "tbl":
@@ -331,6 +388,8 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 			// what was collected rather than swallowing the table.
 			flushASN1()
 			flushDiameter()
+			abandonXMLPending()
+			flushXML()
 			flushCodeBlock()
 			html := tableToHTML(elem.Table, imageContext{relMap: relMap, images: images})
 			if html != "" && currentSection != nil {
@@ -356,6 +415,8 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				// flush so headings are never swallowed into a code block.
 				flushASN1()
 				flushDiameter()
+				abandonXMLPending()
+				flushXML()
 				flushCodeBlock()
 				// Normalize text
 				text := strings.ReplaceAll(info.Text, "\u00a0", " ")
@@ -428,6 +489,24 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				sections = append(sections, section)
 				currentSection = section
 			} else {
+				if xmlPending != nil {
+					// The commit test deliberately ignores element depth
+					// (matchXMLLine, not matchXMLContinuation): a quoted
+					// "<userid>" opener in prose must not pull the following
+					// prose paragraph into a fence.
+					if len(info.Images) == 0 && matchXMLLine(info, &xmlTracker) {
+						// Second consecutive XML-looking paragraph: commit the
+						// held opener and the current line to an XML block.
+						flushCodeBlock()
+						inXML = true
+						line := codeLineText(info)
+						xmlBuffer = append(xmlBuffer, codeLineText(*xmlPending), line)
+						xmlTracker.observe(line)
+						xmlPending = nil
+						continue
+					}
+					abandonXMLPending()
+				}
 				if inASN1 {
 					// Capture verbatim (tabs and indentation kept, blank
 					// paragraphs become blank lines, the STOP marker line
@@ -440,10 +519,31 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				}
 				if matchASN1Marker(asn1StartRE, info) {
 					flushDiameter()
+					flushXML()
 					flushCodeBlock()
 					inASN1 = true
 					asn1Buffer = append(asn1Buffer, codeLineText(info))
 					continue
+				}
+				if inXML {
+					switch {
+					case strings.TrimSpace(info.Text) == "" && len(info.Images) == 0:
+						// Preserve blank lines inside a pending block
+						// (whitespace-only paragraphs included, so indentation
+						// filler does not split the fence); trailing ones are
+						// trimmed at flush.
+						xmlBuffer = append(xmlBuffer, "")
+						continue
+					case len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
+						line := codeLineText(info)
+						xmlBuffer = append(xmlBuffer, line)
+						xmlTracker.observe(line)
+						continue
+					default:
+						// First non-matching paragraph ends the block and is
+						// handled normally below.
+						flushXML()
+					}
 				}
 				if inDiameter {
 					switch {
@@ -470,6 +570,28 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					continue
 				}
 				isCodePara := (info.IsCode || isCodeStyleName(styleName) || codeStyles[info.StyleID]) && len(info.Images) == 0
+				// Content-based XML detection only applies to paragraphs the
+				// style/font paths would render as prose: specs whose XML is
+				// already code-styled keep their existing bare ``` fences.
+				if !isCodePara && len(info.Images) == 0 && currentSection != nil {
+					if matchXMLStrongStart(info) {
+						flushCodeBlock()
+						inXML = true
+						line := codeLineText(info)
+						xmlBuffer = append(xmlBuffer, line)
+						xmlTracker = xmlLineTracker{}
+						xmlTracker.observe(line)
+						continue
+					}
+					if matchXMLCandidateStart(info) {
+						p := info
+						xmlPending = &p
+						xmlPendingStyle = styleName
+						xmlTracker = xmlLineTracker{}
+						xmlTracker.observe(codeLineText(info))
+						continue
+					}
+				}
 				switch {
 				case isCodePara && currentSection != nil:
 					// Append to the pending code block, preserving whitespace.
@@ -478,22 +600,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					// Preserve blank lines inside a pending code block.
 					codeBuffer = append(codeBuffer, "")
 				default:
-					flushCodeBlock()
-					if currentSection != nil {
-						blocks := paragraphToMarkdownBlocks(info, styleName, func(ref imageRef) string {
-							if relMap == nil {
-								return ""
-							}
-							return imagePlaceholder(relMap, images, ref)
-						})
-						currentSection.Content = append(currentSection.Content, blocks...)
-					}
-					// Surface any grouped vector diagram this converter
-					// couldn't render as an image (see issue #25), instead
-					// of silently dropping it.
-					if currentSection != nil && info.SkippedDiagramLabels != nil {
-						currentSection.Content = append(currentSection.Content, diagramPlaceholder(info.SkippedDiagramLabels))
-					}
+					emitParagraph(info, styleName)
 				}
 			}
 		}
@@ -501,6 +608,8 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 
 	flushASN1()
 	flushDiameter()
+	abandonXMLPending()
+	flushXML()
 	flushCodeBlock()
 
 	return sections

--- a/converter/docx/xmlblock.go
+++ b/converter/docx/xmlblock.go
@@ -1,0 +1,178 @@
+package docx
+
+import (
+	"regexp"
+	"strings"
+)
+
+// XML/DTD content detection.
+//
+// Several specs embed XML schemas, XML body examples and DTDs as plain body
+// paragraphs with no code style or font (e.g. TS 29.163 annex F, the OMA-DM
+// DDF annexes of TS 24.216/24.305, the DTDs of TS 31.220), so — like the
+// Diameter definitions — they are detected by content. Detection runs on the
+// raw paragraph text (before bold/italic markers are applied, since some
+// specs style whole XML blocks bold or italic).
+//
+// A strong opener (`<?xml`, `<!DOCTYPE`) starts a block by itself: neither
+// appears in prose. An ordinary tag, comment or DTD markup line only starts
+// a block together with a second consecutive XML-looking paragraph, so prose
+// that quotes a single element like "<userid>" on its own line never fences.
+// Comment openers include the mangled forms observed in converted documents:
+// "<!-" (a hyphen lost) and "<!—"/"<!–" (hyphens folded into a dash).
+var (
+	xmlStrongStartRE = regexp.MustCompile(`(?i)^(?:<\?xml\b|<!DOCTYPE\b)`)
+
+	// A candidate opener additionally requires the trimmed line to end with
+	// ">" (checked in matchXMLCandidateStart): an opening tag, a processing
+	// instruction, a comment or a DTD markup declaration. Closing tags are
+	// excluded — no block starts with one.
+	xmlCandidateStartRE = regexp.MustCompile(`(?i)^(?:<[A-Za-z_]|<\?[A-Za-z]|<!(?:--|[-—–])|<!(?:ELEMENT|ATTLIST|ENTITY|NOTATION)\b)`)
+
+	// A line that continues an open block: any tag (closing included, and
+	// tolerating a mangled space after "<" as seen in TS 31.220),
+	// declaration, comment — or "]>" closing a DOCTYPE internal subset.
+	xmlLooseLineRE = regexp.MustCompile(`^(?:< ?/? ?[A-Za-z_]|<[?!]|\])`)
+
+	// Cross-paragraph comment tracking only trusts a well-formed "<!--":
+	// the mangled openers sometimes lose their closer entirely (TS 29.163
+	// carries "<!-Definition of simple types" with no "-->" at all), and a
+	// sticky comment state with no closer would swallow everything up to the
+	// next heading. The closer accepts mangled hyphen/dash forms.
+	xmlCommentOpenRE  = regexp.MustCompile(`<!--`)
+	xmlCommentCloseRE = regexp.MustCompile(`(?:--|[-—–])>`)
+)
+
+// xmlTrimmedText returns the paragraph's raw text (no markdown emphasis
+// markers) with NBSP normalized to a space, trimmed. NBSP is normalized for
+// the same reason as matchASN1Marker.
+func xmlTrimmedText(info paragraphInfo) string {
+	return strings.TrimSpace(strings.ReplaceAll(codeLineText(info), "\u00a0", " "))
+}
+
+// matchXMLStrongStart reports whether the paragraph opens an XML/DTD block on
+// its own: an XML declaration or a DOCTYPE.
+func matchXMLStrongStart(info paragraphInfo) bool {
+	return xmlStrongStartRE.MatchString(xmlTrimmedText(info))
+}
+
+// matchXMLCandidateStart reports whether the paragraph could open an XML/DTD
+// block if the next paragraph also looks like XML: a whole-line tag, comment
+// or DTD markup declaration ending in ">".
+func matchXMLCandidateStart(info paragraphInfo) bool {
+	t := xmlTrimmedText(info)
+	return strings.HasSuffix(t, ">") && xmlCandidateStartRE.MatchString(t)
+}
+
+// matchXMLLine reports whether the paragraph looks like XML on its own: a
+// tag/comment/declaration line, or the completion of a construct the previous
+// line left unterminated. Used to decide whether a held opener candidate gets
+// its required second XML line. Math paragraphs (OMML converted to $…$) never
+// count, even when a tag is left unterminated.
+func matchXMLLine(info paragraphInfo, tr *xmlLineTracker) bool {
+	t := xmlTrimmedText(info)
+	if t == "" || strings.HasPrefix(t, "$") {
+		return false
+	}
+	return tr.open || xmlLooseLineRE.MatchString(t)
+}
+
+// matchXMLContinuation reports whether the paragraph continues an open XML/DTD
+// block. On top of matchXMLLine, an element left open (depth > 0) absorbs
+// plain text lines: element content regularly spills onto its own paragraph
+// (e.g. the <xs:documentation> text of TS 24.423 clause 6.4).
+func matchXMLContinuation(info paragraphInfo, tr *xmlLineTracker) bool {
+	t := xmlTrimmedText(info)
+	if t == "" || strings.HasPrefix(t, "$") {
+		return false
+	}
+	return tr.open || tr.depth > 0 || xmlLooseLineRE.MatchString(t)
+}
+
+// xmlLineTracker tracks parse state across the captured lines of a block:
+// whether the last line left a construct unterminated — a tag whose
+// attributes spill onto the next paragraph (seen in TS 38.508-1) or a comment
+// spanning paragraphs — and the element nesting depth, so that element text
+// content on its own paragraph stays inside the fence. While open, the block
+// absorbs lines that do not themselves look like XML.
+type xmlLineTracker struct {
+	open      bool
+	inComment bool
+	depth     int    // element nesting depth of the captured lines
+	pending   string // unterminated tag text carried over from earlier lines
+}
+
+// observe updates the tracker after line has been captured into the block.
+func (t *xmlLineTracker) observe(line string) {
+	rest := line
+	if t.inComment {
+		loc := xmlCommentCloseRE.FindStringIndex(rest)
+		if loc == nil {
+			t.open = true
+			return
+		}
+		t.inComment = false
+		rest = rest[loc[1]:]
+	}
+	if t.pending != "" {
+		i := strings.IndexByte(rest, '>')
+		if i < 0 {
+			t.pending += rest
+			t.open = true
+			return
+		}
+		t.observeTag(t.pending + rest[:i+1])
+		t.pending = ""
+		rest = rest[i+1:]
+	}
+	for {
+		i := strings.IndexByte(rest, '<')
+		if i < 0 {
+			break
+		}
+		rest = rest[i:]
+		if loc := xmlCommentOpenRE.FindStringIndex(rest); loc != nil && loc[0] == 0 {
+			end := xmlCommentCloseRE.FindStringIndex(rest[loc[1]:])
+			if end == nil {
+				t.inComment = true
+				t.open = true
+				return
+			}
+			rest = rest[loc[1]+end[1]:]
+			continue
+		}
+		j := strings.IndexByte(rest, '>')
+		if j < 0 {
+			t.pending = rest
+			t.open = true
+			return
+		}
+		t.observeTag(rest[:j+1])
+		rest = rest[j+1:]
+	}
+	t.open = false
+}
+
+// observeTag adjusts the element depth for one complete "<…>" tag.
+// Declarations, processing instructions, comments, self-closing tags and
+// anything unrecognizable leave it unchanged; the mangled "< name>" spelling
+// (TS 31.220) counts like a well-formed tag.
+func (t *xmlLineTracker) observeTag(tag string) {
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(tag, "<"), ">"))
+	if inner == "" || inner[0] == '!' || inner[0] == '?' {
+		return
+	}
+	if strings.HasSuffix(inner, "/") {
+		return
+	}
+	if inner[0] == '/' {
+		if t.depth > 0 {
+			t.depth--
+		}
+		return
+	}
+	c := inner[0]
+	if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+		t.depth++
+	}
+}

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -1,0 +1,376 @@
+package docx
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXMLLineRegex(t *testing.T) {
+	tests := []struct {
+		text      string
+		strong    bool
+		candidate bool
+	}{
+		// Strong openers: never seen in prose, start a block by themselves.
+		{`<?xml version="1.0" encoding="UTF-8"?>`, true, true},
+		{`<?xml version="1.0"?>`, true, true},
+		{`<!DOCTYPE MgmtTree PUBLIC "-//OMA//DTD-DM-DDF 1.2//EN"`, true, false},
+		{`<!doctype html>`, true, false},
+		// Candidate openers: whole-line tag/comment/DTD markup ending in ">".
+		{`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">`, false, true},
+		{`<xcap-caps xmlns="urn:ietf:params:xml:ns:xcap-caps">`, false, true},
+		{`<Value>1</Value>`, false, true},
+		{`<!-- The IM CN subsystem XML body -->`, false, true},
+		{`<!- broken comment marker -->`, false, true},
+		{`<!— em-dash comment —>`, false, true},
+		{`<!ELEMENT MgmtTree (VerDTD, Node*)>`, false, true},
+		{`<!ATTLIST Node type CDATA #IMPLIED>`, false, true},
+		// Not openers: prose, references, Diameter AVP lines, ASN.1.
+		{`The <userid> element carries the user identity.`, false, false},
+		{`<userid> is defined in clause 7.`, false, false},
+		{`<xs:element name="alias"`, false, false}, // no trailing ">" — continuation only
+		{`< Session-Id >`, false, false},
+		{`-- ASN1START`, false, false},
+		{`Foo ::= SEQUENCE {`, false, false},
+		{``, false, false},
+	}
+	for _, tt := range tests {
+		info := paragraphInfo{Text: tt.text, Runs: []runInfo{{Text: tt.text}}}
+		if got := matchXMLStrongStart(info); got != tt.strong {
+			t.Errorf("strong start for %q = %v, want %v", tt.text, got, tt.strong)
+		}
+		if got := matchXMLCandidateStart(info); got != tt.candidate {
+			t.Errorf("candidate start for %q = %v, want %v", tt.text, got, tt.candidate)
+		}
+	}
+}
+
+func TestXMLLineTracker(t *testing.T) {
+	var tr xmlLineTracker
+	tr.observe(`<xs:element name="alias"`)
+	if !tr.open {
+		t.Error("expected tracker open after unterminated tag")
+	}
+	tr.observe(`type="xs:string">`)
+	if tr.open {
+		t.Error("expected tracker closed after the attribute continuation ends the tag")
+	}
+	tr.observe(`<!-- a comment spanning`)
+	if !tr.open || !tr.inComment {
+		t.Error("expected tracker open inside an unterminated comment")
+	}
+	tr.observe(`several paragraphs -->`)
+	if tr.open || tr.inComment {
+		t.Error("expected tracker closed after the comment ends")
+	}
+}
+
+// Element text content on its own paragraph (the <xs:documentation> text of
+// TS 24.423 clause 6.4) is absorbed while an element is open, and the fence
+// closes with the root element so trailing prose stays out.
+func TestParseSections_XMLElementContentSplit(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.4\tTemplate"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<xs:annotation><xs:documentation>Template of a`),
+		xmlTestPara(`Service XML Schema`),
+		xmlTestPara(`</xs:documentation></xs:annotation>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "Template of a\nService XML Schema\n</xs:documentation>") {
+		t.Errorf("expected the split element content inside the fence, got %q", content[0])
+	}
+	if content[1] != "Trailing prose." {
+		t.Errorf("expected trailing prose outside the fence, got %q", content[1])
+	}
+}
+
+func xmlTestPara(text string) bodyElement {
+	return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+		Text: text, Runs: []runInfo{{Text: text}},
+	}}
+}
+
+func xmlTestHeading(text string) bodyElement {
+	return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+		StyleID: "Heading1", Text: text, Runs: []runInfo{{Text: text}},
+	}}
+}
+
+// Unstyled XML schema paragraphs (the TS 29.163 annex F shape) become one
+// ```xml fence, with surrounding prose untouched.
+func TestParseSections_XMLBlockUnstyled(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("F.3\tXML schema"),
+		xmlTestPara("The following XML schema is used:"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">`),
+		xmlTestPara(`	<xs:element name="ims-3gpp"/>`),
+		{Tag: "p", Paragraph: paragraphInfo{}}, // blank paragraph → blank line
+		xmlTestPara(`<!- broken comment marker is still captured -->`),
+		xmlTestPara(`</xs:schema>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	want := "```xml\n" +
+		`<?xml version="1.0" encoding="UTF-8"?>` + "\n" +
+		`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` + "\n" +
+		"\t" + `<xs:element name="ims-3gpp"/>` + "\n" +
+		"\n" +
+		`<!- broken comment marker is still captured -->` + "\n" +
+		`</xs:schema>` + "\n" +
+		"```"
+	if len(content) != 3 {
+		t.Fatalf("expected prose + fence + prose, got %v", content)
+	}
+	if content[0] != "The following XML schema is used:" {
+		t.Errorf("expected leading prose intact, got %q", content[0])
+	}
+	if content[1] != want {
+		t.Errorf("expected xml fence %q, got %q", want, content[1])
+	}
+	if content[2] != "Trailing prose." {
+		t.Errorf("expected trailing prose intact, got %q", content[2])
+	}
+}
+
+// Two consecutive tag lines fence without an XML declaration (weak start),
+// and bold/italic runs (TS 24.423, TS 24.801) leave no markdown markers.
+func TestParseSections_XMLBoldRunsWeakStart(t *testing.T) {
+	boldPara := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text, Bold: true}},
+		}}
+	}
+	elements := []bodyElement{
+		xmlTestHeading("6.3\tXML sample"),
+		boldPara(`<xcap-caps xmlns="urn:ietf:params:xml:ns:xcap-caps">`),
+		boldPara(`<auids>`),
+		boldPara(`</auids>`),
+		boldPara(`</xcap-caps>`),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 {
+		t.Fatalf("expected exactly 1 content entry, got %v", sections[0].Content)
+	}
+	c := sections[0].Content[0]
+	if !strings.HasPrefix(c, "```xml\n") || !strings.HasSuffix(c, "\n```") {
+		t.Errorf("expected xml fence, got %q", c)
+	}
+	if strings.Contains(c, "**") {
+		t.Errorf("bold markers leaked into the fence: %q", c)
+	}
+	if !strings.Contains(c, "<auids>\n</auids>") {
+		t.Errorf("expected consecutive tag lines captured verbatim, got %q", c)
+	}
+}
+
+// A tag whose attributes spill onto the next paragraph (TS 38.508-1) is
+// absorbed until the tag closes.
+func TestParseSections_XMLAttributeContinuation(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("4.14\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<mcpttinfo xmlns="urn:3gpp:ns:mcpttInfo:1.0"`),
+		xmlTestPara(`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`),
+		xmlTestPara(`</mcpttinfo>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "<mcpttinfo xmlns=\"urn:3gpp:ns:mcpttInfo:1.0\"\nxmlns:xsi=") {
+		t.Errorf("expected the attribute continuation line inside the fence, got %q", content[0])
+	}
+}
+
+// A DOCTYPE with an internal subset (the OMA-DM DDF and TS 31.220 DTD shape)
+// fences from the DOCTYPE line through the "]>" close.
+func TestParseSections_XMLDoctypeInternalSubset(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("A.1\tDTD"),
+		xmlTestPara(`<!DOCTYPE MgmtTree [`),
+		xmlTestPara(`<!ELEMENT MgmtTree (VerDTD, Node*)>`),
+		xmlTestPara(`<!— em-dash mangled comment —>`),
+		xmlTestPara(`<!ATTLIST Node type CDATA #IMPLIED>`),
+		xmlTestPara(`]>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 || !strings.HasPrefix(content[0], "```xml\n") {
+		t.Fatalf("expected xml fence + prose, got %v", content)
+	}
+	for _, line := range []string{"<!DOCTYPE MgmtTree [", "<!ELEMENT", "<!— em-dash", "]>"} {
+		if !strings.Contains(content[0], line) {
+			t.Errorf("expected %q inside the fence, got %q", line, content[0])
+		}
+	}
+}
+
+// Prose that quotes an element on its own line never fences: a single
+// XML-looking paragraph is replayed as a normal paragraph.
+func TestParseSections_XMLProseReferenceNotFenced(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("1\tGeneral"),
+		xmlTestPara("The <userid> element carries the user identity."),
+		xmlTestPara(`<userid>`),
+		xmlTestPara("is encoded as a string."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	joined := strings.Join(sections[0].Content, "\n")
+	if strings.Contains(joined, "```") {
+		t.Errorf("expected no fence for prose references, got %v", sections[0].Content)
+	}
+	if len(sections[0].Content) != 3 {
+		t.Errorf("expected all 3 prose paragraphs preserved, got %v", sections[0].Content)
+	}
+}
+
+// A held opener candidate followed by a heading or table is replayed into the
+// section it belongs to, and an open block is flushed by both.
+func TestParseSections_XMLFlushedByHeadingAndTable(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("1\tFirst"),
+		xmlTestPara(`<pending-tag-before-heading>`),
+		xmlTestHeading("2\tSecond"),
+		xmlTestPara(`<?xml version="1.0"?>`),
+		xmlTestPara(`<body>`),
+		{Tag: "tbl", Table: tableInfo{Rows: []tableRow{{Cells: []tableCell{{Paras: []paragraphInfo{{Text: "cell", Runs: []runInfo{{Text: "cell"}}}}}}}}}},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 || strings.Contains(sections[0].Content[0], "```") {
+		t.Errorf("expected the abandoned candidate as plain paragraph in first section, got %v", sections[0].Content)
+	}
+	second := strings.Join(sections[1].Content, "\n")
+	if !strings.Contains(second, "```xml\n") || !strings.Contains(second, "cell") {
+		t.Errorf("expected xml fence flushed by table plus table content, got %v", sections[1].Content)
+	}
+	if strings.Index(second, "```xml") > strings.Index(second, "cell") {
+		t.Errorf("expected fence before table content, got %v", sections[1].Content)
+	}
+}
+
+// Code-styled XML paragraphs keep their existing bare ``` fence: content
+// detection must not retag the ~190 specs already fenced via style/font.
+func TestParseSections_XMLCodeStyledUnchanged(t *testing.T) {
+	codePara := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text, IsCode: true}}, IsCode: true,
+		}}
+	}
+	elements := []bodyElement{
+		xmlTestHeading("10.2.2.3\tXML schema"),
+		codePara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		codePara(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">`),
+		codePara(`</xs:schema>`),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 {
+		t.Fatalf("expected exactly 1 content entry, got %v", sections[0].Content)
+	}
+	c := sections[0].Content[0]
+	if !strings.HasPrefix(c, "```\n") {
+		t.Errorf("expected the pre-existing bare fence for code-styled XML, got %q", c)
+	}
+	if strings.HasPrefix(c, "```xml") {
+		t.Errorf("code-styled XML must not be retagged, got %q", c)
+	}
+}
+
+// An OMML math paragraph ($…$) and an image paragraph end an open block
+// instead of being swallowed into the fence.
+func TestParseSections_XMLNotSwallowingMathOrImages(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("1\tFirst"),
+		xmlTestPara(`<?xml version="1.0"?>`),
+		xmlTestPara(`<body>`),
+		xmlTestPara(`$x = y$`),
+		xmlTestPara(`<?xml version="1.0"?>`),
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text:   "",
+			Images: []imageRef{{RID: "rId1"}},
+			Runs:   []runInfo{{Image: &imageRef{RID: "rId1"}}},
+		}},
+		xmlTestPara("Trailing prose."),
+	}
+	relMap := map[string]string{"rId1": "media/image1.png"}
+	images := map[string]*EmbeddedImage{
+		"media/image1.png": {Name: "image1.png", MIMEType: "image/png"},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, relMap, images)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	joined := strings.Join(sections[0].Content, "\n")
+	if strings.Contains(joined, "```xml\n<?xml version=\"1.0\"?>\n<body>\n$x") {
+		t.Errorf("math paragraph swallowed into the fence: %v", sections[0].Content)
+	}
+	if !strings.Contains(joined, "$x = y$") {
+		t.Errorf("expected math paragraph preserved outside the fence, got %v", sections[0].Content)
+	}
+	if !strings.Contains(joined, "image://image1.png") {
+		t.Errorf("expected image placeholder preserved outside the fence, got %v", sections[0].Content)
+	}
+	if c := strings.Count(joined, "```xml"); c != 2 {
+		t.Errorf("expected 2 separate xml fences, got %d in %v", c, sections[0].Content)
+	}
+}
+
+// A candidate opener directly followed by a code-styled paragraph is
+// abandoned and the code block forms as before.
+func TestParseSections_XMLPendingAbandonedByCodePara(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("1\tFirst"),
+		xmlTestPara(`<single-tag-line>`),
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "yaml: sample", Runs: []runInfo{{Text: "yaml: sample"}}, IsCode: true,
+		}},
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected plain paragraph + bare fence, got %v", content)
+	}
+	if strings.Contains(content[0], "```") {
+		t.Errorf("expected abandoned candidate as plain paragraph, got %q", content[0])
+	}
+	if !strings.HasPrefix(content[1], "```\n") || !strings.Contains(content[1], "yaml: sample") {
+		t.Errorf("expected bare code fence after abandoned candidate, got %q", content[1])
+	}
+}

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -349,6 +349,48 @@ func TestParseSections_XMLNotSwallowingMathOrImages(t *testing.T) {
 	}
 }
 
+// An XML-looking but code-styled paragraph neither confirms a held opener
+// candidate nor continues an open block: code-styled XML keeps its bare
+// fence in both positions.
+func TestParseSections_XMLCodeStyledStopsPendingAndContinuation(t *testing.T) {
+	codePara := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text, IsCode: true}}, IsCode: true,
+		}}
+	}
+	elements := []bodyElement{
+		xmlTestHeading("1\tFirst"),
+		// Unstyled candidate followed by code-styled XML: no commit.
+		xmlTestPara(`<single-tag-line>`),
+		codePara(`<code-styled-tag>`),
+		xmlTestHeading("2\tSecond"),
+		// Open block ended by code-styled XML: fence flushes before it.
+		xmlTestPara(`<?xml version="1.0"?>`),
+		codePara(`<code-styled-tag>`),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	first := sections[0].Content
+	if len(first) != 2 || strings.Contains(first[0], "```") {
+		t.Fatalf("expected abandoned candidate as plain paragraph, got %v", first)
+	}
+	if !strings.HasPrefix(first[1], "```\n") || strings.HasPrefix(first[1], "```xml") {
+		t.Errorf("expected code-styled paragraph in a bare fence, got %q", first[1])
+	}
+	second := sections[1].Content
+	if len(second) != 2 {
+		t.Fatalf("expected xml fence + bare fence, got %v", second)
+	}
+	if !strings.HasPrefix(second[0], "```xml\n") || strings.Contains(second[0], "code-styled-tag") {
+		t.Errorf("expected xml fence without the code-styled line, got %q", second[0])
+	}
+	if !strings.HasPrefix(second[1], "```\n") || !strings.Contains(second[1], "<code-styled-tag>") {
+		t.Errorf("expected code-styled paragraph in a bare fence, got %q", second[1])
+	}
+}
+
 // A candidate opener directly followed by a code-styled paragraph is
 // abandoned and the code block forms as before.
 func TestParseSections_XMLPendingAbandonedByCodePara(t *testing.T) {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -52,8 +52,9 @@ const DefaultFileName = "versions.db"
 // are re-downloadable, so a wipe is cheaper than migrating. Bump it when the
 // stored content becomes incompatible — generation 2 unified the image
 // reference notation (![Figure](image://...) for every format), generation 3
-// fences Diameter command/AVP definitions (```diameter).
-const cacheSchemaVersion = 3
+// fences Diameter command/AVP definitions (```diameter), generation 4 fences
+// content-detected XML/DTD blocks (```xml).
+const cacheSchemaVersion = 4
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search


### PR DESCRIPTION
## Summary

Some specs write XML schemas, XML body examples and DTDs as plain body paragraphs with no code style or font (e.g. TS 29.163 F.3, the OMA-DM DDF annexes of TS 24.216/24.305, the DTDs of TS 31.220). They were emitted as separate prose paragraphs, so raw tags were eaten as HTML by Markdown renderers and bold/italic runs corrupted the markup (TS 24.423, TS 24.801). Like the Diameter definitions (#78), these blocks are now detected by content and emitted as ` ```xml ` fences, highlighted by Chroma's built-in XML lexer.

## Changes

- New `converter/docx/xmlblock.go`: an XML declaration or DOCTYPE starts a block on its own; ordinary tag/comment/DTD lines only in consecutive pairs, so prose quoting a single element like `<userid>` never fences
- Absorbs attribute continuation lines of an unterminated tag (TS 38.508-1), element text content on its own paragraph (TS 24.423), mangled comment openers (`<!-`, `<!—`) and DOCTYPE internal subsets
- Detection runs on raw paragraph text, before bold/italic markers are applied
- Paragraphs already fenced via code style or font are skipped — existing bare fences stay byte-identical
- Bumps the version cache generation so on-demand versions re-convert
- Updates the Code fences section of AGENTS.md

## Verification

Converted real archive files and compared section-by-section against `main`:

- Fenced as intended, with only the expected sections changing: TS 29.163 §F.3, TS 24.216/24.305 Annex A, TS 24.423 §6.3/§6.4, TS 31.220 §A.1/§B.1/§C.1 (+§F.2 improved), TS 24.516 §4.4, TS 38.508-1 §4.14, TS 29.228 Annex C, TS 24.801 §D.2.2.8
- No regression: TS 24.484, TS 29.364 and TS 24.237 output is byte-identical

`go build` / `go vet` / `gofmt -l` / `golangci-lint run` (v2.11.4) / `go test -race ./...` all pass.

## Note

**A database rebuild (`make build-db`) is required**: databases built before this change are incompatible with the compare normalization.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxF4mpmCY8roZQATq85UNa)_