### PR TITLE
feat(converter): fence SIP/SDP message examples by content detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,11 +138,22 @@ source documents, so they are detected by content (`::= < Diameter|AVP
 Header:` starts a block, AVP reference lines continue it). Monospace-styled
 paragraphs outside these two notations become bare ` ``` ` fences.
 
+SIP/RTSP message and SDP session-description examples are also detected by
+content (`converter/docx/sipblock.go`), since several specs write them as
+plain Normal-styled paragraphs: a SIP/RTSP request or status line — or a run
+of at least three SDP field lines (two when starting at `v=0`) — opens a
+block, message-shaped lines continue it, and the first paragraph that is
+neither ends it. These become bare ` ``` ` fences; paragraphs already claimed
+by a style-based path never enter this detection, so monospace-styled
+examples keep their existing output. An `EXAMPLE n:` label directly in front
+of a match is emitted as its own prose paragraph, and a leading list dash is
+dropped.
+
 The version cache stamps `PRAGMA user_version`
 (`versionstore.cacheSchemaVersion`); opening a cache from another generation
-wipes it. Databases built before the unified notation or the Diameter
-code-fence change are incompatible with the compare normalization —
-rebuild them (`make build-db`).
+wipes it. Databases built before the unified notation, the Diameter
+code-fence change or the SIP/SDP fencing change are incompatible with the
+compare normalization — rebuild them (`make build-db`).
 
 ### MCP Tools
 

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -324,13 +324,40 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 		diameterBuffer = nil
 	}
 
