### PR TITLE
fix(web): keep settings popover inside the viewport on narrow screens

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -21,26 +21,35 @@
     const settingsPopover = document.getElementById('settings-popover');
 
     if (settingsToggle && settingsPopover) {
+        // Keep the popover inside the viewport: on narrow screens the
+        // navbar wraps and the gear no longer sits at the right edge, so
+        // right-aligning the popover to it can push it off the left edge.
+        // Measure and shift right just enough, without crossing the right
+        // edge either. Recomputed on resize (e.g. orientation change) while
+        // the popover is open, since the offset depends on the layout.
+        const clampToViewport = function () {
+            settingsPopover.style.right = '';
+            const margin = 8;
+            const rect = settingsPopover.getBoundingClientRect();
+            if (rect.left < margin) {
+                const shift = Math.min(margin - rect.left, window.innerWidth - margin - rect.right);
+                if (shift > 0) {
+                    settingsPopover.style.right = -shift + 'px';
+                }
+            }
+        };
         const setOpen = function (open) {
             settingsPopover.hidden = !open;
             settingsToggle.setAttribute('aria-expanded', String(open));
             if (open) {
-                // Keep the popover inside the viewport: on narrow screens
-                // the navbar wraps and the gear no longer sits at the right
-                // edge, so right-aligning the popover to it can push it off
-                // the left edge. Measure after showing and shift right just
-                // enough, without crossing the right edge either.
-                settingsPopover.style.right = '';
-                const margin = 8;
-                const rect = settingsPopover.getBoundingClientRect();
-                if (rect.left < margin) {
-                    const shift = Math.min(margin - rect.left, window.innerWidth - margin - rect.right);
-                    if (shift > 0) {
-                        settingsPopover.style.right = -shift + 'px';
-                    }
-                }
+                clampToViewport();
             }
         };
+        window.addEventListener('resize', function () {
+            if (!settingsPopover.hidden) {
+                clampToViewport();
+            }
+        });
         settingsToggle.addEventListener('click', function () {
             setOpen(settingsPopover.hidden);
         });

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -24,6 +24,22 @@
         const setOpen = function (open) {
             settingsPopover.hidden = !open;
             settingsToggle.setAttribute('aria-expanded', String(open));
+            if (open) {
+                // Keep the popover inside the viewport: on narrow screens
+                // the navbar wraps and the gear no longer sits at the right
+                // edge, so right-aligning the popover to it can push it off
+                // the left edge. Measure after showing and shift right just
+                // enough, without crossing the right edge either.
+                settingsPopover.style.right = '';
+                const margin = 8;
+                const rect = settingsPopover.getBoundingClientRect();
+                if (rect.left < margin) {
+                    const shift = Math.min(margin - rect.left, window.innerWidth - margin - rect.right);
+                    if (shift > 0) {
+                        settingsPopover.style.right = -shift + 'px';
+                    }
+                }
+            }
         };
         settingsToggle.addEventListener('click', function () {
             setOpen(settingsPopover.hidden);


### PR DESCRIPTION
## Summary

On mobile widths the navbar wraps, so the gear button no longer sits at the right edge of the viewport. The settings popover is right-aligned to the gear, which pushed it past the left edge (measured `left: -49px` at 375px width).

The popover is now measured when it opens and shifted right just enough to keep an 8px margin from the left edge, capped so it never crosses the right edge either. Desktop positioning is unchanged (still right-aligned to the gear). CSS-only anchoring can't handle this because the wrapped navbar's gear position isn't known statically.

## Verification

Playwright against a local server: popover box is fully inside the viewport at 375px and 320px (`left: 8`), and unchanged at 1100px; screenshot checked at 375px with all four options visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQQN92YWGosHPhdzctgR85)_