### PR TITLE
fix(docx): escape image names and keep run formatting in list items

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -547,16 +547,23 @@ func paragraphToMarkdown(info paragraphInfo, styleName string) string {
 		// level, which CommonMark/GFM recognizes as nested under both "- "
 		// and "1. " parent markers.
 		indent := strings.Repeat("    ", listStyleLevel(styleName)-1)
-		if strings.Contains(styleName, "Bullet") {
-			return indent + "- " + text
+		marker := "- " // default to bullet for unknown list styles
+		if !strings.Contains(styleName, "Bullet") && strings.Contains(styleName, "Number") {
+			marker = "1. "
 		}
-		if strings.Contains(styleName, "Number") {
-			return indent + "1. " + text
-		}
-		return indent + "- " + text // default to bullet for unknown list styles
+		// The item's runs go through the same renderer as a non-list
+		// paragraph's, so bold/italic/<sup>/<sub> survive inside list items;
+		// fall back to the plain text when the runs render to nothing (e.g. a
+		// paragraphInfo carrying Text but no Runs) so an item is never empty.
+		return indent + marker + runsOrText(info, text)
 	}
 
-	// Handle bold/italic at run level
+	return runsOrText(info, text)
+}
+
+// runsOrText renders info's runs to markdown, falling back to the given
+// already-trimmed plain text when they produce nothing.
+func runsOrText(info paragraphInfo, text string) string {
 	if len(info.Runs) > 0 {
 		if md := runsToMarkdown(info.Runs); md != "" {
 			return md

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -462,6 +462,120 @@ func TestParagraphToMarkdown(t *testing.T) {
 	}
 }
 
+// TestParagraphToMarkdown_ListRunFormatting pins that a list item's runs go
+// through the same renderer as a non-list paragraph's: bold, italic and
+// superscript/subscript formatting used to be dropped because the list branch
+// returned the flattened paragraph text before runsToMarkdown ever ran.
+func TestParagraphToMarkdown_ListRunFormatting(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      paragraphInfo
+		styleName string
+		want      string
+	}{
+		{
+			name: "bullet item keeps bold and italic runs",
+			info: paragraphInfo{
+				Text: "Bold and italic",
+				Runs: []runInfo{
+					{Text: "Bold", Bold: true},
+					{Text: " and "},
+					{Text: "italic", Italic: true},
+				},
+			},
+			styleName: "List Bullet",
+			want:      "- **Bold** and *italic*",
+		},
+		{
+			name: "numbered item keeps superscript and subscript runs",
+			info: paragraphInfo{
+				Text: "Pmax1 for H2O",
+				Runs: []runInfo{
+					{Text: "P"},
+					{Text: "max", VertAlign: "subscript"},
+					{Text: "1", VertAlign: "superscript"},
+					{Text: " for H"},
+					{Text: "2", VertAlign: "subscript"},
+					{Text: "O"},
+				},
+			},
+			styleName: "List Number",
+			want:      "1. P<sub>max</sub><sup>1</sup> for H<sub>2</sub>O",
+		},
+		{
+			name: "nested bullet item keeps indent and formatting",
+			info: paragraphInfo{
+				Text: "nested bold",
+				Runs: []runInfo{
+					{Text: "nested "},
+					{Text: "bold", Bold: true},
+				},
+			},
+			styleName: "List Bullet 2",
+			want:      "    - nested **bold**",
+		},
+		{
+			name: "nested numbered item keeps indent and formatting",
+			info: paragraphInfo{
+				Text: "both",
+				Runs: []runInfo{{Text: "both", Bold: true, Italic: true}},
+			},
+			styleName: "List Number 3",
+			want:      "        1. ***both***",
+		},
+		{
+			name:      "item with no runs falls back to plain text",
+			info:      paragraphInfo{Text: "fallback"},
+			styleName: "List Bullet",
+			want:      "- fallback",
+		},
+		{
+			name: "item whose runs render to nothing falls back to plain text",
+			info: paragraphInfo{
+				Text: "image caption",
+				Runs: []runInfo{{Image: &imageRef{RID: "rId1"}}},
+			},
+			styleName: "List Number 2",
+			want:      "    1. image caption",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paragraphToMarkdown(tt.info, tt.styleName)
+			if got != tt.want {
+				t.Errorf("paragraphToMarkdown = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParagraphToMarkdownBlocks_ListItemWithImage checks that rendering a list
+// item's runs through runsToMarkdown (which skips images) does not lose the
+// image: paragraphToMarkdownBlocks still emits the placeholder as its own
+// block after the list-item text.
+func TestParagraphToMarkdownBlocks_ListItemWithImage(t *testing.T) {
+	info := paragraphInfo{
+		Text: "see figure",
+		Runs: []runInfo{
+			{Text: "see ", Bold: true},
+			{Image: &imageRef{RID: "rId1"}},
+			{Text: "figure"},
+		},
+	}
+	got := paragraphToMarkdownBlocks(info, "List Bullet", func(ref imageRef) string {
+		return "![Figure](image://" + ref.RID + ")"
+	})
+	want := []string{"- **see** figure", "![Figure](image://rId1)"}
+	if len(got) != len(want) {
+		t.Fatalf("blocks = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("block %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestIsMonospaceFont(t *testing.T) {
 	cases := map[string]bool{
 		"Courier New":     true,

--- a/converter/docx/table.go
+++ b/converter/docx/table.go
@@ -307,8 +307,13 @@ func imageHTML(ctx imageContext, ref imageRef) string {
 	if ref.AltText != "" {
 		alt = ref.AltText
 	}
+	// img.Name comes from a DOCX zip entry name, so it must be escaped before
+	// it is interpolated into the double-quoted src attribute; otherwise a
+	// crafted filename could close the attribute and inject markup. dimSuffix
+	// and dimAttrs are formatted from integers and stay literal, keeping the
+	// "?w=..&h=.." notation byte-identical across conversion paths.
 	return fmt.Sprintf(`<img src="image://%s%s" alt="%s"%s>`,
-		img.Name, dimSuffix, htmlpkg.EscapeString(alt), dimAttrs)
+		htmlpkg.EscapeString(img.Name), dimSuffix, htmlpkg.EscapeString(alt), dimAttrs)
 }
 
 // extractTable parses a w:tbl XML element and returns its parsed structure.

--- a/converter/docx/table_test.go
+++ b/converter/docx/table_test.go
@@ -366,3 +366,51 @@ func TestTableToHTML_NonReadableImageInCell(t *testing.T) {
 		t.Errorf("expected <img> tag with alt=Figure for EMF cell image, got: %s", html)
 	}
 }
+
+// TestTableToHTML_ImageNameEscaped verifies that an image filename containing
+// HTML metacharacters cannot break out of the src attribute and inject extra
+// attributes or markup. The name comes from a DOCX zip entry, so a crafted
+// document must not be able to smuggle e.g. onerror= into the rendered tag
+// (the web viewer renders this HTML unescaped).
+func TestTableToHTML_ImageNameEscaped(t *testing.T) {
+	xml := `<w:tbl xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+		xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+		xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+		xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+		<w:tr><w:tc>
+			<w:p><w:r>
+				<w:drawing>
+					<wp:inline>
+						<wp:extent cx="952500" cy="952500"/>
+						<a:graphic><a:graphicData>
+							<a:blip r:embed="rId7"/>
+						</a:graphicData></a:graphic>
+					</wp:inline>
+				</w:drawing>
+			</w:r></w:p>
+		</w:tc></w:tr>
+	</w:tbl>`
+	info := extractTable([]byte(xml))
+	const evil = `x" onerror="alert(1)" data-<b>.png`
+	ctx := imageContext{
+		relMap: map[string]string{"rId7": "media/" + evil},
+		images: map[string]*EmbeddedImage{
+			"media/" + evil: {Name: evil, LLMReadable: true},
+		},
+	}
+	html := tableToHTML(info, ctx)
+	if strings.Contains(html, `onerror="`) {
+		t.Errorf("image name must not close src and inject attributes, got: %s", html)
+	}
+	if strings.Contains(html, `<b>`) {
+		t.Errorf("image name must not inject markup, got: %s", html)
+	}
+	if !strings.Contains(html, `&#34;`) || !strings.Contains(html, `&lt;b&gt;`) {
+		t.Errorf("expected image name to be HTML-escaped, got: %s", html)
+	}
+	// The dimension query string keeps its literal separators so the image
+	// reference notation stays byte-identical across conversion paths.
+	if !strings.Contains(html, `?w=100&h=100" alt="Figure" width="100" height="100">`) {
+		t.Errorf("expected unchanged dimension suffix/attrs, got: %s", html)
+	}
+}


### PR DESCRIPTION
Two defects in the DOCX converter, both confirmed against the code before being fixed. Each commit adds a regression test that fails on the current `main`.

## Changes

### `fix(docx): escape image name in generated img src attribute`

In `converter/docx/table.go`, the image-cell renderer escaped `alt` but interpolated `img.Name` raw into the `src` attribute right next to it:

```go
return fmt.Sprintf(``'&lt;img src="image://%s%s" alt="%s"%s&gt;'``,
    img.Name, dimSuffix, htmlpkg.EscapeString(alt), dimAttrs)
```

`img.Name` comes from `filepath.Base` of a DOCX zip entry, so a name containing `"` closes the attribute and lets arbitrary ones (`onerror=`, …) be injected. The markup is not escaped downstream either — `web/markdown.go` builds goldmark with `html.WithUnsafe()` and `web/handlers.go` wraps the result in `template.HTML`, both deliberately, so the fix belongs at the point where the attribute is built.

Scope notes:

- `converter/docx/parser.go` (`imagePlaceholder`) emits Markdown, not HTML, and `web/markdown.go` rebuilds that tag with `url.PathEscape` for `src`, so it was already safe and is unchanged.
- `dimSuffix` / `dimAttrs` are built only from `%d` of int fields, so no attacker-controlled bytes can reach them.
- The literal `&` in `?w=..&h=..` is intentionally left unescaped: turning it into `&amp;` would change the image-reference notation that AGENTS.md requires to be byte-identical across the prebuilt-build and `versionstore` fetch paths, forcing a cache schema bump and breaking `structdiff.NormalizeImageRefs` against existing databases. Existing tests pinning `?w=N&h=N` are unchanged.

### `fix(docx): keep run formatting in list items`

The list-item branch in `converter/docx/paragraph.go` returned early with the plain concatenated text, so `runsToMarkdown` — which sits after it — never ran for list items. Bold, italic, `<sup>`/`<sub>` and code runs inside a list item were flattened to plain text, unlike the same runs in a non-list paragraph.

List items now render through the same path, keeping the indent and the `- ` / `1. ` marker. The empty-runs fallback that the non-list path already had is shared via a small helper so an item is never rendered empty. Images in list items are emitted by `paragraphToMarkdownBlocks` as separate blocks and are unaffected; a test pins that.

## Investigated, deliberately not fixed

A third report — that the supersede cleanup in `db/db.go` only deletes rows of *other* versions, so re-importing the *same* version leaves rows for sections that disappeared upstream — is accurate and was reproduced. It is **not** fixed here, on purpose.

The cleanup is written that way because a multi-part spec calls `InsertSpecWithSectionsAndImages` once per DOCX **with the same version**; deleting same-version rows would make the second part wipe the first part's sections. Tracking "first insert for this (spec, version)" cannot fix it either, because `import` runs one DOCX per process, so a `make import FILE=part1.docx` / `FILE=part2.docx` sequence would hit exactly the same breakage across process boundaries. Distinguishing a re-import from a sibling part by section numbers is also unsound, since cover and body files legitimately share numbers such as Foreword and Scope.

The cost of leaving it is stale sections from a removed version lingering in search after a converter change alters section structure; the cost of getting the fix wrong is missing content in multi-part specs. A durable fix needs a schema column recording which source file a row came from, which is outside this change. The workaround is `make clean && make build-db` after a converter change that alters section structure — the same procedure AGENTS.md already documents for schema-incompatible rebuilds.

## Verification

On the merged branch:

- `gofmt -l .` — no output
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all packages pass

Both fixes were confirmed to fail before their change and pass after.

### Note on `converter/pipeline` test duration

`converter/pipeline` currently runs for about 600s, which is Go's default per-package test timeout, so a `go test -race ./...` run can fail there with a timeout rather than an assertion. This is unrelated to these changes — measured on this branch and on the base commit `41941d6`:

| | elapsed |
|---|---|
| base `41941d6` | 598.9s |
| this branch | 601.4s |

A 2.5s (0.4%) difference. With `-timeout 40m` both pass. The package is simply sitting on the default limit and its network-backed integration tests make it variable; worth raising the timeout in CI independently of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_015wuJ7wFdcWYPC4LvNKxcR9)_