-	for _, elem := range elements {
+	// Accumulates SIP message and standalone SDP examples into one bare
+	// fence. Like the Diameter definitions, these carry no code style or
+	// font in several specs, so capture is content-based: a SIP
+	// request/status line or an SDP field-line run starts it, and the first
+	// paragraph that no longer looks like part of the message ends it (see
+	// sipblock.go).
+	var sipBuffer []string
+	inSIP := false
+	sipSDPOnly := false
+	flushSIP := func() {
+		inSIP = false
+		sipSDPOnly = false
+		if len(sipBuffer) == 0 || currentSection == nil {
+			sipBuffer = nil
+			return
+		}
+		// Trim trailing blank lines, including a soft line break at the end
+		// of the final absorbed paragraph.
+		body := strings.TrimRight(strings.Join(sipBuffer, "\n"), " \t\n")
+		if body != "" {
+			currentSection.Content = append(currentSection.Content,
+				"```\n"+body+"\n```")
+		}
+		sipBuffer = nil
+	}
+
+	for i, elem := range elements {
 		switch elem.Tag {
 		case "tbl":
 			// A table while capturing ASN.1 means a missing ASN1STOP; flush
 			// what was collected rather than swallowing the table.
 			flushASN1()
 			flushDiameter()
+			flushSIP()
 			flushCodeBlock()
 			html := tableToHTML(elem.Table, imageContext{relMap: relMap, images: images})
 			if html != "" && currentSection != nil {
@@ -356,6 +383,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				// flush so headings are never swallowed into a code block.
 				flushASN1()
 				flushDiameter()
+				flushSIP()
 				flushCodeBlock()
 				// Normalize text
 				text := strings.ReplaceAll(info.Text, "\u00a0", " ")
@@ -440,10 +468,30 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 				}
 				if matchASN1Marker(asn1StartRE, info) {
 					flushDiameter()
+					flushSIP()
 					flushCodeBlock()
 					inASN1 = true
 					asn1Buffer = append(asn1Buffer, codeLineText(info))
 					continue
+				}
+				if inSIP {
+					continues := sipBlockContinues(info, sipLastBufferedLine(sipBuffer))
+					if sipSDPOnly {
+						continues = sdpBlockContinues(info, sipLastBufferedLine(sipBuffer))
+					}
+					if continues {
+						if strings.TrimSpace(codeLineText(info)) == "" {
+							// Preserve blank lines inside a pending block;
+							// trailing ones are trimmed at flush.
+							sipBuffer = append(sipBuffer, "")
+						} else {
+							sipBuffer = append(sipBuffer, codeLineText(info))
+						}
+						continue
+					}
+					// First non-matching paragraph ends the block and is
+					// handled normally below.
+					flushSIP()
 				}
 				if inDiameter {
 					switch {
@@ -470,6 +518,26 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					continue
 				}
 				isCodePara := (info.IsCode || isCodeStyleName(styleName) || codeStyles[info.StyleID]) && len(info.Images) == 0
+				// Content-based SIP/SDP example detection applies only to
+				// paragraphs that no style-based path claims, so specs whose
+				// examples are monospace-styled keep their existing fenced
+				// output unchanged.
+				if !isCodePara && currentSection != nil && len(info.Images) == 0 && info.SkippedDiagramLabels == nil {
+					label, text, ok := sipExampleStart(info)
+					if ok {
+						inSIP = true
+					} else if label, text, ok = sdpExampleStart(elements, i); ok {
+						inSIP, sipSDPOnly = true, true
+					}
+					if ok {
+						flushCodeBlock()
+						if label != "" {
+							currentSection.Content = append(currentSection.Content, label)
+						}
+						sipBuffer = append(sipBuffer, text)
+						continue
+					}
+				}
 				switch {
 				case isCodePara && currentSection != nil:
 					// Append to the pending code block, preserving whitespace.
@@ -501,6 +569,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 
 	flushASN1()
 	flushDiameter()
+	flushSIP()
 	flushCodeBlock()
 
 	return sections

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -49,10 +49,11 @@ var (
 	sipStatusRE = regexp.MustCompile(`^` + sipDirectionPat + sipVersionPat + `[ \t]+\d{3}(?:[ \t]+[A-Z][A-Za-z-]*){0,4}[ \t]*$`)
 
 	// Header lines that continue a SIP message. A hyphenated field name
-	// ("Call-ID:", "Max-Forwards:70", "UC-Indicator=true;") is accepted
-	// generically; hyphen-less names are limited to well-known SIP headers
-	// so prose like "where:" or "NOTE:" ends the block.
-	sipHyphenHeaderRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)+[ \t]*[:=]`)
+	// ("Call-ID:", "Max-Forwards:70", "UC-Indicator=true;",
+	// "3GPP-QoE-Metrics:url=...") is accepted generically; hyphen-less names
+	// are limited to well-known SIP headers so prose like "where:" or
+	// "NOTE:" ends the block.
+	sipHyphenHeaderRE = regexp.MustCompile(`^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+[ \t]*[:=]`)
 	sipPlainHeaderRE  = regexp.MustCompile(`(?i)^(?:via|to|from|contact|cseq|route|path|require|supported|expires|event|accept|allow|authorization|privacy|reason|warning|server|unsupported|date|subject|priority|organization|rack|rseq|join|replaces|timestamp)[ \t]*:`)
 	// Compact-form header, one letter and a colon: "v:SIP/2.0/UDP A;...",
 	// "f:<sip:A>;tag=205847", "l:120" (TS 23.700-19).

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -1,0 +1,251 @@
+package docx
+
+// Content-based detection of SIP message and SDP session-description
+// examples. Several specs (e.g. TS 23.877, TS 23.850, TS 23.700-19) write
+// these examples as plain body paragraphs — Normal style, no code font —
+// so none of the style-based code paths fire and every line ends up as an
+// ordinary prose paragraph. Like the Diameter definitions, they are
+// recognized by their line syntax instead: a SIP request/status line or an
+// SDP field-line run opens a block, message-shaped lines continue it, and
+// the first paragraph that is neither ends it. Matched blocks become bare
+// ``` fences.
+//
+// Detection runs on the raw paragraph text (codeLineText), before any
+// bold/italic markers are applied — TS 23.700-19 styles entire SIP
+// messages in italics — and only on paragraphs that are not already
+// code-styled, so specs whose examples are monospace-styled (TS 24.228,
+// TS 24.337, ...) keep their existing fenced output byte-for-byte.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// sipMethodsPat lists the SIP request methods that may open an example
+// (RFC 3261 plus the standard extension methods used in 3GPP specs), and
+// the RTSP methods — the PSS specs (TS 26.234, TS 26.905) carry their SDP
+// examples inside RTSP exchanges of the exact same shape.
+const sipMethodsPat = `(?:INVITE|REGISTER|ACK|BYE|CANCEL|OPTIONS|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|REFER|UPDATE|PRACK|INFO|DESCRIBE|SETUP|PLAY|PAUSE|TEARDOWN|ANNOUNCE|RECORD|REDIRECT|GET_PARAMETER|SET_PARAMETER)`
+
+// sipVersionPat matches the protocol-version token ending a request line or
+// starting a status line.
+const sipVersionPat = `(?:SIP/2\.0|RTSP/1\.[01])`
+
+// sipDirectionPat matches an optional interchange direction prefix:
+// "S->C  RTSP/1.0 200 OK" (TS 26.234 clause 11.3).
+const sipDirectionPat = `(?:[SC][ \t]*->[ \t]*[SC][ \t]+)?`
+
+var (
+	// Full request line: "INVITE sip:B-Party;tgrp=CGR2@operator.net SIP/2.0".
+	// End-anchored so prose that merely mentions a method never matches.
+	sipRequestFullRE = regexp.MustCompile(`^` + sipDirectionPat + sipMethodsPat + `[ \t]+\S+[ \t]+` + sipVersionPat + `[ \t]*$`)
+	// Request line without the version token, as some older specs write it:
+	// "INVITE sip: A2EA2@Iputrannode2.operator.net" (TS 25.933). The whole
+	// line must be method + URI — trailing prose disqualifies it.
+	sipRequestURIRE = regexp.MustCompile(`^` + sipMethodsPat + `[ \t]+(?:sips?|tel|rtspu?):[ \t]*\S+[ \t]*$`)
+	// Status line: "SIP/2.0 100", "SIP/2.0 183 Session Progress". The reason
+	// phrase is limited to a few capitalized words so sentences like
+	// "SIP/2.0 200 OK is sent to the UE" stay prose.
+	sipStatusRE = regexp.MustCompile(`^` + sipDirectionPat + sipVersionPat + `[ \t]+\d{3}(?:[ \t]+[A-Z][A-Za-z-]*){0,4}[ \t]*$`)
+
+	// Header lines that continue a SIP message. A hyphenated field name
+	// ("Call-ID:", "Max-Forwards:70", "UC-Indicator=true;") is accepted
+	// generically; hyphen-less names are limited to well-known SIP headers
+	// so prose like "where:" or "NOTE:" ends the block.
+	sipHyphenHeaderRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)+[ \t]*[:=]`)
+	sipPlainHeaderRE  = regexp.MustCompile(`(?i)^(?:via|to|from|contact|cseq|route|path|require|supported|expires|event|accept|allow|authorization|privacy|reason|warning|server|unsupported|date|subject|priority|organization|rack|rseq|join|replaces|timestamp)[ \t]*:`)
+	// Compact-form header, one letter and a colon: "v:SIP/2.0/UDP A;...",
+	// "f:<sip:A>;tag=205847", "l:120" (TS 23.700-19).
+	sipCompactHeaderRE = regexp.MustCompile(`^[a-z]:`)
+
+	// One SDP field line. The type letter is restricted to the RFC 4566
+	// field set so prose equations ("x=y") never match.
+	sdpFieldLineRE = regexp.MustCompile(`^[abceikmoprstuvz]=`)
+	sdpVersionRE   = regexp.MustCompile(`^v=0[ \t]*$`)
+
+	// "EXAMPLE 1:<tab>v=0" (TS 26.234): a label immediately followed by the
+	// first line of the example, on the same line or after a soft line
+	// break. The label is emitted as its own prose paragraph before the
+	// fence.
+	sipExampleLabelRE = regexp.MustCompile(`(?i)^(example(?:[ \t\x{00a0}]+\d+)?[ \t\x{00a0}]*:)[ \t\x{00a0}\n]+`)
+	// "-<tab>INVITE sip:..." (TS 22.948): a list dash before the start line.
+	// The dash is list styling, not message content, and is dropped.
+	sipDashPrefixRE = regexp.MustCompile(`^\p{Pd}[ \t\x{00a0}]+`)
+)
+
+// sipNormalize returns the paragraph's raw text with NBSP normalized to a
+// space for matching (Go's \s and literal spaces do not match U+00A0).
+func sipNormalize(s string) string {
+	return strings.ReplaceAll(s, "\u00a0", " ")
+}
+
+// sipFirstLine returns the first line of a possibly multi-line paragraph
+// text (soft line breaks inside a paragraph become \n in run text).
+func sipFirstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// sipStartLine reports whether line is a SIP request or status line that
+// can open a message example.
+func sipStartLine(line string) bool {
+	line = strings.TrimSpace(line)
+	return sipRequestFullRE.MatchString(line) ||
+		sipRequestURIRE.MatchString(line) ||
+		sipStatusRE.MatchString(line)
+}
+
+// sipHeaderLine reports whether line looks like a SIP header field line.
+func sipHeaderLine(line string) bool {
+	return sipHyphenHeaderRE.MatchString(line) ||
+		sipPlainHeaderRE.MatchString(line) ||
+		sipCompactHeaderRE.MatchString(line)
+}
+
+// splitSIPExampleLabel splits an optional example prefix off the paragraph
+// text: an "EXAMPLE n:" label (returned so the caller can emit it as prose)
+// or a list dash (dropped). rest is the candidate message text.
+func splitSIPExampleLabel(text string) (label, rest string) {
+	if m := sipExampleLabelRE.FindStringSubmatchIndex(text); m != nil {
+		return text[m[2]:m[3]], text[m[1]:]
+	}
+	if loc := sipDashPrefixRE.FindStringIndex(text); loc != nil {
+		return "", text[loc[1]:]
+	}
+	return "", text
+}
+
+// sipLastBufferedLine returns the final line of the last buffered
+// paragraph, for the backslash-continuation check.
+func sipLastBufferedLine(buffer []string) string {
+	if len(buffer) == 0 {
+		return ""
+	}
+	last := buffer[len(buffer)-1]
+	if i := strings.LastIndexByte(last, '\n'); i >= 0 {
+		last = last[i+1:]
+	}
+	return last
+}
+
+// sdpFieldLine reports whether line is an SDP field line. A trailing
+// period marks a sentence, not a field value — prose enumerations of the
+// SDP field types ("v= (protocol version).", TS 23.700-19) must stay
+// prose, and no real field value ends with one.
+func sdpFieldLine(line string) bool {
+	return sdpFieldLineRE.MatchString(line) && !strings.HasSuffix(line, ".")
+}
+
+// sdpFieldLineCount counts the SDP field lines of a paragraph. allFields
+// reports whether every non-blank line is one (a line following a
+// backslash-continued line counts, e.g. the wrapped a=fmtp value in
+// TS 26.234 A.1).
+func sdpFieldLineCount(text string) (count int, allFields bool) {
+	prevContinued := false
+	for _, ln := range strings.Split(text, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		if !prevContinued && !sdpFieldLine(ln) {
+			return count, false
+		}
+		count++
+		prevContinued = strings.HasSuffix(ln, `\`)
+	}
+	return count, true
+}
+
+// sipExampleStart reports whether the paragraph opens a SIP message
+// example. text is the paragraph text to buffer (prefix stripped); label,
+// when non-empty, is an "EXAMPLE n:" label to emit as prose first.
+func sipExampleStart(info paragraphInfo) (label, text string, ok bool) {
+	label, rest := splitSIPExampleLabel(codeLineText(info))
+	if sipStartLine(sipFirstLine(sipNormalize(rest))) {
+		return label, rest, true
+	}
+	return "", "", false
+}
+
+// sdpExampleStart reports whether the paragraph at elements[idx] opens a
+// standalone SDP example. To keep isolated field-form templates in prose
+// ("m=<media> <port> <transport> <fmt list>", TS 23.207) from matching, an
+// example needs a run of at least three consecutive field lines — two when
+// it starts with "v=0" — counted across the paragraph itself and the
+// immediately following all-SDP paragraphs (blank paragraphs skipped).
+func sdpExampleStart(elements []bodyElement, idx int) (label, text string, ok bool) {
+	label, rest := splitSIPExampleLabel(codeLineText(elements[idx].Paragraph))
+	norm := sipNormalize(rest)
+	count, allFields := sdpFieldLineCount(norm)
+	if !allFields || count == 0 {
+		return "", "", false
+	}
+	need := 3
+	if sdpVersionRE.MatchString(strings.TrimSpace(sipFirstLine(norm))) {
+		need = 2
+	}
+	for j := idx + 1; count < need && j < len(elements); j++ {
+		if elements[j].Tag != "p" {
+			break
+		}
+		p := elements[j].Paragraph
+		if len(p.Images) > 0 || p.SkippedDiagramLabels != nil {
+			break
+		}
+		t := sipNormalize(codeLineText(p))
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		c, a := sdpFieldLineCount(t)
+		if !a {
+			break
+		}
+		count += c
+	}
+	if count < need {
+		return "", "", false
+	}
+	return label, rest, true
+}
+
+// sipBlockContinues reports whether the paragraph continues a SIP message
+// block: a blank line, another start line (back-to-back messages), a
+// header line, an SDP body line, or any line after a backslash-continued
+// one. Leading whitespace is ignored when matching — TS 23.700-19 indents
+// every message line with a tab — but indentation alone never continues a
+// block, since the surrounding prose is indented the same way.
+func sipBlockContinues(info paragraphInfo, lastLine string) bool {
+	if len(info.Images) > 0 || info.SkippedDiagramLabels != nil {
+		return false
+	}
+	t := sipNormalize(codeLineText(info))
+	if strings.TrimSpace(t) == "" {
+		return true
+	}
+	if strings.HasSuffix(strings.TrimSpace(lastLine), `\`) {
+		return true
+	}
+	line := strings.TrimSpace(sipFirstLine(t))
+	return sipStartLine(line) || sipHeaderLine(line) || sdpFieldLine(line)
+}
+
+// sdpBlockContinues reports whether the paragraph continues a standalone
+// SDP block: a blank line, further field lines, or any line after a
+// backslash-continued one. SIP headers deliberately do not continue an
+// SDP-only block.
+func sdpBlockContinues(info paragraphInfo, lastLine string) bool {
+	if len(info.Images) > 0 || info.SkippedDiagramLabels != nil {
+		return false
+	}
+	t := sipNormalize(codeLineText(info))
+	if strings.TrimSpace(t) == "" {
+		return true
+	}
+	if strings.HasSuffix(strings.TrimSpace(lastLine), `\`) {
+		return true
+	}
+	_, allFields := sdpFieldLineCount(t)
+	return allFields
+}

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -1,0 +1,469 @@
+package docx
+
+import (
+	"strings"
+	"testing"
+)
+
+func sipPara(text string) bodyElement {
+	return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+		Text: text, Runs: []runInfo{{Text: text}},
+	}}
+}
+
+func sipHeading(text string) bodyElement {
+	return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+		StyleID: "Heading1", Text: text, Runs: []runInfo{{Text: text}},
+	}}
+}
+
+func sipParse(elements []bodyElement) []*Section {
+	return parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+}
+
+func TestSIPStartLineRegex(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		// Request lines with the SIP-version token.
+		{"INVITE sip:B-Party;tgrp=CGR2;trunk-context=Realm6@operator.net SIP/2.0", true},
+		{"INVITE tel:+8613587654321 SIP/2.0", true},
+		{"INVITE sip:bob@example.net SIP/2.0", true},
+		{"REGISTER sip:registrar.home1.net SIP/2.0", true},
+		// Request line without the version token (TS 25.933), including a
+		// space after the URI scheme.
+		{"INVITE sip: A2EA2@Iputrannode2.operator.net", true},
+		{"INVITE sip:control@mrf.example.com;ccxml=http://server.example.com/conference.ccxml", true},
+		// Status lines.
+		{"SIP/2.0 100", true},
+		{"SIP/2.0 100 Trying", true},
+		{"SIP/2.0 183 Session Progress", true},
+		{"SIP/2.0 486 Busy Here", true},
+		// Prose that mentions SIP must not match.
+		{"The UE sends an INVITE request to the P-CSCF.", false},
+		{"INVITE sip:bob@example.com is then routed onwards", false},
+		{"SIP/2.0 200 OK is sent to the UE", false},
+		{"SIP/2.0 200 OK is sent to the UE.", false},
+		{"sends an INVITE request", false},
+		{"The SIP/2.0 protocol is used", false},
+		{"OPTIONS for deployment are discussed below", false},
+	}
+	for _, tt := range tests {
+		if got := sipStartLine(tt.line); got != tt.want {
+			t.Errorf("sipStartLine(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}
+
+// TS 25.933 style: full SIP message with SDP body, each line its own
+// Normal-styled paragraph, request line without a SIP-version token.
+func TestParseSections_SIPFullMessageBlock(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tExample message"),
+		sipPara("An example SIP Invite request could be represented as the following:"),
+		sipPara("INVITE sip: A2EA2@Iputrannode2.operator.net"),
+		sipPara("Via: SIP/2.0/SCTP 194.237.226.242:5062"),
+		sipPara("From: sip: A2EA1@iwf1.operator.net"),
+		sipPara("To: sip: A2EA2@Iputrannode2.operator.net"),
+		sipPara("Call-ID: <BIDD1>"),
+		sipPara("CSeq: 1 INVITE"),
+		sipPara("Content-type: application/sdp"),
+		sipPara("Content-length: 141"),
+		sipPara("v=0"),
+		sipPara("o= - <bidd1> 924526776692 IN IP4 194.237.226.242"),
+		sipPara("s= -"),
+		sipPara("c=IN IP4 194.237.226.242"),
+		// Soft line break inside one paragraph.
+		sipPara("t=76554467889 0\nm=app 7094 UDP/IubFP 96"),
+		sipPara("a= fmtp: 96 41 38 16400 8550"),
+		sipPara("where:"),
+		sipPara("A2EA1 = E164 address of the ATM node"),
+	}
+	sections := sipParse(elements)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 4 {
+		t.Fatalf("expected intro, fence, and two trailing prose paragraphs, got %v", content)
+	}
+	want := "```\n" +
+		"INVITE sip: A2EA2@Iputrannode2.operator.net\n" +
+		"Via: SIP/2.0/SCTP 194.237.226.242:5062\n" +
+		"From: sip: A2EA1@iwf1.operator.net\n" +
+		"To: sip: A2EA2@Iputrannode2.operator.net\n" +
+		"Call-ID: <BIDD1>\n" +
+		"CSeq: 1 INVITE\n" +
+		"Content-type: application/sdp\n" +
+		"Content-length: 141\n" +
+		"v=0\n" +
+		"o= - <bidd1> 924526776692 IN IP4 194.237.226.242\n" +
+		"s= -\n" +
+		"c=IN IP4 194.237.226.242\n" +
+		"t=76554467889 0\nm=app 7094 UDP/IubFP 96\n" +
+		"a= fmtp: 96 41 38 16400 8550\n" +
+		"```"
+	if content[1] != want {
+		t.Errorf("expected verbatim SIP fence %q, got %q", want, content[1])
+	}
+	if content[2] != "where:" {
+		t.Errorf("expected prose to resume at %q, got %q", "where:", content[2])
+	}
+}
+
+// TS 23.850 style: a request line with nothing else, ended by prose.
+func TestParseSections_SIPRequestLineOnly(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tRouting"),
+		sipPara("For example as follows:"),
+		sipPara("INVITE sip:B-Party;tgrp=CGR2;trunk-context=Realm6@operator.net SIP/2.0"),
+		sipPara("Table 5.3.3.2-1"),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected prose, fence, prose, got %v", content)
+	}
+	want := "```\nINVITE sip:B-Party;tgrp=CGR2;trunk-context=Realm6@operator.net SIP/2.0\n```"
+	if content[1] != want {
+		t.Errorf("expected single-line fence %q, got %q", want, content[1])
+	}
+}
+
+// TS 23.700-19 style: request and status messages styled bold/italic, with
+// compact-form headers and an SDP body, ended by an Editor's note.
+func TestParseSections_SIPCompactHeadersAndEmphasis(t *testing.T) {
+	emphaticPara := func(runs ...runInfo) bodyElement {
+		var full []string
+		for _, r := range runs {
+			full = append(full, r.Text)
+		}
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: strings.Join(full, ""), Runs: runs,
+		}}
+	}
+	elements := []bodyElement{
+		sipHeading("1\tMobile originating"),
+		sipPara("The UE sends SIP INVITE with SDP offer to the P-CSCF."),
+		emphaticPara(runInfo{Text: "INVITE", Bold: true, Italic: true}, runInfo{Text: " tel:+8613587654321 SIP/2.0", Italic: true}),
+		emphaticPara(runInfo{Text: "v:SIP/2.0/UDP A;branch=z9hG4bK122456", Italic: true}),
+		emphaticPara(runInfo{Text: "f:<sip:A>;tag=205847", Italic: true}),
+		emphaticPara(runInfo{Text: "CSeq:81 INVITE", Italic: true}),
+		emphaticPara(runInfo{Text: "Max-Forwards:70", Italic: true}),
+		emphaticPara(runInfo{Text: "l:120", Italic: true}),
+		emphaticPara(runInfo{Text: "v=0", Italic: true}),
+		emphaticPara(runInfo{Text: "m=audio 49155 RTP/AVP 0 8", Italic: true}),
+		sipPara("The P-CSCF sends SIP 100 to the UE."),
+		emphaticPara(runInfo{Text: "SIP/2.0", Italic: true}, runInfo{Text: " 100", Bold: true, Italic: true}),
+		emphaticPara(runInfo{Text: "i:a9gH", Italic: true}),
+		sipPara("Editor's note:\tWhether SIP 100 can be omitted is FFS."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 5 {
+		t.Fatalf("expected prose, fence, prose, fence, prose, got %v", content)
+	}
+	wantFirst := "```\n" +
+		"INVITE tel:+8613587654321 SIP/2.0\n" +
+		"v:SIP/2.0/UDP A;branch=z9hG4bK122456\n" +
+		"f:<sip:A>;tag=205847\n" +
+		"CSeq:81 INVITE\n" +
+		"Max-Forwards:70\n" +
+		"l:120\n" +
+		"v=0\n" +
+		"m=audio 49155 RTP/AVP 0 8\n" +
+		"```"
+	if content[1] != wantFirst {
+		t.Errorf("expected INVITE fence without emphasis markers %q, got %q", wantFirst, content[1])
+	}
+	wantSecond := "```\nSIP/2.0 100\ni:a9gH\n```"
+	if content[3] != wantSecond {
+		t.Errorf("expected status fence %q, got %q", wantSecond, content[3])
+	}
+	if !strings.HasPrefix(content[4], "Editor's note:") {
+		t.Errorf("expected Editor's note to stay prose, got %q", content[4])
+	}
+}
+
+// TS 22.948 style: a list dash before the request line. The dash is
+// styling, not message content, and the next dashed list item stays prose.
+func TestParseSections_SIPDashPrefixedRequestLine(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tRe-use of W3C conferencing capabilities"),
+		sipPara("CCXML can be invoked using SIP in IMS networks. For example:"),
+		sipPara("-\tINVITE sip:control@mrf.example.com;ccxml=http://server.example.com/conference.ccxml"),
+		sipPara("-\tSIP/2.0\tThis allows application servers to use CCXML in IMS network."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected prose, fence, prose, got %v", content)
+	}
+	want := "```\nINVITE sip:control@mrf.example.com;ccxml=http://server.example.com/conference.ccxml\n```"
+	if content[1] != want {
+		t.Errorf("expected dash-stripped fence %q, got %q", want, content[1])
+	}
+	if !strings.Contains(content[2], "This allows application servers") {
+		t.Errorf("expected following list item to stay prose, got %q", content[2])
+	}
+}
+
+// TS 23.877 style: a standalone SDP description, one field line per
+// paragraph, no SIP message around it.
+func TestParseSections_SDPBlock(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tUni-directional codec and SDP"),
+		sipPara("One example for DSR on the uplink is shown below:"),
+		sipPara("v=0"),
+		sipPara("o=SESPhone 0 1 IN IP4 10.132.30.33"),
+		sipPara("s=asymmetric ses dsr session"),
+		sipPara("c=IN IP4 10.132.30.33"),
+		sipPara("t=0 0"),
+		sipPara("m=audio 9002 RTP/AVP 97"),
+		sipPara("a=rtpmap:97 AMR/8000"),
+		sipPara("a=recvonly"),
+		sipPara("This example above uses IP4 but can easily be extended to IP6 for IMS."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected prose, fence, prose, got %v", content)
+	}
+	want := "```\n" +
+		"v=0\n" +
+		"o=SESPhone 0 1 IN IP4 10.132.30.33\n" +
+		"s=asymmetric ses dsr session\n" +
+		"c=IN IP4 10.132.30.33\n" +
+		"t=0 0\n" +
+		"m=audio 9002 RTP/AVP 97\n" +
+		"a=rtpmap:97 AMR/8000\n" +
+		"a=recvonly\n" +
+		"```"
+	if content[1] != want {
+		t.Errorf("expected SDP fence %q, got %q", want, content[1])
+	}
+}
+
+// TS 26.234 A.1 style: "EXAMPLE 1:<tab>v=0" starts a multi-line SDP
+// paragraph, with a backslash-wrapped a=fmtp value whose continuation line
+// is not itself a field line.
+func TestParseSections_SDPExampleLabelAndWrappedLine(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tSDP"),
+		sipPara("The example below shows an SDP file:"),
+		sipPara("EXAMPLE 1:\tv=0\no=ghost 2890844526 2890842807 IN IP4 192.168.10.10\ns=3GPP Unicast SDP Example\nc=IN IP4 0.0.0.0\nt=0 0"),
+		bodyElement{Tag: "p", Paragraph: paragraphInfo{}}, // blank paragraph
+		sipPara("a=range:npt=0-45.678\nm=video 1024 RTP/AVP 96"),
+		sipPara("a=fmtp:96 packetization-mode=1; profile-level-id=64001e; \\"),
+		sipPara("sprop-parameter-sets= Z2QAHpWQC0PaAfyQ,aOuOoA=="),
+		sipPara("a=control:rtsp://mediaserver.com/movie.3gp/trackID=1"),
+		sipPara("The following examples show some usage of the \"alt\" attribute:"),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 4 {
+		t.Fatalf("expected prose, label, fence, prose, got %v", content)
+	}
+	if content[1] != "EXAMPLE 1:" {
+		t.Errorf("expected the example label as its own paragraph, got %q", content[1])
+	}
+	want := "```\n" +
+		"v=0\no=ghost 2890844526 2890842807 IN IP4 192.168.10.10\ns=3GPP Unicast SDP Example\nc=IN IP4 0.0.0.0\nt=0 0\n" +
+		"\n" +
+		"a=range:npt=0-45.678\nm=video 1024 RTP/AVP 96\n" +
+		"a=fmtp:96 packetization-mode=1; profile-level-id=64001e; \\\n" +
+		"sprop-parameter-sets= Z2QAHpWQC0PaAfyQ,aOuOoA==\n" +
+		"a=control:rtsp://mediaserver.com/movie.3gp/trackID=1\n" +
+		"```"
+	if content[2] != want {
+		t.Errorf("expected labeled SDP fence %q, got %q", want, content[2])
+	}
+}
+
+// TS 26.234 A.2.1 style: an SDP fragment that starts at an m-line rather
+// than v=0 still fences once three field lines run consecutively.
+func TestParseSections_SDPFragmentStartingAtMediaLine(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tExamples"),
+		sipPara("The equivalent SDP for alternative 1 (default) is:"),
+		sipPara("EXAMPLE 3:\tm=audio 0 RTP/AVP 97"),
+		sipPara("b=AS:12"),
+		sipPara("b=TIAS:8500"),
+		sipPara("a=rtpmap:97 AMR/8000"),
+		sipPara("Alternative 2 is based on the default alternative."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 4 {
+		t.Fatalf("expected prose, label, fence, prose, got %v", content)
+	}
+	if content[1] != "EXAMPLE 3:" {
+		t.Errorf("expected the example label as its own paragraph, got %q", content[1])
+	}
+	want := "```\nm=audio 0 RTP/AVP 97\nb=AS:12\nb=TIAS:8500\na=rtpmap:97 AMR/8000\n```"
+	if content[2] != want {
+		t.Errorf("expected SDP fragment fence %q, got %q", want, content[2])
+	}
+}
+
+// TS 23.207 Annex C prose: isolated SDP field-form templates separated by
+// prose must not fence, and neither must equations or short field runs.
+func TestParseSections_SDPFalsePositiveProse(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tMapping"),
+		sipPara("The media announcements field is of the form:"),
+		sipPara("m=<media> <port> <transport> <fmt list>"),
+		sipPara("The attributes field is of the form:"),
+		sipPara("a=<attribute><value>"),
+		sipPara("The connection data field is of the form:"),
+		sipPara("c=<network type> <address type> <connection address>"),
+		sipPara("An equation like x=y+1 stays prose."),
+		sipPara("v=0"),
+		sipPara("Only one field line follows nothing, so it stays prose too."),
+		// Prose enumerations of the SDP field types (TS 23.700-19) end each
+		// line with a period, which no real field value does.
+		sipPara("v= (protocol version)."),
+		sipPara("o= (originator and session identifier)."),
+		sipPara("s= (session name)."),
+		sipPara("c= (connection information)."),
+	}
+	sections := sipParse(elements)
+	for _, c := range sections[0].Content {
+		if strings.Contains(c, "```") {
+			t.Errorf("expected no fence in prose-only section, got %q", c)
+		}
+	}
+	if len(sections[0].Content) != len(elements)-1 {
+		t.Errorf("expected every paragraph kept as prose, got %v", sections[0].Content)
+	}
+}
+
+// TS 29.332 style: SDP lines inside an H.248 Local descriptor. The braces
+// stay prose; the field lines in between fence.
+func TestParseSections_SDPInsideH248Local(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tAMR and AMR-WB Codecs"),
+		sipPara("ABNF:"),
+		sipPara("Local {"),
+		sipPara("v=0"),
+		sipPara("c=IN IP4 $"),
+		sipPara("m=audio $ RTP/AVP 96"),
+		sipPara("a=rtpmap:96 AMR/8000"),
+		sipPara("}"),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 4 {
+		t.Fatalf("expected two prose paragraphs, fence, closing brace, got %v", content)
+	}
+	want := "```\nv=0\nc=IN IP4 $\nm=audio $ RTP/AVP 96\na=rtpmap:96 AMR/8000\n```"
+	if content[2] != want {
+		t.Errorf("expected SDP fence %q, got %q", want, content[2])
+	}
+}
+
+// TS 33.838 style: generic hyphenated headers and parameter continuation
+// lines ("UC-Indicator=true;") stay inside the message.
+func TestParseSections_SIPHyphenatedHeaderContinuation(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tPUCI information"),
+		sipPara("The UC Score could be incorporated into the SIP header as shown below:"),
+		sipPara("INVITE sip:bob@example.net SIP/2.0"),
+		sipPara("Via: SIP/2.0/UDP sip.example.net;branch=z9hG4bKnashds8;received=192.0.2.1"),
+		sipPara("UC-Score: 75 by sip.example.net;"),
+		sipPara("UC-Indicator=true;"),
+		sipPara("Max-Forwards: 70"),
+		sipPara("To: Bob <sip:bob@example.net>"),
+		sipPara("Content-Length: 142"),
+		sipPara("[... SDP excluded from this example...]"),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected prose, fence, trailing prose, got %v", content)
+	}
+	fence := content[1]
+	for _, line := range []string{"UC-Score: 75", "UC-Indicator=true;", "Content-Length: 142"} {
+		if !strings.Contains(fence, line) {
+			t.Errorf("expected %q inside the fence, got %q", line, fence)
+		}
+	}
+	if strings.Contains(fence, "SDP excluded") {
+		t.Errorf("expected the bracketed omission note to stay prose, got %q", fence)
+	}
+}
+
+// Monospace-styled SIP examples (TS 24.228, TS 24.337, ...) must keep
+// flowing through the style-based code path unchanged.
+func TestParseSections_SIPCodeStyledUnchanged(t *testing.T) {
+	codePara := func(text string) bodyElement {
+		return bodyElement{Tag: "p", Paragraph: paragraphInfo{
+			Text: text, Runs: []runInfo{{Text: text, IsCode: true}}, IsCode: true,
+		}}
+	}
+	elements := []bodyElement{
+		sipHeading("1\tSignalling flows"),
+		codePara("INVITE sip:bob@example.net SIP/2.0"),
+		codePara("Via: SIP/2.0/UDP pc33.example.com"),
+		codePara("v=0"),
+		sipPara("Trailing prose."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected one fence and one prose paragraph, got %v", content)
+	}
+	want := "```\nINVITE sip:bob@example.net SIP/2.0\nVia: SIP/2.0/UDP pc33.example.com\nv=0\n```"
+	if content[0] != want {
+		t.Errorf("expected the code-styled fence unchanged %q, got %q", want, content[0])
+	}
+}
+
+// A heading or table while capturing flushes the pending block.
+func TestParseSections_SIPFlushedByHeadingAndTable(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tFirst"),
+		sipPara("INVITE sip:bob@example.net SIP/2.0"),
+		sipPara("Via: SIP/2.0/UDP pc33.example.com"),
+		sipHeading("2\tSecond"),
+		sipPara("SIP/2.0 183 Session Progress"),
+		{Tag: "tbl", Table: tableInfo{Rows: []tableRow{{Cells: []tableCell{{Paras: []paragraphInfo{{Text: "cell", Runs: []runInfo{{Text: "cell"}}}}}}}}}},
+	}
+	sections := sipParse(elements)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if len(sections[0].Content) != 1 || !strings.HasPrefix(sections[0].Content[0], "```\n") {
+		t.Errorf("expected SIP fence flushed by heading in first section, got %v", sections[0].Content)
+	}
+	second := strings.Join(sections[1].Content, "\n")
+	if !strings.Contains(second, "```\nSIP/2.0 183 Session Progress\n```") || !strings.Contains(second, "cell") {
+		t.Errorf("expected SIP fence flushed by table plus table content, got %v", sections[1].Content)
+	}
+	if strings.Index(second, "```") > strings.Index(second, "cell") {
+		t.Errorf("expected fence before table content, got %v", sections[1].Content)
+	}
+}
+
+// A paragraph with an image never joins or continues a block.
+func TestParseSections_SIPImageParagraphEndsBlock(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tFirst"),
+		sipPara("INVITE sip:bob@example.net SIP/2.0"),
+		{Tag: "p", Paragraph: paragraphInfo{
+			Text: "v=0", Runs: []runInfo{{Text: "v=0"}},
+			Images: []imageRef{{RID: "rId1"}},
+		}},
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) == 0 || content[0] != "```\nINVITE sip:bob@example.net SIP/2.0\n```" {
+		t.Errorf("expected the image paragraph to end the fence, got %v", content)
+	}
+	for _, c := range content[1:] {
+		if strings.Contains(c, "```") {
+			t.Errorf("expected no second fence, got %q", c)
+		}
+	}
+}

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -394,6 +394,33 @@ func TestParseSections_SIPHyphenatedHeaderContinuation(t *testing.T) {
 	}
 }
 
