### PR TITLE
fix: four defects found by an automated review sweep

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -61,7 +61,19 @@ func parseParagraph(data []byte) paragraphInfo {
 
 // parseParagraphFromDecoder parses a w:p element from an existing decoder.
 // The start element has already been consumed; this reads through the matching end element.
-func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo {
+func parseParagraphFromDecoder(d *xml.Decoder, start xml.StartElement) paragraphInfo {
+	return parseParagraphFromDecoderDepth(d, start, 0)
+}
+
+// parseParagraphFromDecoderDepth is parseParagraphFromDecoder with the drawing
+// recursion depth threaded through. A paragraph can be reached from inside a
+// drawing (a w:txbxContent text box label), and that paragraph can contain
+// another drawing, so drawDepth must be carried across the whole
+// scanDrawingSubtreeDepth -> scanTextBoxLabels -> parseParagraphFromDecoderDepth
+// cycle; otherwise the counter restarts at 0 on every lap and maxDrawingDepth
+// bounds nothing. The depth travels on the stack rather than in package state so
+// the parser stays safe for concurrent use.
+func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDepth int) paragraphInfo {
 	var info paragraphInfo
 	var inPPr, inPPrRPr, inRPr, inR, inT bool
 	var paragraphCodeFont bool
@@ -105,7 +117,7 @@ func parseParagraphFromDecoder(d *xml.Decoder, _ xml.StartElement) paragraphInfo
 			// (see issue #25). scanDrawingSubtree consumes the whole subtree
 			// itself, so rebalance depth afterwards like the OMML case above.
 			if local == "group" || local == "AlternateContent" {
-				imgs, labels, hasGroup, hasRaster := scanDrawingSubtree(d, t)
+				imgs, labels, hasGroup, hasRaster := scanDrawingSubtreeDepth(d, t, drawDepth)
 				depth--
 				if local == "group" {
 					hasGroup = true
@@ -337,12 +349,14 @@ func scanDrawingSubtree(d *xml.Decoder, start xml.StartElement) (imgs []imageRef
 	return scanDrawingSubtreeDepth(d, start, 0)
 }
 
-// maxDrawingDepth bounds scanDrawingSubtree's recursion. Real diagrams nest a
+// maxDrawingDepth bounds scanDrawingSubtree's recursion, both the direct
+// shape-in-shape nesting and the indirect route back through a text box's
+// paragraphs (see parseParagraphFromDecoderDepth). Real diagrams nest a
 // handful of levels; anything deeper is corrupt or hostile input that would
 // otherwise exhaust the stack.
 const maxDrawingDepth = 100
 
-func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, depth int) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
+func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, drawDepth int) (imgs []imageRef, labels []string, hasGroup, hasRaster bool) {
 	for {
 		tok, err := d.Token()
 		if err != nil {
@@ -376,16 +390,24 @@ func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, depth int) (img
 				}
 				_ = d.Skip()
 			case "txbxContent":
-				labels = append(labels, scanTextBoxLabels(d)...)
+				// A text box's paragraphs can contain drawings of their own,
+				// which re-enter this function through scanTextBoxLabels; the
+				// depth has to be spent here too, or that cycle escapes the
+				// bound entirely.
+				if drawDepth >= maxDrawingDepth {
+					_ = d.Skip()
+					continue
+				}
+				labels = append(labels, scanTextBoxLabels(d, drawDepth+1)...)
 			default:
 				if t.Name.Local == "group" {
 					hasGroup = true
 				}
-				if depth >= maxDrawingDepth {
+				if drawDepth >= maxDrawingDepth {
 					_ = d.Skip()
 					continue
 				}
-				subImgs, subLabels, subHasGroup, subHasRaster := scanDrawingSubtreeDepth(d, t, depth+1)
+				subImgs, subLabels, subHasGroup, subHasRaster := scanDrawingSubtreeDepth(d, t, drawDepth+1)
 				imgs = append(imgs, subImgs...)
 				labels = append(labels, subLabels...)
 				hasGroup = hasGroup || subHasGroup
@@ -399,8 +421,10 @@ func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, depth int) (img
 
 // scanTextBoxLabels consumes a w:txbxContent element (the start element has
 // already been consumed by the caller) and returns the trimmed text of each
-// paragraph inside it, in document order.
-func scanTextBoxLabels(d *xml.Decoder) []string {
+// paragraph inside it, in document order. drawDepth is the enclosing drawing's
+// recursion depth, passed on to the paragraphs so a drawing nested inside a
+// text box keeps counting against maxDrawingDepth.
+func scanTextBoxLabels(d *xml.Decoder, drawDepth int) []string {
 	var labels []string
 	for {
 		tok, err := d.Token()
@@ -410,7 +434,7 @@ func scanTextBoxLabels(d *xml.Decoder) []string {
 		switch t := tok.(type) {
 		case xml.StartElement:
 			if t.Name.Local == "p" {
-				pInfo := parseParagraphFromDecoder(d, t)
+				pInfo := parseParagraphFromDecoderDepth(d, t, drawDepth)
 				if text := strings.TrimSpace(pInfo.Text); text != "" {
 					labels = append(labels, text)
 				}

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -2,6 +2,7 @@ package docx
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -638,6 +639,48 @@ func TestScanDrawingSubtree_DepthCap(t *testing.T) {
 	_, _, _, _ = scanDrawingSubtree(d, start)
 	if _, err := d.Token(); err == nil {
 		t.Error("expected the decoder to be fully consumed")
+	}
+}
+
+// TestScanDrawingSubtree_DepthCapAcrossTextBoxes verifies that the depth cap
+// also holds across the indirect recursion cycle
+// scanDrawingSubtreeDepth -> txbxContent -> scanTextBoxLabels ->
+// parseParagraphFromDecoderDepth -> scanDrawingSubtreeDepth. Before the fix
+// the paragraph parser restarted the counter at 0 on every lap, so nesting
+// drawings inside text boxes inside drawings recursed without bound: every one
+// of the labels below was collected, and a document with enough laps could
+// exhaust the goroutine stack.
+func TestScanDrawingSubtree_DepthCapAcrossTextBoxes(t *testing.T) {
+	// Every lap is a group that also holds a raster image, so its text-box
+	// labels are folded into the enclosing paragraph's own text; that makes the
+	// innermost label observable at the top level exactly when the parser
+	// descended all the way down.
+	laps := maxDrawingDepth * 3
+	var sb strings.Builder
+	sb.WriteString(`<w:p ` + wXMLNS + `><w:r><w:pict>`)
+	for i := range laps {
+		fmt.Fprintf(&sb, `<group><shape><imagedata r:id="rId%d"/></shape>`, i)
+		fmt.Fprintf(&sb, `<shape><textbox><txbxContent><w:p><w:r><w:t>lap%d </w:t></w:r><w:pict>`, i)
+	}
+	sb.WriteString(`<w:r><w:t>DEEPEST</w:t></w:r>`)
+	for range laps {
+		sb.WriteString(`</w:pict></w:p></txbxContent></textbox></shape></group>`)
+	}
+	sb.WriteString(`</w:pict></w:r></w:p>`)
+
+	info := parseParagraph([]byte(sb.String()))
+
+	// The outermost laps are still parsed normally...
+	if !strings.Contains(info.Text, "lap0 ") {
+		t.Errorf("expected the outermost text-box label in Text, got %q", info.Text)
+	}
+	// ...but the cap must stop the descent well before the bottom, otherwise
+	// the recursion is unbounded and a deeper document exhausts the stack.
+	if strings.Contains(info.Text, "DEEPEST") {
+		t.Error("depth cap not enforced across the txbxContent cycle: the parser recursed through all nesting levels")
+	}
+	if n := strings.Count(info.Text, "lap"); n > maxDrawingDepth {
+		t.Errorf("descended %d laps, want at most %d", n, maxDrawingDepth)
 	}
 }
 

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -133,6 +133,14 @@ func DownloadAndExtract(ctx context.Context, client *http.Client, spec *SpecVers
 					}
 				}
 			}
+			// The archive listed .docx entries but none of them could be
+			// written out (disk full, permission denied, corrupt member),
+			// leaving callers with nothing to parse. A partial extraction
+			// still counts as OK; an empty one must not.
+			if len(result.DocxFiles) == 0 {
+				result.Status = "FAILED"
+				return result, fmt.Errorf("extracted none of the %d .docx file(s) in the archive", len(docxFiles))
+			}
 			result.Status = "OK"
 			return result, nil
 		}

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -158,6 +158,63 @@ func TestDownloadAndExtract_NoDoc(t *testing.T) {
 	}
 }
 
+// TestDownloadAndExtract_AllDocxExtractionsFail verifies that a ZIP whose only
+// .docx entry cannot be extracted is not reported as OK. The entry name carries
+// a path-traversal component, so extractFile rejects it and no file lands in the
+// output directory.
+func TestDownloadAndExtract_AllDocxExtractionsFail(t *testing.T) {
+	zipBytes := makeRawZipEntry(t, "../evil.docx", []byte("pwned"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	}))
+	defer ts.Close()
+
+	outDir := t.TempDir()
+	spec := &SpecVersion{SpecID: "TS 99.003", URL: ts.URL + "/z.zip"}
+	result, err := DownloadAndExtract(context.Background(), ts.Client(), spec, outDir, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected an error when no .docx could be extracted")
+	}
+	if result.Status != "FAILED" {
+		t.Errorf("status = %q, want FAILED", result.Status)
+	}
+	if len(result.DocxFiles) != 0 {
+		t.Errorf("DocxFiles = %v, want none", result.DocxFiles)
+	}
+	if _, statErr := os.Stat(filepath.Join(outDir, "evil.docx")); !os.IsNotExist(statErr) {
+		t.Errorf("evil.docx should not exist: %v", statErr)
+	}
+}
+
+// TestDownloadAndExtract_OK verifies the success path is unchanged: an
+// extractable .docx yields OK, a nil error and the extracted path.
+func TestDownloadAndExtract_OK(t *testing.T) {
+	zipBytes := makeZipWithFile(t, "spec.docx", []byte("docx content"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	}))
+	defer ts.Close()
+
+	outDir := t.TempDir()
+	spec := &SpecVersion{SpecID: "TS 99.004", URL: ts.URL + "/ok.zip"}
+	result, err := DownloadAndExtract(context.Background(), ts.Client(), spec, outDir, 5*time.Second)
+	if err != nil {
+		t.Fatalf("DownloadAndExtract: %v", err)
+	}
+	if result.Status != "OK" {
+		t.Errorf("status = %q, want OK", result.Status)
+	}
+	want := []string{filepath.Join(outDir, "spec.docx")}
+	if len(result.DocxFiles) != 1 || result.DocxFiles[0] != want[0] {
+		t.Fatalf("DocxFiles = %v, want %v", result.DocxFiles, want)
+	}
+	if _, err := os.Stat(want[0]); err != nil {
+		t.Errorf("expected spec.docx on disk: %v", err)
+	}
+}
+
 // TestDownloadZip_TooLargeContentLength verifies the early rejection path when
 // the server advertises a Content-Length that exceeds maxZipSize.
 func TestDownloadZip_TooLargeContentLength(t *testing.T) {

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -41,7 +41,7 @@ func releaseFromDocxFilename(filename string) int {
 
 var (
 	yamlFilenameRE = regexp.MustCompile(`^TS(\d{2})(\d{3})_(.+)\.ya?ml$`)
-	yamlVersionRE  = regexp.MustCompile(`(?m)^\s+version:\s*['"]?([^'"\\n]+)`)
+	yamlVersionRE  = regexp.MustCompile(`(?m)^\s+version:\s*['"]?([^'"\n]+)`)
 )
 
 // Pipeline orchestrates the download-convert-store workflow.

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -597,3 +597,57 @@ func TestPipelineRun_AllFailed(t *testing.T) {
 		t.Error("expected an error when every spec failed")
 	}
 }
+
+// TestYAMLVersionRE checks that the OpenAPI version capture stops at the end of
+// the line. The character class must exclude a newline, and must not exclude
+// the letter "n" or a backslash.
+func TestYAMLVersionRE(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "unquoted followed by more yaml",
+			content: "info:\n  version: 1.2.3\n  title: Nnrf_NFManagement\n",
+			want:    "1.2.3",
+		},
+		{
+			name:    "single quoted",
+			content: "info:\n  version: '1.2.0-alpha.1'\n  title: Nnrf_NFManagement\n",
+			want:    "1.2.0-alpha.1",
+		},
+		{
+			name:    "double quoted",
+			content: "info:\n  version: \"1.2.0-alpha.1\"\n  title: Nnrf_NFManagement\n",
+			want:    "1.2.0-alpha.1",
+		},
+		{
+			name:    "unquoted containing the letter n",
+			content: "info:\n  version: 1.0.0-nightly\n  title: 3gpp-ue-context-transfer\n",
+			want:    "1.0.0-nightly",
+		},
+		{
+			name:    "unquoted on the last line without a trailing newline",
+			content: "info:\n  version: 1.0.0",
+			want:    "1.0.0",
+		},
+		{
+			name:    "crlf line ending",
+			content: "info:\r\n  version: 1.2.3\r\n  title: Nnrf_NFManagement\r\n",
+			want:    "1.2.3",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := yamlVersionRE.FindSubmatch([]byte(tc.content))
+			if m == nil {
+				t.Fatalf("no match for %q", tc.content)
+			}
+			// processOne applies the same TrimSpace to the capture.
+			if got := strings.TrimSpace(string(m[1])); got != tc.want {
+				t.Errorf("version = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/higebu/3gpp-mcp/internal/specver"
 	_ "modernc.org/sqlite"
@@ -1417,6 +1418,19 @@ func extractContext(content string, start, end int) string {
 		if idx := strings.LastIndexByte(content[end:ctxEnd], ' '); idx >= 0 {
 			ctxEnd = end + idx
 		}
+	}
+
+	// The window and the snapping above work on raw byte offsets, so both ends
+	// can still sit inside a multi-byte rune whenever no ASCII space falls in
+	// the window (CJK text, no-break spaces, long unbroken tokens). Pull each
+	// end onto the nearest rune boundary, inwards, before slicing. The match
+	// itself is rune-aligned, so neither loop can cross it and ctxStart <=
+	// ctxEnd is preserved.
+	for ctxStart < start && !utf8.RuneStart(content[ctxStart]) {
+		ctxStart++
+	}
+	for ctxEnd > end && ctxEnd < len(content) && !utf8.RuneStart(content[ctxEnd]) {
+		ctxEnd--
 	}
 
 	var b strings.Builder

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 const seedData = `
@@ -1740,4 +1741,75 @@ RRCSetup-IEs ::= SEQUENCE {');`)
 			t.Fatalf("expected 0 results, got %d", len(page.Results))
 		}
 	})
+}
+
+func TestExtractContext(t *testing.T) {
+	// The context window is a byte count, so text without ASCII spaces used to
+	// be sliced in the middle of a multi-byte rune.
+	cjkPad := strings.Repeat("日本語仕様書テキスト", 8)
+	// 3GPP DOCX files separate spec IDs with NO-BREAK SPACE (U+00A0), which the
+	// space-based snapping never sees.
+	nbspPad := strings.Repeat("あ\u00a0い", 20)
+	asciiPad := strings.Repeat("A", 60)
+
+	tests := []struct {
+		name    string
+		content string
+		match   string
+		want    string
+	}{
+		{
+			name:    "ascii snaps to word boundaries",
+			content: "The IMS registration procedure for the terminal is specified in TS 23.228 clause 5.2.1 and it also applies to roaming subscribers.",
+			match:   "TS 23.228",
+			want:    "...procedure for the terminal is specified in TS 23.228 clause 5.2.1 and it also applies to roaming...",
+		},
+		{
+			name:    "short content keeps no ellipsis",
+			content: "See TS 23.228 for details.",
+			match:   "TS 23.228",
+			want:    "See TS 23.228 for details.",
+		},
+		{
+			name:    "long unbroken ascii token is cut at the window",
+			content: asciiPad + "TS 23.228" + asciiPad,
+			match:   "TS 23.228",
+			want:    "..." + strings.Repeat("A", 50) + "TS 23.228" + strings.Repeat("A", 50) + "...",
+		},
+		{
+			name:    "cjk without spaces stays on rune boundaries",
+			content: cjkPad + "TS 23.228" + cjkPad,
+			match:   "TS 23.228",
+			want: "..." + "様書テキスト日本語仕様書テキスト" +
+				"TS 23.228" +
+				"日本語仕様書テキスト日本語仕様書" + "...",
+		},
+		{
+			name:    "no-break space separators stay on rune boundaries",
+			content: nbspPad + "TS\u00a023.228" + nbspPad,
+			match:   "TS\u00a023.228",
+			want: "..." + strings.Repeat("あ\u00a0い", 6) +
+				"TS\u00a023.228" +
+				strings.Repeat("あ\u00a0い", 6) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := strings.Index(tt.content, tt.match)
+			if start < 0 {
+				t.Fatalf("match %q not found in content", tt.match)
+			}
+			got := extractContext(tt.content, start, start+len(tt.match))
+			if !utf8.ValidString(got) {
+				t.Errorf("extractContext returned invalid UTF-8: %q", got)
+			}
+			if !strings.Contains(got, tt.match) {
+				t.Errorf("extractContext dropped the match: %q", got)
+			}
+			if got != tt.want {
+				t.Errorf("extractContext = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes four defects surfaced by a 100-run automated review sweep over the 20 largest source files. Each was verified against the code before being fixed, and each commit adds a regression test that fails on the current `main`.

## Changes

### `fix(pipeline): stop OpenAPI version capture at end of line`

`yamlVersionRE` was written as `[^'"\\n]` inside a **raw string literal**, so the regexp engine received a literal backslash and the letter `n` — not a newline. Go character classes match newlines by default, so the capture ran past the end of the line:

| input | before | after |
|---|---|---|
| `version: 1.2.3` + following YAML | `"1.2.3\n  title: N"` | `"1.2.3"` |
| `version: 1.0.0-nightly` | `"1.0.0-"` | `"1.0.0-nightly"` |
| `version: '1.2.0'` | `"1.2.0"` | `"1.2.0"` |

`strings.TrimSpace` at the call site only trims the ends, so the corrupted value reached `UpsertOpenAPI`. Only unquoted values were affected — a closing quote happened to stop the class. CRLF files were corrupted the same way.

### `fix(pipeline): do not report OK when no docx could be extracted`

`DownloadAndExtract` keyed its `OK` status on the `.docx` entries **listed** in the ZIP rather than the ones actually **written**. When every `extractFile` call failed (disk full, permission denied, path-traversal rejection) it logged each failure and still returned `OK` with a `nil` error and an empty `DocxFiles`, so callers counted a spec that produced nothing as a successful download. It now returns `FAILED` with an error; partial extraction still returns `OK`. `FAILED` was already a documented status value, so no caller needed changing.

### `fix(db): keep reference context on UTF-8 rune boundaries`

`extractContext` sliced at raw byte offsets and only moved them when an ASCII space fell inside the 50-byte window. CJK text, no-break-space separators and long unbroken tokens produced snippets containing a broken multi-byte sequence — contradicting the function's own doc comment. Both ends are now clamped onto the nearest rune boundary after the existing word-boundary snapping; the ellipsis and word-boundary behaviour are unchanged. This snippet is surfaced by `get_references` and the web viewer.

### `fix(docx): enforce drawing depth limit across textbox recursion`

`maxDrawingDepth` bounded `scanDrawingSubtree`, but the walk re-entered a paragraph through `w:txbxContent` via `scanTextBoxLabels` → `parseParagraphFromDecoder` → `scanDrawingSubtree`, which restarted the counter at 0. Drawings nested inside text boxes inside drawings therefore recursed without bound. The depth is now threaded through that cycle and the subtree is skipped once the limit is reached, matching the direct-recursion guard. Depth travels on the stack, so the parser stays safe for the conversion worker pool. The existing depth test only covered direct recursion and passed before this change.

## Verification

Run on the merged branch:

- `gofmt -l .` — no output
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all packages pass, including the network-backed integration tests

Each fix was also confirmed to fail before its change and pass after.