### PR TITLE
feat(web): syntax-highlight SIP/RTSP and SDP code fences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,13 +129,14 @@ serves an SVG placeholder for formats a browser cannot render (EMF/WMF).
 
 ### Code fences
 
-The converter emits three tagged fences: ` ```asn1 ` for ASN.1 modules
+The converter emits five tagged fences: ` ```asn1 ` for ASN.1 modules
 between the `-- ASN1START`/`-- ASN1STOP` markers, ` ```diameter ` for
-Diameter command/grouped-AVP definitions (RFC 6733 Command Code Format), and
+Diameter command/grouped-AVP definitions (RFC 6733 Command Code Format),
 ` ```xml ` for XML schemas, XML body examples and DTDs written as plain body
-paragraphs. The web viewer highlights the first two through custom Chroma
-lexers (`web/asn1lexer.go`, `web/diameterlexer.go`) and ` ```xml ` through
-Chroma's built-in XML lexer. Diameter definitions and XML/DTD blocks carry no
+paragraphs, and ` ```sip `/` ```sdp ` for SIP/RTSP messages and SDP session
+descriptions (see below). The web viewer highlights them through custom
+Chroma lexers (`web/asn1lexer.go`, `web/diameterlexer.go`,
+`web/siplexer.go`) and, for ` ```xml `, Chroma's built-in XML lexer. Diameter definitions and XML/DTD blocks carry no
 code style or font in the source documents, so both are detected by content:
 `::= < Diameter|AVP Header:` starts a Diameter block and AVP reference lines
 continue it; an XML declaration or DOCTYPE starts an XML block on its own,
@@ -150,17 +151,19 @@ content (`converter/docx/sipblock.go`), since several specs write them as
 plain Normal-styled paragraphs: a SIP/RTSP request or status line — or a run
 of at least three SDP field lines (two when starting at `v=0`) — opens a
 block, message-shaped lines continue it, and the first paragraph that is
-neither ends it. These become bare ` ``` ` fences; paragraphs already claimed
-by a style-based path never enter this detection, so monospace-styled
-examples keep their existing output. An `EXAMPLE n:` label directly in front
-of a match is emitted as its own prose paragraph, and a leading list dash is
-dropped.
+neither ends it. These become ` ```sip ` fences (` ```sdp ` for SDP-only
+blocks), highlighted by a shared custom Chroma lexer (`web/siplexer.go`,
+registered under the `sip`, `sdp` and `rtsp` aliases); paragraphs already
+claimed by a style-based path never enter this detection, so
+monospace-styled examples keep their existing bare ` ``` ` fences. An
+`EXAMPLE n:` label directly in front of a match is emitted as its own prose
+paragraph, and a leading list dash is dropped.
 
 The version cache stamps `PRAGMA user_version`
 (`versionstore.cacheSchemaVersion`); opening a cache from another generation
 wipes it. Databases built before the unified notation, the Diameter
-code-fence change, the SIP/SDP fencing change or the XML code-fence change
-are incompatible with the compare normalization — rebuild them
+code-fence change, the SIP/SDP fencing/tagging changes or the XML code-fence
+change are incompatible with the compare normalization — rebuild them
 (`make build-db`).
 
 ### MCP Tools

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -381,16 +381,21 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 		xmlTracker = xmlLineTracker{}
 	}
 