+// TS 26.234 11.3.3 style: a continuation paragraph whose header value wraps
+// onto a soft-break line that matches no line rule on its own. Blocks are
+// absorbed at paragraph granularity — only the first line decides — so the
+// wrapped value stays inside the message instead of ending the block; prose
+// in these specs lives in its own paragraphs, never after a soft break in a
+// message paragraph.
+func TestParseSections_SIPWrappedHeaderContinuation(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tMetrics initiation with RTSP"),
+		sipPara("SETUP rtsp://example.com/foo/bar/baz.3gp/trackID=3 RTSP/1.0"),
+		sipPara("Cseq: 2"),
+		sipPara("3GPP-QoE-Metrics:url=\"rtsp://example.com/foo/bar/baz.3gp/trackID=3\"; metrics={Corruption_Duration };rate=10, url=\"rtsp://example.com/foo/bar/baz.3gp\";\nmetrics={Initial_Buffering_Duration|Rebuffering_Duration };rate=End"),
+		sipPara("In the above SETUP request, the client modifies the sending rate."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence and trailing prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "\nmetrics={Initial_Buffering_Duration|Rebuffering_Duration };rate=End\n") {
+		t.Errorf("expected the wrapped header value inside the fence, got %q", content[0])
+	}
+	if !strings.HasPrefix(content[1], "In the above SETUP request") {
+		t.Errorf("expected trailing prose after the fence, got %q", content[1])
+	}
+}
+
 // Monospace-styled SIP examples (TS 24.228, TS 24.337, ...) must keep
 // flowing through the style-based code path unchanged.
 func TestParseSections_SIPCodeStyledUnchanged(t *testing.T) {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -52,8 +52,9 @@ const DefaultFileName = "versions.db"
 // are re-downloadable, so a wipe is cheaper than migrating. Bump it when the
 // stored content becomes incompatible — generation 2 unified the image
 // reference notation (![Figure](image://...) for every format), generation 3
-// fences Diameter command/AVP definitions (```diameter).
-const cacheSchemaVersion = 3
+// fences Diameter command/AVP definitions (```diameter), generation 4 fences
+// SIP/RTSP message and SDP examples by content detection.
+const cacheSchemaVersion = 4
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search


### PR DESCRIPTION
## Summary

Several specs (TS 23.877, TS 23.850, TS 23.700-19, TS 25.933, TS 26.234, ...) write SIP/RTSP message and SDP session-description examples as plain Normal-styled paragraphs, so no style-based code path fired: every line became its own prose paragraph, and bold/italic runs corrupted some messages (e.g. `***INVITE*** *tel:... SIP/2.0*`).

- Detect examples by content in a new `converter/docx/sipblock.go`, following the Diameter approach: a SIP/RTSP request or status line — or a run of at least three SDP field lines (two when starting at `v=0`) — opens a block; header lines, field lines, blank lines and backslash-continued lines continue it; the first paragraph that is neither ends it
- Capture the raw run text so emphasis markers never corrupt messages, emit an `EXAMPLE n:` label as its own prose paragraph, drop a leading list dash, and emit the block as a bare ``` fence
- Paragraphs claimed by a style-based path never enter this detection, so monospace-styled examples (TS 24.228, TS 24.337, ...) keep their output byte-for-byte
- Bump `versionstore.cacheSchemaVersion` so on-demand cached versions re-convert

## Verification against real archive files

Converted 12 specs from the 3GPP archive with the old and new converter and diffed the full output:

- Fenced as intended: TS 25.933 §6.10.5.1.3.1.4.2.3 (full SIP+SDP message), TS 33.838 §10.1, TS 23.850 §5.3.3.2 (single request line), TS 22.948 §13.3 (dash-prefixed), TS 23.700-19 §6.12.2.2/§6.12.2.3 (emphasis-styled, compact headers), TS 23.877 §7.3, TS 23.207 Annex C, TS 26.905 §5.4.1, TS 23.140 Annex J, TS 29.332 §10.2.1 (SDP inside H.248 `Local { }`), TS 26.234 §A.1/§A.2.1/§5.8/§11.3.2/§11.3.3 (RTSP exchanges)
- No regression: TS 24.228 output is byte-identical; TS 26.234 §5.7 and TS 23.700-19 §6.17.1.2 (already fenced via code styles) unchanged; audited every diff line — no prose was removed from or swallowed into a fence
- False positives checked: SDP field-form templates (`m=<media> <port> ...`, TS 23.207), field-type enumerations (`v= (protocol version).`, TS 23.700-19), equations and prose mentioning SIP methods all stay prose

## Note

**The database must be rebuilt (`make build-db`)** for existing deployments to pick up the new fencing; the on-demand version cache re-converts automatically via the generation bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQQN92YWGosHPhdzctgR85)_