-	// Accumulates SIP message and standalone SDP examples into one bare
-	// fence. Like the Diameter definitions, these carry no code style or
-	// font in several specs, so capture is content-based: a SIP
-	// request/status line or an SDP field-line run starts it, and the first
-	// paragraph that no longer looks like part of the message ends it (see
-	// sipblock.go).
+	// Accumulates SIP message and standalone SDP examples into one tagged
+	// fence — ```sip for message blocks, ```sdp for SDP-only blocks, both
+	// highlighted by the web viewer's SIP lexer (web/siplexer.go). Like the
+	// Diameter definitions, these carry no code style or font in several
+	// specs, so capture is content-based: a SIP request/status line or an
+	// SDP field-line run starts it, and the first paragraph that no longer
+	// looks like part of the message ends it (see sipblock.go).
 	var sipBuffer []string
 	inSIP := false
 	sipSDPOnly := false
 	flushSIP := func() {
+		tag := "sip"
+		if sipSDPOnly {
+			tag = "sdp"
+		}
 		inSIP = false
 		sipSDPOnly = false
 		if len(sipBuffer) == 0 || currentSection == nil {
@@ -402,7 +407,7 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 		body := strings.TrimRight(strings.Join(sipBuffer, "\n"), " \t\n")
 		if body != "" {
 			currentSection.Content = append(currentSection.Content,
-				"```\n"+body+"\n```")
+				"```"+tag+"\n"+body+"\n```")
 		}
 		sipBuffer = nil
 	}

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -7,8 +7,8 @@ package docx
 // ordinary prose paragraph. Like the Diameter definitions, they are
 // recognized by their line syntax instead: a SIP request/status line or an
 // SDP field-line run opens a block, message-shaped lines continue it, and
-// the first paragraph that is neither ends it. Matched blocks become bare
-// ``` fences.
+// the first paragraph that is neither ends it. Matched blocks become ```sip
+// fences (```sdp for SDP-only blocks), highlighted by web/siplexer.go.
 //
 // Detection runs on the raw paragraph text (codeLineText), before any
 // bold/italic markers are applied — TS 23.700-19 styles entire SIP

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -88,7 +88,7 @@ func TestParseSections_SIPFullMessageBlock(t *testing.T) {
 	if len(content) != 4 {
 		t.Fatalf("expected intro, fence, and two trailing prose paragraphs, got %v", content)
 	}
-	want := "```\n" +
+	want := "```sip\n" +
 		"INVITE sip: A2EA2@Iputrannode2.operator.net\n" +
 		"Via: SIP/2.0/SCTP 194.237.226.242:5062\n" +
 		"From: sip: A2EA1@iwf1.operator.net\n" +
@@ -125,7 +125,7 @@ func TestParseSections_SIPRequestLineOnly(t *testing.T) {
 	if len(content) != 3 {
 		t.Fatalf("expected prose, fence, prose, got %v", content)
 	}
-	want := "```\nINVITE sip:B-Party;tgrp=CGR2;trunk-context=Realm6@operator.net SIP/2.0\n```"
+	want := "```sip\nINVITE sip:B-Party;tgrp=CGR2;trunk-context=Realm6@operator.net SIP/2.0\n```"
 	if content[1] != want {
 		t.Errorf("expected single-line fence %q, got %q", want, content[1])
 	}
@@ -164,7 +164,7 @@ func TestParseSections_SIPCompactHeadersAndEmphasis(t *testing.T) {
 	if len(content) != 5 {
 		t.Fatalf("expected prose, fence, prose, fence, prose, got %v", content)
 	}
-	wantFirst := "```\n" +
+	wantFirst := "```sip\n" +
 		"INVITE tel:+8613587654321 SIP/2.0\n" +
 		"v:SIP/2.0/UDP A;branch=z9hG4bK122456\n" +
 		"f:<sip:A>;tag=205847\n" +
@@ -177,7 +177,7 @@ func TestParseSections_SIPCompactHeadersAndEmphasis(t *testing.T) {
 	if content[1] != wantFirst {
 		t.Errorf("expected INVITE fence without emphasis markers %q, got %q", wantFirst, content[1])
 	}
-	wantSecond := "```\nSIP/2.0 100\ni:a9gH\n```"
+	wantSecond := "```sip\nSIP/2.0 100\ni:a9gH\n```"
 	if content[3] != wantSecond {
 		t.Errorf("expected status fence %q, got %q", wantSecond, content[3])
 	}
@@ -200,7 +200,7 @@ func TestParseSections_SIPDashPrefixedRequestLine(t *testing.T) {
 	if len(content) != 3 {
 		t.Fatalf("expected prose, fence, prose, got %v", content)
 	}
-	want := "```\nINVITE sip:control@mrf.example.com;ccxml=http://server.example.com/conference.ccxml\n```"
+	want := "```sip\nINVITE sip:control@mrf.example.com;ccxml=http://server.example.com/conference.ccxml\n```"
 	if content[1] != want {
 		t.Errorf("expected dash-stripped fence %q, got %q", want, content[1])
 	}
@@ -230,7 +230,7 @@ func TestParseSections_SDPBlock(t *testing.T) {
 	if len(content) != 3 {
 		t.Fatalf("expected prose, fence, prose, got %v", content)
 	}
-	want := "```\n" +
+	want := "```sdp\n" +
 		"v=0\n" +
 		"o=SESPhone 0 1 IN IP4 10.132.30.33\n" +
 		"s=asymmetric ses dsr session\n" +
@@ -268,7 +268,7 @@ func TestParseSections_SDPExampleLabelAndWrappedLine(t *testing.T) {
 	if content[1] != "EXAMPLE 1:" {
 		t.Errorf("expected the example label as its own paragraph, got %q", content[1])
 	}
-	want := "```\n" +
+	want := "```sdp\n" +
 		"v=0\no=ghost 2890844526 2890842807 IN IP4 192.168.10.10\ns=3GPP Unicast SDP Example\nc=IN IP4 0.0.0.0\nt=0 0\n" +
 		"\n" +
 		"a=range:npt=0-45.678\nm=video 1024 RTP/AVP 96\n" +
@@ -301,7 +301,7 @@ func TestParseSections_SDPFragmentStartingAtMediaLine(t *testing.T) {
 	if content[1] != "EXAMPLE 3:" {
 		t.Errorf("expected the example label as its own paragraph, got %q", content[1])
 	}
-	want := "```\nm=audio 0 RTP/AVP 97\nb=AS:12\nb=TIAS:8500\na=rtpmap:97 AMR/8000\n```"
+	want := "```sdp\nm=audio 0 RTP/AVP 97\nb=AS:12\nb=TIAS:8500\na=rtpmap:97 AMR/8000\n```"
 	if content[2] != want {
 		t.Errorf("expected SDP fragment fence %q, got %q", want, content[2])
 	}
@@ -357,7 +357,7 @@ func TestParseSections_SDPInsideH248Local(t *testing.T) {
 	if len(content) != 4 {
 		t.Fatalf("expected two prose paragraphs, fence, closing brace, got %v", content)
 	}
-	want := "```\nv=0\nc=IN IP4 $\nm=audio $ RTP/AVP 96\na=rtpmap:96 AMR/8000\n```"
+	want := "```sdp\nv=0\nc=IN IP4 $\nm=audio $ RTP/AVP 96\na=rtpmap:96 AMR/8000\n```"
 	if content[2] != want {
 		t.Errorf("expected SDP fence %q, got %q", want, content[2])
 	}
@@ -461,11 +461,11 @@ func TestParseSections_SIPFlushedByHeadingAndTable(t *testing.T) {
 	if len(sections) != 2 {
 		t.Fatalf("expected 2 sections, got %d", len(sections))
 	}
-	if len(sections[0].Content) != 1 || !strings.HasPrefix(sections[0].Content[0], "```\n") {
+	if len(sections[0].Content) != 1 || !strings.HasPrefix(sections[0].Content[0], "```sip\n") {
 		t.Errorf("expected SIP fence flushed by heading in first section, got %v", sections[0].Content)
 	}
 	second := strings.Join(sections[1].Content, "\n")
-	if !strings.Contains(second, "```\nSIP/2.0 183 Session Progress\n```") || !strings.Contains(second, "cell") {
+	if !strings.Contains(second, "```sip\nSIP/2.0 183 Session Progress\n```") || !strings.Contains(second, "cell") {
 		t.Errorf("expected SIP fence flushed by table plus table content, got %v", sections[1].Content)
 	}
 	if strings.Index(second, "```") > strings.Index(second, "cell") {
@@ -485,7 +485,7 @@ func TestParseSections_SIPImageParagraphEndsBlock(t *testing.T) {
 	}
 	sections := sipParse(elements)
 	content := sections[0].Content
-	if len(content) == 0 || content[0] != "```\nINVITE sip:bob@example.net SIP/2.0\n```" {
+	if len(content) == 0 || content[0] != "```sip\nINVITE sip:bob@example.net SIP/2.0\n```" {
 		t.Errorf("expected the image paragraph to end the fence, got %v", content)
 	}
 	for _, c := range content[1:] {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -54,8 +54,9 @@ const DefaultFileName = "versions.db"
 // reference notation (![Figure](image://...) for every format), generation 3
 // fences Diameter command/AVP definitions (```diameter), generation 4 fences
 // SIP/RTSP message and SDP examples by content detection, generation 5
-// fences content-detected XML/DTD blocks (```xml).
-const cacheSchemaVersion = 5
+// fences content-detected XML/DTD blocks (```xml), generation 6 tags the
+// SIP/SDP fences (```sip / ```sdp) for syntax highlighting.
+const cacheSchemaVersion = 6
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search

--- a/web/siplexer.go
+++ b/web/siplexer.go
@@ -1,0 +1,68 @@
+package web
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// The DOCX converter emits SIP/RTSP message examples as ```sip fences and
+// standalone SDP session descriptions as ```sdp fences; Chroma ships no
+// lexer for either notation, so this registers one under both aliases
+// (SDP lines also appear inside SIP message bodies, so one lexer covers
+// both). The existing light/dark .chroma stylesheets cover the emitted
+// token classes.
+func init() {
+	lexers.Register(chroma.MustNewLexer(
+		&chroma.Config{
+			Name:    "SIP",
+			Aliases: []string{"sip", "sdp", "rtsp"},
+		},
+		sipRules,
+	))
+}
+
+// sipRules covers SIP and RTSP messages as printed in 3GPP specifications —
+// request/status lines (optionally behind an interchange direction prefix
+// like "S->C"), "Name: value" header lines including the one-letter compact
+// forms, and SDP field lines ("v=0"). Header-name and SDP-field rules are
+// line-anchored so colons and equals signs inside header values never lex
+// as field names; methods, protocol versions and URIs are matched anywhere,
+// which also highlights them inside values (CSeq: 1 INVITE, Via: SIP/2.0/UDP).
+func sipRules() chroma.Rules {
+	rule := func(pattern string, typ chroma.TokenType, mutator chroma.Mutator) chroma.Rule {
+		return chroma.Rule{Pattern: pattern, Type: typ, Mutator: mutator}
+	}
+	byGroups := func(pattern string, types ...chroma.Emitter) chroma.Rule {
+		return chroma.Rule{Pattern: pattern, Type: chroma.ByGroups(types...)}
+	}
+	return chroma.Rules{
+		"root": {
+			// Interchange direction prefix: "S->C", "C->S" (TS 26.234).
+			byGroups(`^([ \t]*)([SC][ \t]*->[ \t]*[SC])\b`,
+				chroma.TextWhitespace, chroma.NameLabel),
+			// SDP field line: the type letter is the RFC 4566 field set, as
+			// in the converter's detection (converter/docx/sipblock.go).
+			byGroups(`^([ \t]*)([abceikmoprstuvz])(=)`,
+				chroma.TextWhitespace, chroma.NameAttribute, chroma.Operator),
+			// Header line, including compact forms ("v:", "f:", "l:") and
+			// digit-leading extension names ("3GPP-QoE-Metrics:").
+			byGroups(`^([ \t]*)([A-Za-z0-9][A-Za-z0-9-]*)(:)`,
+				chroma.TextWhitespace, chroma.NameAttribute, chroma.Punctuation),
+			// Protocol version, on status lines and inside Via values.
+			rule(`\b(?:SIP|RTSP)/\d+\.\d+`, chroma.KeywordConstant, nil),
+			// Request methods (SIP and RTSP), on request lines and inside
+			// values such as "CSeq: 1 INVITE".
+			rule(`\b(?:INVITE|REGISTER|ACK|BYE|CANCEL|OPTIONS|SUBSCRIBE|NOTIFY|PUBLISH|MESSAGE|REFER|UPDATE|PRACK|INFO|DESCRIBE|SETUP|PLAY|PAUSE|TEARDOWN|ANNOUNCE|RECORD|REDIRECT|GET_PARAMETER|SET_PARAMETER)\b`,
+				chroma.KeywordReserved, nil),
+			// URIs. The character class stops at delimiters that end a URI
+			// in headers (<>, quotes, commas, whitespace).
+			rule(`\b(?:sips?|tel|rtspu?|https?):[^\s<>",]+`, chroma.LiteralString, nil),
+			rule(`\b\d+\b`, chroma.LiteralNumber, nil),
+			rule(`[<>;,=/@]`, chroma.Punctuation, nil),
+			rule(`[ \t]+`, chroma.TextWhitespace, nil),
+			rule(`\n`, chroma.TextWhitespace, nil),
+			rule(`\w+`, chroma.Text, nil),
+			rule(`.`, chroma.Text, nil),
+		},
+	}
+}

--- a/web/siplexer_test.go
+++ b/web/siplexer_test.go
@@ -1,0 +1,124 @@
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+func TestSIPLexerRegistered(t *testing.T) {
+	for _, alias := range []string{"sip", "sdp", "rtsp"} {
+		if lexers.Get(alias) == nil {
+			t.Errorf("lexers.Get(%q) = nil, want the registered SIP lexer", alias)
+		}
+	}
+}
+
+func TestSIPLexerTokens(t *testing.T) {
+	src := `INVITE tel:+8613587654321 SIP/2.0
+Via: SIP/2.0/UDP pc33.example.com;branch=z9hG4bK776asdhds
+v:SIP/2.0/UDP A;branch=z9hG4bK122456
+3GPP-QoE-Metrics:url="rtsp://example.com/foo";rate=10
+CSeq: 314159 INVITE
+S->C 	RTSP/1.0 200 OK
+v=0
+m=audio 49155 RTP/AVP 0 8`
+
+	lexer := lexers.Get("sip")
+	it, err := lexer.Tokenise(nil, src)
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+
+	type tok struct {
+		typ   chroma.TokenType
+		value string
+	}
+	var tokens []tok
+	for _, tk := range it.Tokens() {
+		tokens = append(tokens, tok{tk.Type, tk.Value})
+	}
+
+	want := []tok{
+		// Request line: method, URI, version.
+		{chroma.KeywordReserved, "INVITE"},
+		{chroma.LiteralString, "tel:+8613587654321"},
+		{chroma.KeywordConstant, "SIP/2.0"},
+		// Header name, and the version inside the Via value.
+		{chroma.NameAttribute, "Via"},
+		{chroma.KeywordConstant, "SIP/2.0"},
+		// Compact-form header.
+		{chroma.NameAttribute, "v"},
+		{chroma.KeywordConstant, "SIP/2.0"},
+		// Digit-leading extension header, quoted URI in its value.
+		{chroma.NameAttribute, "3GPP-QoE-Metrics"},
+		{chroma.LiteralString, "rtsp://example.com/foo"},
+		// Method inside a header value.
+		{chroma.NameAttribute, "CSeq"},
+		{chroma.LiteralNumber, "314159"},
+		{chroma.KeywordReserved, "INVITE"},
+		// Direction prefix and status line.
+		{chroma.NameLabel, "S->C"},
+		{chroma.KeywordConstant, "RTSP/1.0"},
+		{chroma.LiteralNumber, "200"},
+		// SDP field lines.
+		{chroma.NameAttribute, "v"},
+		{chroma.Operator, "="},
+		{chroma.LiteralNumber, "0"},
+		{chroma.NameAttribute, "m"},
+	}
+	i := 0
+	for _, w := range want {
+		found := false
+		for ; i < len(tokens); i++ {
+			if tokens[i].value == w.value && tokens[i].typ == w.typ {
+				found = true
+				i++
+				break
+			}
+		}
+		if !found {
+			t.Errorf("token %q (%v) not found in expected order; got tokens: %v", w.value, w.typ, tokens)
+			break
+		}
+	}
+}
+
+// Colons and equals signs inside header values must not lex as header names
+// or SDP fields — those rules are line-anchored.
+func TestSIPLexerValueColonNotHeader(t *testing.T) {
+	lexer := lexers.Get("sip")
+	it, err := lexer.Tokenise(nil, "Via: SIP/2.0/UDP [5555::aaa:bbb:ccc:ddd];comp=sigcomp\n")
+	if err != nil {
+		t.Fatalf("Tokenise() error = %v", err)
+	}
+	var attrs []string
+	for _, tk := range it.Tokens() {
+		if tk.Type == chroma.NameAttribute {
+			attrs = append(attrs, tk.Value)
+		}
+	}
+	if len(attrs) != 1 || attrs[0] != "Via" {
+		t.Errorf("NameAttribute tokens = %v, want only [Via]", attrs)
+	}
+}
+
+func TestRenderMarkdownHighlightsSIPAndSDP(t *testing.T) {
+	for _, tt := range []struct {
+		content string
+		wantTok string
+	}{
+		{"```sip\nINVITE sip:bob@example.net SIP/2.0\nVia: SIP/2.0/UDP pc33.example.com\n```", ">INVITE</span>"},
+		{"```sdp\nv=0\no=- 4567 1234 IN IP4 1.1.1.1\n```", ">v</span>"},
+	} {
+		got := renderMarkdown(tt.content, "TS 24.228", "", nil)
+		if !strings.Contains(got, "chroma") {
+			t.Errorf("renderMarkdown(%q) = %q, want chroma-highlighted output", tt.content, got)
+		}
+		if !strings.Contains(got, tt.wantTok) {
+			t.Errorf("renderMarkdown(%q) = %q, want %q inside a token span", tt.content, got, tt.wantTok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #80: content-detected SIP/RTSP message and SDP example blocks were emitted as bare fences, so the web viewer rendered them plain while ASN.1, Diameter and XML fences are colored.

- The converter now tags the fences: ` ```sip ` for message blocks, ` ```sdp ` for SDP-only blocks
- A custom Chroma lexer (`web/siplexer.go`, registered under the `sip`, `sdp` and `rtsp` aliases) highlights both, modeled on the classification of Chroma's HTTP lexer: methods and protocol versions as keywords, URIs as strings, header names and SDP field letters as attributes, status codes as numbers. Header-name and SDP-field rules are line-anchored so colons/equals inside values (IPv6 hosts, `branch=` params) never lex as names. No new colors are defined — the existing light/dark `.chroma` stylesheets cover the emitted token classes
- `versionstore.cacheSchemaVersion` bumped to 6 so on-demand cached versions re-convert

## Verification

- Converted the 12-spec archive set (TS 22.948, 23.140, 23.207, 23.700-19, 23.850, 23.877, 24.228, 25.933, 26.234, 26.905, 29.332, 33.838) with main and this branch: the only output difference is the tag on the opening fences (57 tag insertions, zero other changes); TS 24.228 stays byte-identical
- Lexer unit tests cover request/status lines, compact headers (`v:`), digit-leading extension headers (`3GPP-QoE-Metrics:`), direction prefixes (`S->C`), SDP field lines, and the value-colon anchoring; a render test asserts both ` ```sip ` and ` ```sdp ` produce chroma token spans

## Note

**The database must be rebuilt (`make build-db`)** for existing deployments to pick up the tagged fences; the on-demand version cache re-converts automatically via the generation bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQQN92YWGosHPhdzctgR85)_