### PR TITLE
fix: verified findings from the LLM review backlog

### DIFF
--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -557,6 +557,33 @@ complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download im
 	}
 }
 
+// finalizeWorkingCopy merges path's write-ahead log into the main file and
+// closes d, leaving a single self-contained file that can be renamed over the
+// live database.
+//
+// The sidecar files are only removed once the merge is known to have happened.
+// PRAGMA wal_checkpoint reports a blocked checkpoint in its result row rather
+// than as an error, so a checkpoint can leave the whole update sitting in the
+// WAL while both Exec and Close return nil; deleting the WAL at that point
+// discards every change the run just made. A clean close unlinks the WAL, so a
+// surviving non-empty one means the merge did not complete.
+func finalizeWorkingCopy(d *db.DB, path string) error {
+	checkpointErr := d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	closeErr := d.Close()
+	if checkpointErr != nil {
+		return fmt.Errorf("checkpoint working copy: %w", checkpointErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close working copy: %w", closeErr)
+	}
+	if fi, err := os.Stat(path + "-wal"); err == nil && fi.Size() > 0 {
+		return fmt.Errorf("working copy still has a %d-byte write-ahead log after checkpoint", fi.Size())
+	}
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+	return nil
+}
+
 func cmdUpdate(args []string) {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "SQLite database path")
@@ -685,10 +712,9 @@ func cmdUpdate(args []string) {
 	}
 
 	// Checkpoint WAL into the main file so the renamed DB is self-contained.
-	_ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
-	_ = d.Close()
-	_ = os.Remove(newPath + "-wal")
-	_ = os.Remove(newPath + "-shm")
+	if err := finalizeWorkingCopy(d, newPath); err != nil {
+		log.Fatalf("Failed to finalize working copy: %v\nThe updated database is left at %s; %s was not replaced.", err, newPath, *dbPath)
+	}
 
 	// Atomically replace the live database. The serve process retains its old
 	// inode until restarted; ExecStartPost in the systemd unit handles that.

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -606,7 +606,13 @@ func cmdUpdate(args []string) {
 		log.Fatalf("Failed to open database: %v", err)
 	}
 	currentResult, err := src.ListSpecs("", "", -1, 0)
-	if err != nil || len(currentResult.Specs) == 0 {
+	if err != nil {
+		// An unreadable database is not an empty one; telling the user to run
+		// 'build' would hide the real failure and still exit 0.
+		_ = src.Close()
+		log.Fatalf("Failed to read specs from %s: %v", *dbPath, err)
+	}
+	if len(currentResult.Specs) == 0 {
 		_ = src.Close()
 		fmt.Println("No specs in database. Use 'build' command first.")
 		return

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,8 @@ import (
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/higebu/3gpp-mcp/internal/testutil"
 	"github.com/higebu/3gpp-mcp/tools"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -924,4 +927,88 @@ func TestRunHTTPServer(t *testing.T) {
 			t.Error("expected an error for an unbindable address")
 		}
 	})
+}
+
+// seedWorkingCopy builds a WAL-mode database at path with enough rows to leave
+// a substantial write-ahead log behind.
+func seedWorkingCopy(t *testing.T, path string) *db.DB {
+	t.Helper()
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Exec("CREATE TABLE t(a)"); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 200 {
+		if err := d.Exec("INSERT INTO t VALUES (?)", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return d
+}
+
+func TestFinalizeWorkingCopy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "3gpp.db.new")
+	d := seedWorkingCopy(t, path)
+
+	if err := finalizeWorkingCopy(d, path); err != nil {
+		t.Fatalf("finalizeWorkingCopy: %v", err)
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Errorf("%s still exists after finalize (stat err %v)", sidecar, err)
+		}
+	}
+
+	// The rows have to survive in the main file on their own.
+	conn, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var n int
+	if err := conn.QueryRow("SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 200 {
+		t.Errorf("row count = %d, want 200", n)
+	}
+}
+
+// A checkpoint blocked by a concurrent reader reports "busy" in its result row,
+// not as an error: PRAGMA wal_checkpoint and Close both return nil while the
+// whole update is still sitting in the WAL. Deleting the WAL and renaming the
+// file at that point throws the run away and still reports success.
+func TestFinalizeWorkingCopy_BlockedCheckpointKeepsWAL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "3gpp.db.new")
+	d := seedWorkingCopy(t, path)
+
+	reader, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	reader.SetMaxOpenConns(1)
+	// An open read transaction pins the snapshot the WAL still describes.
+	tx, err := reader.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	var n int
+	if err := tx.QueryRow("SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := finalizeWorkingCopy(d, path); err == nil {
+		t.Fatal("expected an error when the checkpoint cannot merge the WAL")
+	}
+	fi, statErr := os.Stat(path + "-wal")
+	if statErr != nil {
+		t.Fatalf("the unmerged WAL was deleted: %v", statErr)
+	}
+	if fi.Size() == 0 {
+		t.Error("the unmerged WAL was truncated")
+	}
 }

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1012,3 +1012,35 @@ func TestFinalizeWorkingCopy_BlockedCheckpointKeepsWAL(t *testing.T) {
 		t.Error("the unmerged WAL was truncated")
 	}
 }
+
+// TestCmdUpdate_UnreadableDB checks that a database that cannot be read is
+// reported as a failure rather than as "No specs in database": the two used to
+// share one branch, so a broken database told the user to run 'build' and
+// exited 0. Run as a subprocess because the failure path calls log.Fatalf.
+func TestCmdUpdate_UnreadableDB(t *testing.T) {
+	if os.Getenv("CMD_UPDATE_UNREADABLE_HELPER") != "" {
+		cmdUpdate([]string{"-db", os.Getenv("CMD_UPDATE_UNREADABLE_HELPER")})
+		return
+	}
+	// A database file with no schema at all: ListSpecs fails with "no such
+	// table" instead of returning zero rows.
+	dbPath := filepath.Join(t.TempDir(), "broken.db")
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	d.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdUpdate_UnreadableDB")
+	cmd.Env = append(os.Environ(), "CMD_UPDATE_UNREADABLE_HELPER="+dbPath)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit for an unreadable database, got: %s", out)
+	}
+	if strings.Contains(string(out), "No specs in database") {
+		t.Errorf("an unreadable database was reported as empty: %s", out)
+	}
+	if !strings.Contains(string(out), "Failed to read specs") {
+		t.Errorf("expected the read failure to be reported, got: %s", out)
+	}
+}

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -150,6 +150,23 @@ const (
 // with SIGABRT in EMFPPlusDrawPolygon → B2DPolygon::count(). Since EMF files
 // are dual-format, the legacy EMR records render identically for these
 // diagrams. Microsoft Word handles this gracefully by falling back to EMR.
+// emrRecordEnd returns the end offset of the EMR record that starts at offset
+// and reports whether the record is well-formed and fits inside a buffer of n
+// bytes. recSize comes straight out of the file, so the arithmetic runs in
+// uint64: on a 32-bit build "offset + int(recSize)" wraps to a negative int
+// for a large recSize, slips past a plain "> n" comparison and panics the
+// slice expression that follows.
+func emrRecordEnd(offset int, recSize uint32, n int) (int, bool) {
+	if recSize < emrMinSize {
+		return 0, false
+	}
+	end := uint64(offset) + uint64(recSize)
+	if end > uint64(n) {
+		return 0, false
+	}
+	return int(end), true
+}
+
 func stripEMFPlus(data []byte) []byte {
 	if len(data) < emfHeaderMinSize {
 		return data
@@ -167,7 +184,8 @@ func stripEMFPlus(data []byte) []byte {
 	for offset+emrMinSize <= len(data) {
 		recType := binary.LittleEndian.Uint32(data[offset : offset+4])
 		recSize := binary.LittleEndian.Uint32(data[offset+4 : offset+8])
-		if recSize < emrMinSize || offset+int(recSize) > len(data) {
+		end, ok := emrRecordEnd(offset, recSize, len(data))
+		if !ok {
 			break
 		}
 
@@ -182,10 +200,10 @@ func stripEMFPlus(data []byte) []byte {
 		}
 
 		if !isEMFPlus {
-			out = append(out, data[offset:offset+int(recSize)]...)
+			out = append(out, data[offset:end]...)
 			nRecords++
 		}
-		offset += int(recSize)
+		offset = end
 	}
 
 	if !hasEMFPlus {

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -388,3 +388,48 @@ func TestRunSofficeBatch_Timeout(t *testing.T) {
 		t.Errorf("expected timeout error, got: %v", err)
 	}
 }
+
+func TestEMRRecordEnd(t *testing.T) {
+	tests := []struct {
+		name    string
+		offset  int
+		recSize uint32
+		n       int
+		wantEnd int
+		wantOK  bool
+	}{
+		{"header record", 0, 8, 100, 8, true},
+		{"record fills the buffer", 84, 16, 100, 100, true},
+		{"below the minimum record size", 0, 7, 100, 0, false},
+		{"record longer than the buffer", 0, 200, 100, 0, false},
+		{"record straddles the end", 92, 16, 100, 0, false},
+		// A record size near 2^32 wraps to a negative int on a 32-bit build,
+		// which used to slip past the bounds check and panic the slice
+		// expression in stripEMFPlus.
+		{"size wraps a 32-bit int", 0, 0xFFFFFFF0, 100, 0, false},
+		{"max size at a nonzero offset", 64, 0xFFFFFFFF, 100, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			end, ok := emrRecordEnd(tt.offset, tt.recSize, tt.n)
+			if end != tt.wantEnd || ok != tt.wantOK {
+				t.Errorf("emrRecordEnd(%d, %d, %d) = (%d, %v), want (%d, %v)",
+					tt.offset, tt.recSize, tt.n, end, ok, tt.wantEnd, tt.wantOK)
+			}
+		})
+	}
+}
+
+// A malformed record size must stop the scan, not panic. On a 32-bit build
+// (goreleaser ships 386 binaries) the oversized size wrapped negative and
+// panicked the slice expression.
+func TestStripEMFPlus_OversizedRecordSize(t *testing.T) {
+	data := make([]byte, 64)
+	binary.LittleEndian.PutUint32(data[0:4], 0x01) // EMR_HEADER
+	binary.LittleEndian.PutUint32(data[4:8], 0xFFFFFFF0)
+
+	out := stripEMFPlus(data)
+	if len(out) != len(data) {
+		t.Errorf("len(out) = %d, want %d (input returned unchanged)", len(out), len(data))
+	}
+}

--- a/converter/docx/metadata.go
+++ b/converter/docx/metadata.go
@@ -117,12 +117,14 @@ func extractMetadata(filename string, props coreProperties, bodyElements []bodyE
 
 	// Try to get title from document properties
 	if props.Subject != "" && !isTemplateValue(props.Subject) {
-		if relMatch := releaseRE.FindStringSubmatch(props.Subject); relMatch != nil {
-			release = relMatch[1]
-			idx := strings.Index(props.Subject, "(Release")
-			if idx >= 0 {
-				title = strings.TrimRight(props.Subject[:idx], "; ")
-			}
+		// The release marker is usually parenthesised ("...; (Release 18)"),
+		// but releaseRE does not require the parenthesis. Cut the title at
+		// wherever the marker actually starts, otherwise a subject that spells
+		// the release without parentheses yields no title at all and the spec
+		// falls back to its first heading.
+		if relMatch := releaseRE.FindStringSubmatchIndex(props.Subject); relMatch != nil {
+			release = props.Subject[relMatch[2]:relMatch[3]]
+			title = strings.TrimRight(props.Subject[:relMatch[0]], "; (")
 		} else {
 			title = props.Subject
 		}

--- a/converter/docx/metadata_test.go
+++ b/converter/docx/metadata_test.go
@@ -179,6 +179,40 @@ func TestExtractMetadata_SubjectWithRelease(t *testing.T) {
 	}
 }
 
+// The release marker is not always parenthesised. Cutting the title at a
+// literal "(Release" left the title empty for these subjects, so the spec fell
+// back to whatever its first heading happened to be.
+func TestExtractMetadata_SubjectWithUnparenthesisedRelease(t *testing.T) {
+	for _, tt := range []struct {
+		subject   string
+		wantTitle string
+	}{
+		{"5G System architecture; Release 18", "5G System architecture"},
+		{"5G System architecture, Release 18", "5G System architecture,"},
+		{"5G System architecture (Release 18)", "5G System architecture"},
+	} {
+		meta := extractMetadata("23501-i30.docx", coreProperties{Subject: tt.subject}, nil, nil)
+		if meta.Title != tt.wantTitle {
+			t.Errorf("subject %q: Title = %q, want %q", tt.subject, meta.Title, tt.wantTitle)
+		}
+		if meta.Release != "18" {
+			t.Errorf("subject %q: Release = %q, want 18", tt.subject, meta.Release)
+		}
+	}
+}
+
+// A subject that is nothing but the release marker carries no title, so the
+// usual fallbacks still have to run.
+func TestExtractMetadata_SubjectOnlyRelease(t *testing.T) {
+	meta := extractMetadata("23501-i30.docx", coreProperties{Subject: "(Release 18)"}, nil, nil)
+	if meta.Title != "TS 23.501" {
+		t.Errorf("Title = %q, want fallback to spec ID", meta.Title)
+	}
+	if meta.Release != "18" {
+		t.Errorf("Release = %q, want 18", meta.Release)
+	}
+}
+
 func TestExtractMetadata_TitleFromTitleProperty(t *testing.T) {
 	props := coreProperties{
 		Title: "Network Function Repository Services",

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -488,9 +488,12 @@ func escapeMathText(s string) string {
 		case '$':
 			b.WriteString("\\$")
 		case '~':
-			b.WriteString("\\textasciitilde ")
+			// \textasciitilde and \textasciicircum are text-mode commands,
+			// and every caller wraps this output in $...$, so they have to
+			// go back through \text{} to stay defined in math mode.
+			b.WriteString("\\text{\\textasciitilde}")
 		case '^':
-			b.WriteString("\\textasciicircum ")
+			b.WriteString("\\text{\\textasciicircum}")
 		default:
 			b.WriteRune(r)
 		}

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -267,11 +267,21 @@ func renderNary(n *ommlNode) string {
 
 	var b strings.Builder
 	b.WriteString(op)
+	limits := false
 	if sub := child(n, "sub"); sub != nil && !isTrue(subHide, sp) {
 		b.WriteString("_{" + renderOMML(sub) + "}")
+		limits = true
 	}
 	if sup := child(n, "sup"); sup != nil && !isTrue(supHide, pp) {
 		b.WriteString("^{" + renderOMML(sup) + "}")
+		limits = true
+	}
+	// With no limits to close the operator, a command runs straight into the
+	// operand and forms an invalid token ("\int" + "x" must not become
+	// "\intx"). Only commands need the separator; a literal operator
+	// character from naryOp's default branch does not.
+	if !limits && strings.HasPrefix(op, "\\") {
+		b.WriteString(" ")
 	}
 	b.WriteString(renderOMML(child(n, "e")))
 	return b.String()

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -109,6 +109,30 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "\\sum_{i=1}^{n}i",
 		},
 		{
+			// Without limits to close it, the operator command would run into
+			// the operand and form an undefined control sequence ("\intx").
+			name: "nary without limits separates operator from operand",
+			xml: `<m:oMath ` + mXMLNS + `><m:nary><m:naryPr><m:chr m:val="∫"/></m:naryPr>` +
+				`<m:e>` + mrun("x") + `</m:e></m:nary></m:oMath>`,
+			want: "\\int x",
+		},
+		{
+			name: "nary with both limits hidden separates operator from operand",
+			xml: `<m:oMath ` + mXMLNS + `><m:nary>` +
+				`<m:naryPr><m:chr m:val="∑"/><m:subHide m:val="1"/><m:supHide m:val="1"/></m:naryPr>` +
+				`<m:sub>` + mrun("i") + `</m:sub><m:sup>` + mrun("n") + `</m:sup>` +
+				`<m:e>` + mrun("a") + `</m:e></m:nary></m:oMath>`,
+			want: "\\sum a",
+		},
+		{
+			// naryOp passes an unmapped character through verbatim; it is not
+			// a command, so it needs no separator.
+			name: "nary with literal operator character needs no separator",
+			xml: `<m:oMath ` + mXMLNS + `><m:nary><m:naryPr><m:chr m:val="⨄"/></m:naryPr>` +
+				`<m:e>` + mrun("x") + `</m:e></m:nary></m:oMath>`,
+			want: "⨄x",
+		},
+		{
 			name: "delimiter parens",
 			xml: `<m:oMath ` + mXMLNS + `><m:d>` +
 				`<m:e>` + mrun("x") + `</m:e>` +

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -255,8 +255,11 @@ func TestEscapeMathText(t *testing.T) {
 		{"#1", "\\#1"},
 		{`a\b`, "a\\backslash b"},
 		{"{x}", "\\{x\\}"},
-		{"a~b", "a\\textasciitilde b"},
-		{"a^b", "a\\textasciicircum b"},
+		// Callers wrap the result in $...$, so the text-mode escapes for "~"
+		// and "^" need their own \text{} group; bare \textasciitilde is an
+		// undefined control sequence in math mode.
+		{"a~b", "a\\text{\\textasciitilde}b"},
+		{"a^b", "a\\text{\\textasciicircum}b"},
 		{"$x", "\\$x"},
 		{"β≥γ", "\\beta \\geq \\gamma "},
 		{"a×b", "a\\times b"},

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -148,6 +148,11 @@ func sdpFieldLineCount(text string) (count int, allFields bool) {
 	for _, ln := range strings.Split(text, "\n") {
 		ln = strings.TrimSpace(ln)
 		if ln == "" {
+			// A blank line ends the continuation: the wrapped remainder of a
+			// value has to follow its backslash immediately. Carrying the flag
+			// across the gap would waive the field-line check for whatever
+			// prose comes next and pull it into the block.
+			prevContinued = false
 			continue
 		}
 		if !prevContinued && !sdpFieldLine(ln) {

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -494,3 +494,48 @@ func TestParseSections_SIPImageParagraphEndsBlock(t *testing.T) {
 		}
 	}
 }
+
+func TestSDPFieldLineCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		text          string
+		wantCount     int
+		wantAllFields bool
+	}{
+		{
+			name:          "plain field lines",
+			text:          "v=0\nm=audio 49170 RTP/AVP 0",
+			wantCount:     2,
+			wantAllFields: true,
+		},
+		{
+			name:          "backslash continuation covers the next line",
+			text:          "m=audio 49170 RTP/AVP 96\na=fmtp:96 mode-set=0,2,4,7; \\\n         mode-change-period=2",
+			wantCount:     3,
+			wantAllFields: true,
+		},
+		{
+			name:          "prose line is rejected",
+			text:          "v=0\nThis paragraph explains the fields.",
+			wantCount:     1,
+			wantAllFields: false,
+		},
+		{
+			// A blank line ends the continuation, so the prose after it has to
+			// be checked like any other line instead of being waved through.
+			name:          "continuation does not survive a blank line",
+			text:          "a=fmtp:96 mode-set=0,2,4,7; \\\n\nThis paragraph explains the fields.",
+			wantCount:     1,
+			wantAllFields: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, allFields := sdpFieldLineCount(tt.text)
+			if count != tt.wantCount || allFields != tt.wantAllFields {
+				t.Errorf("sdpFieldLineCount(%q) = (%d, %v), want (%d, %v)",
+					tt.text, count, allFields, tt.wantCount, tt.wantAllFields)
+			}
+		})
+	}
+}

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -461,17 +461,28 @@ func ConvertDir(ctx context.Context, d *db.DB, dirPath string, workers int, conv
 		return fmt.Errorf("all %d files failed to parse", len(files))
 	}
 
-	// Write to DB in cover-last order
+	// Write to DB in cover-last order. A failing file does not abort the rest,
+	// but the caller has to hear about it: a silently empty database must not
+	// look like a successful import to cron/CI.
+	var dbErr error
+	dbErrors := 0
 	for _, f := range files {
 		if r, ok := parsed[f]; ok {
 			if err := d.InsertSpecWithSectionsAndImages(r.spec, r.sections, r.images); err != nil {
 				log.Printf("  DB error for %s: %v", r.spec.ID, err)
+				dbErrors++
+				if dbErr == nil {
+					dbErr = fmt.Errorf("store %s: %w", r.spec.ID, err)
+				}
 			}
 		}
 	}
 
 	if parseErrors > 0 {
 		log.Printf("  %d of %d files failed to parse", parseErrors, len(files))
+	}
+	if dbErrors > 0 {
+		return fmt.Errorf("%d of %d files failed to store: %w", dbErrors, len(parsed), dbErr)
 	}
 
 	return docConvertErr

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -651,3 +651,29 @@ func TestYAMLVersionRE(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertDir_DBErrorPropagates verifies that a failing database write is
+// surfaced as a non-nil error instead of being logged and forgotten. Without
+// it, an import that stored nothing at all still exited 0.
+func TestConvertDir_DBErrorPropagates(t *testing.T) {
+	docxData, err := os.ReadFile(testdataDocxPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.docx"), docxData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A database with no schema: every insert fails with "no such table".
+	d, err := db.OpenReadWrite(filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	if err := ConvertDir(context.Background(), d, dir, 1, false, false); err == nil {
+		t.Fatal("expected an error when the database write fails")
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -933,6 +933,19 @@ func quoteFTS5String(s string) string {
 	return "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
 }
 
+// quoteFTS5Term quotes a search term, keeping a single trailing "*" outside
+// the quotes so it keeps its prefix-match meaning: inside a quoted string FTS5
+// treats "*" as an ordinary character, so "38.10*" matches nothing while
+// "38.10"* matches every term starting with 38.10. A term that is nothing but
+// stars, or that ends in several of them, has no valid prefix form and is
+// quoted whole ("38.10"** is a syntax error).
+func quoteFTS5Term(s string) string {
+	if stem, ok := strings.CutSuffix(s, "*"); ok && stem != "" && !strings.HasSuffix(stem, "*") {
+		return quoteFTS5String(stem) + "*"
+	}
+	return quoteFTS5String(s)
+}
+
 // classifyToken quotes a bareword or "col:val" column-filter token if it
 // contains a character FTS5 cannot parse in an unquoted bareword.
 func classifyToken(token string) string {
@@ -946,21 +959,22 @@ func classifyToken(token string) string {
 				return quoteFTS5String(token)
 			}
 			if strings.HasPrefix(val, "\"") {
-				// Already phrase-quoted (content:"foo"). Repair it if the
+				// Already phrase-quoted (content:"foo"), optionally with a
+				// prefix "*" after the closing quote. Repair it if the
 				// closing quote is missing.
-				if len(val) >= 2 && strings.HasSuffix(val, "\"") {
+				if body := strings.TrimSuffix(val, "*"); len(body) >= 2 && strings.HasSuffix(body, "\"") {
 					return token
 				}
-				return col + ":" + quoteFTS5String(strings.Trim(val, "\""))
+				return col + ":" + quoteFTS5Term(strings.Trim(val, "\""))
 			}
 			if needsFTS5Quoting(val) {
-				return col + ":" + quoteFTS5String(val)
+				return col + ":" + quoteFTS5Term(val)
 			}
 			return token
 		}
 	}
 	if needsFTS5Quoting(token) {
-		return quoteFTS5String(token)
+		return quoteFTS5Term(token)
 	}
 	return token
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1022,6 +1022,20 @@ func sanitizeFTS5Query(query string) string {
 
 		j := i
 		for j < n && query[j] != ' ' && query[j] != '\t' && query[j] != '\n' {
+			if query[j] == '"' {
+				// A quoted phrase riding inside a token (content:"foo bar")
+				// carries its own spaces. Consume it whole, otherwise the
+				// split on whitespace tears the phrase in two and the halves
+				// end up as separate, unrelated match terms.
+				j++
+				for j < n && query[j] != '"' {
+					j++
+				}
+				if j < n {
+					j++
+				}
+				continue
+			}
 			j++
 		}
 		token := query[i:j]

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -397,6 +397,9 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"empty column filter quoted", "content:", `"content:"`},
 		{"balanced quoted column filter unchanged", `content:"band"`, `content:"band"`},
 		{"unterminated quoted column filter repaired", `content:"band`, `content:"band"`},
+		{"multi-word phrase column filter kept whole", `content:"core network"`, `content:"core network"`},
+		{"multi-word phrase column filter with trailing term", `title:"band requirements" AMF`, `title:"band requirements" AMF`},
+		{"unterminated multi-word phrase column filter repaired", `content:"core network`, `content:"core network"`},
 	}
 
 	for _, tt := range tests {
@@ -443,7 +446,8 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 		"AMF AND -excluded", "AMF OR -excluded",
 		"-excluded", "-one-two",
 		`Rel-18"`, `"core network`, "(38.331 OR SMF)", "content:",
-		`AMF"`, `content:"band`,
+		`AMF"`, `content:"band`, `content:"core network"`, `content:"core network`,
+		"38.10*", "title:38.10*", "RRCSetup-IEs*", "38.10**",
 	}
 	for _, q := range queries {
 		sanitized := sanitizeFTS5Query(q)
@@ -453,6 +457,40 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 			continue
 		}
 		rows.Close()
+	}
+}
+
+// TestSanitizeFTS5Query_ColumnFilterPhrase checks that a phrase inside a
+// column filter still matches as a phrase. Splitting the token on whitespace
+// before recognising the quotes turned content:"foo bar" into two independent
+// terms, which matched documents that never contain the phrase at all.
+func TestSanitizeFTS5Query_ColumnFilterPhrase(t *testing.T) {
+	dbConn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbConn.Close()
+	dbConn.SetMaxOpenConns(1)
+
+	if _, err := dbConn.Exec(`CREATE VIRTUAL TABLE t USING fts5(spec_id, number, title, content)`); err != nil {
+		t.Fatal(err)
+	}
+	// "network" is in the title and "core" is in the content, but the phrase
+	// "core network" appears in neither column.
+	if _, err := dbConn.Exec(
+		`INSERT INTO t(spec_id, number, title, content) VALUES (?, ?, ?, ?)`,
+		"TS 23.501", "4.2", "network architecture", "the core is described here",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var n int
+	sanitized := sanitizeFTS5Query(`content:"core network"`)
+	if err := dbConn.QueryRow(`SELECT count(*) FROM t WHERE t MATCH ?`, sanitized).Scan(&n); err != nil {
+		t.Fatalf("query sanitized to %q, which FTS5 rejected: %v", sanitized, err)
+	}
+	if n != 0 {
+		t.Errorf("content:%q sanitized to %q and matched %d rows, want 0", "core network", sanitized, n)
 	}
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -397,6 +397,12 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"empty column filter quoted", "content:", `"content:"`},
 		{"balanced quoted column filter unchanged", `content:"band"`, `content:"band"`},
 		{"unterminated quoted column filter repaired", `content:"band`, `content:"band"`},
+		{"prefix wildcard on dotted stem", "38.10*", `"38.10"*`},
+		{"prefix wildcard on hyphenated stem", "RRCSetup-IEs*", `"RRCSetup-IEs"*`},
+		{"prefix wildcard in column filter", "title:38.10*", `title:"38.10"*`},
+		{"repeated stars quoted whole", "38.10**", `"38.10**"`},
+		{"lone star unchanged", "*", "*"},
+		{"quoted phrase with prefix star kept", `content:"core network"*`, `content:"core network"*`},
 		{"multi-word phrase column filter kept whole", `content:"core network"`, `content:"core network"`},
 		{"multi-word phrase column filter with trailing term", `title:"band requirements" AMF`, `title:"band requirements" AMF`},
 		{"unterminated multi-word phrase column filter repaired", `content:"core network`, `content:"core network"`},
@@ -447,7 +453,8 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 		"-excluded", "-one-two",
 		`Rel-18"`, `"core network`, "(38.331 OR SMF)", "content:",
 		`AMF"`, `content:"band`, `content:"core network"`, `content:"core network`,
-		"38.10*", "title:38.10*", "RRCSetup-IEs*", "38.10**",
+		"38.10*", "title:38.10*", "RRCSetup-IEs*", "38.10**", "AMF -38.10*",
+		`content:"core network"*`,
 	}
 	for _, q := range queries {
 		sanitized := sanitizeFTS5Query(q)
@@ -491,6 +498,49 @@ func TestSanitizeFTS5Query_ColumnFilterPhrase(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("content:%q sanitized to %q and matched %d rows, want 0", "core network", sanitized, n)
+	}
+}
+
+// TestSanitizeFTS5Query_PrefixWildcard checks that a prefix search on a term
+// that has to be quoted still matches as a prefix. FTS5 treats "*" inside a
+// quoted string as an ordinary character, so quoting "38.10*" whole turned a
+// prefix search into a search for a term nothing can match.
+func TestSanitizeFTS5Query_PrefixWildcard(t *testing.T) {
+	dbConn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbConn.Close()
+	dbConn.SetMaxOpenConns(1)
+
+	if _, err := dbConn.Exec(`CREATE VIRTUAL TABLE t USING fts5(spec_id, number, title, content)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbConn.Exec(
+		`INSERT INTO t(spec_id, number, title, content) VALUES (?, ?, ?, ?)`,
+		"TS 38.101-1", "5.1", "Band requirements", "see 38.101 and RRCSetup-IEs for details",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		query string
+		want  int
+	}{
+		{"38.10*", 1},
+		{"RRCSetup-IE*", 1},
+		{"title:Ban*", 1},
+		{"39.10*", 0},
+	} {
+		sanitized := sanitizeFTS5Query(tt.query)
+		var n int
+		if err := dbConn.QueryRow(`SELECT count(*) FROM t WHERE t MATCH ?`, sanitized).Scan(&n); err != nil {
+			t.Errorf("query %q sanitized to %q, which FTS5 rejected: %v", tt.query, sanitized, err)
+			continue
+		}
+		if n != tt.want {
+			t.Errorf("query %q sanitized to %q and matched %d rows, want %d", tt.query, sanitized, n, tt.want)
+		}
 	}
 }
 

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -55,8 +55,10 @@ const DefaultFileName = "versions.db"
 // fences Diameter command/AVP definitions (```diameter), generation 4 fences
 // SIP/RTSP message and SDP examples by content detection, generation 5
 // fences content-detected XML/DTD blocks (```xml), generation 6 tags the
-// SIP/SDP fences (```sip / ```sdp) for syntax highlighting.
-const cacheSchemaVersion = 6
+// SIP/SDP fences (```sip / ```sdp) for syntax highlighting, generation 7
+// makes OMML math render in math mode (n-ary operators separated from their
+// operand, "~" and "^" escaped through \text{}).
+const cacheSchemaVersion = 7
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -57,7 +57,8 @@ const DefaultFileName = "versions.db"
 // fences content-detected XML/DTD blocks (```xml), generation 6 tags the
 // SIP/SDP fences (```sip / ```sdp) for syntax highlighting, generation 7
 // makes OMML math render in math mode (n-ary operators separated from their
-// operand, "~" and "^" escaped through \text{}).
+// operand, "~" and "^" escaped through \text{}) and stops a backslash
+// continuation from pulling prose after a blank line into an SDP fence.
 const cacheSchemaVersion = 7
 
 // schema mirrors the spec, section and image tables of the main database,


### PR DESCRIPTION
Validation pass over the remaining unverified LLM review findings. Each candidate was read at its actual location, traced for reachability, and measured where behaviour could be observed. Only the findings that reproduced were fixed; every fix has a regression test that fails before it and passes after.

Most of the list did not survive verification.

## Fixed

| Commit | Finding | Evidence |
| --- | --- | --- |
| `fix(db): keep quoted phrases whole in column-filtered FTS5 queries` | `db.go:1022` — a quoted phrase after a column filter is split on whitespace before the quotes are recognised | `content:"core network"` sanitised to `content:"core" "network"""` — a column-filtered term plus an unrelated one. Measured against a real FTS5 table holding "network" in the title and "core" in the content and the phrase in neither: correct query 0 hits, sanitised query 1 hit. |
| `fix(db): keep prefix wildcard outside quotes when quoting FTS5 terms` | `db.go:961` — prefix search on a dotted/hyphenated stem loses its wildcard meaning | FTS5 treats `*` inside a quoted string as an ordinary character. `"38.10*"` matched 0 rows, `"38.10"*` matched 1. Repeated trailing stars stay quoted whole because `"38.10"**` is a hard syntax error. |
| `fix(docx): separate n-ary operator from its operand in OMML output` | `omml.go:269` — an n-ary operator with no limits concatenates onto its operand | Rendered through the KaTeX build bundled in `web/static`: `\intx` and `\sumx` are undefined control sequences, `\int x` renders. A literal operator character from `naryOp`'s default branch needs no separator and does not get one. |
| `fix(docx): wrap text-mode escapes in \text{} for math-mode output` | `omml.go:480` — `\textasciitilde` / `\textasciicircum` are text-mode commands but callers wrap the output in `$…$` | Same KaTeX bundle: both are undefined control sequences in math mode; `\text{\textasciitilde}` renders the literal character. |
| `fix(docx): cut title at the release marker even without parentheses` | `metadata.go:120` — release extracted without a parenthesised `(Release` marker | `releaseRE` does not require the parenthesis but the title is cut at a literal `"(Release"`. A subject like `"…; Release 18"` set the release and left the title empty, so the spec fell back to its first heading. |
| `fix(docx): bound EMR record size with overflow-safe arithmetic` | `emf.go:170` — `uint32` → `int` truncation bypasses the bounds check on 32-bit | Reproduced under `GOARCH=386`: a malformed record size panics with `slice bounds out of range [:-16]`. goreleaser ships 386 binaries, so this is a supported target. The bounds check now runs in `uint64`. |
| `fix(pipeline): report database write failures from ConvertDir` | `pipeline.go:464` — `ConvertDir` logs database insert errors and returns `nil` | `import-dir` exited 0 with nothing stored. Sibling paths already fail loudly (`processOne` returns `FAILED`, `Run` refuses to report success when nothing succeeded). Failing files no longer abort the rest, but the caller now hears about them. |
| `fix(cmd): verify the WAL merged before replacing the live database` | `main.go:687` — `PRAGMA wal_checkpoint(TRUNCATE)` error ignored, `-wal`/`-shm` deleted unconditionally | Worse than reported: a blocked checkpoint reports "busy" in its **result row**, so `Exec` *and* `Close` both return `nil` while the WAL still holds the entire update — measured at 832 KB. The old code then deleted it and renamed the file over the live database, printing "Database updated successfully". Checking the `Exec` error alone would not have caught this; the sidecars are now only removed once the merge is confirmed. |
| `fix(cmd): distinguish an unreadable database from an empty one in update` | `main.go:581` — `ListSpecs` error conflated with "database is empty" | A database that cannot be read printed "No specs in database. Use 'build' command first." and exited 0. (`TestCmdUpdate_EmptyDB` already sidestepped this branch on purpose.) |
| `fix(docx): end backslash continuation at a blank line in SDP detection` | `sipblock.go:149` — continuation state survives a blank line | `prevContinued` was not reset on a blank line, so the field-line check was waived for whatever followed and prose was pulled into an SDP fence. |

`versionstore.cacheSchemaVersion` is bumped to 7 for the two OMML changes and the SDP fence change, per the notation-output invariant in AGENTS.md. A `make build-db` rebuild is needed for the prebuilt database.

## False positives

- **`db.go:93` `uriPathEscaper` does not escape `;`** — measured, not reproducible. A database file literally named `a;vfs=unix-none.db` opens the real file through `file:…?mode=ro`; the semicolon is not a VFS parameter separator in a SQLite URI. `mode=ro` also stays enforced against a path containing `;mode=rw`.
- **`emf.go:249` path traversal via `item.original.Name`** — doubly unreachable. `EmbeddedImage.Name` is `filepath.Base(f.Name)` at extraction (`image.go:60`), so it cannot contain a separator, and the mandatory `i%d_` prefix stops even a bare `..` from acting as a parent reference (`filepath.Join(tmp, "i0_..")` = `tmp/i0_..`). An unprefixed name would escape, which is why this matters — but neither precondition is reachable.
- **`pipeline.go:281` `applyArchiveVersion` leaves `dbImages` on the old version** — `InsertSpecWithSectionsAndImages` ignores `Image.Version` and inserts every image row with `spec.Version` ("The spec row is the authority on the version, so child rows take it from there rather than from their own field"). The same is true of the `Section.Version` the function does set; both are belt-and-braces.
- **`download.go:307` / `:299` `downloadZip` drops `timeout` / `CheckRedirect`** — dropping the overall timeout is deliberate and the comment above the line explains it (a 258 MB ZIP must not be cut off; the transport's dial/TLS timeouts still apply). No client anywhere in the tree sets `CheckRedirect` or `Jar`, so nothing else is lost.
- **`main.go:693` `os.Rename` while serve holds the old inode** — stated as intended directly above the line, with the mitigation named (systemd `ExecStartPost`).
- **`main.go:281` `server.Shutdown` failure ignored** — it is logged, and the doc comment explains why the function still returns `nil`: returning an error there would skip the caller's deferred database and version-cache closes.
- **`db.go:1471` `includeSubsections` ignored for incoming references** — the tool schema scopes the flag to outgoing (`Include subsections when collecting outgoing references`). The incoming query deliberately also matches subsections and spec-level (`target_section = ''`) references.
- **`ondemand.go:159` `docx.ParseDocx` is not cancellable** — literally true, but the loop checks `ctx.Err()` before each file, bounding cancellation latency to one document. `processOne` uses the identical pattern. Threading a context through the whole DOCX parser is not warranted by this.
- **`pipeline.go:187` `--convert-doc` succeeds with zero .docx** — it does not. `processOne` returns `DOC_ONLY`, which `Run` logs as `DOC_ONLY (conversion failed)` and counts separately.
- **`download.go:285` `ConvertDocFiles` count vs the caller's subtraction** — the counts do differ (files vs specs), but the caller clamps to `stats["DOC_ONLY"]` so it can never go negative, and `DownloadSpecs`' stats feed nothing but the printed summary in `cmdDownload`. Cosmetic imprecision in one log line.
- **`db.go:1066` public query methods** and **`structdiff.go:164`** — no claim was recorded for either. Both were reviewed anyway: every method in the group closes its rows and checks `rows.Err()`, and all user input is parameter-bound; `bodyKey`'s line-by-line `NormalizeImageRefs` is equivalent to whole-string application because the regexes are line-oriented. No defect found.
- **`db.go:120` `OpenReadWrite` ignores PRAGMA failures** — deliberate degradation, logged as `warning:`. WAL mode and `busy_timeout` are optimisations, not correctness requirements, and the connection is capped at one.

## Real, but not fixed

- **`metadata.go:102` `specID` hardcoded to `"TS …"`, losing the document type.** Confirmed against the production database: `TR 38.901` ("Study on channel model…") and `TR 21.905` ("Vocabulary for 3GPP Specifications") are both stored as `TS …`, and all 500 incoming references to `TR 21.905` come back with an empty `target_title` because the title lookup joins `sections.spec_id = 'TR 21.905'`, which does not exist.

  There is no safe local fix. The archive filename carries no document type at all, so only the `specPatternRE` branch could honour it — and fixing just that branch is worse than the bug: the same specification would get `TR 38.901` when imported from a `TR 38.901 …docx` filename and `TS 38.901` from an archive filename, splitting one spec across two IDs and duplicating it in the FTS index, against the "one version per spec" invariant. Doing it properly means sniffing the type off the cover page and changing the primary key of every stored spec, which breaks every client already using `TS nn.nnn` IDs and touches `ondemand.go`, `versionstore`, the web routes and the tool docs. That is a design change, not a bug fix.

- **`emf.go:58` converted images with the same base name collide.** `image1.emf` and `image1.wmf` both become `image1.png`; `UpdateImagePlaceholders` keys on the base name so both references resolve to one image, and the `UNIQUE(spec_id, version, name)` constraint drops the other row. The tmpdir half of this was already fixed with the `i%d_` prefix (see the comment at `emf.go:246`), but the final name still collides. A fix has to change the emitted `image://` names, which is a notation change requiring a full database rebuild — disproportionate to a collision I could not demonstrate in any real document, since Word numbers `word/media` entries sequentially across the folder.

- **`table.go:96` rowspan continuation matches on the start column only, ignoring `gridSpan`.** The code does what the comment above it describes. Requiring equal widths does not fix the layout either: the continuation cell is still skipped by `writeRowHTML`, so its content would be dropped instead of misplaced. Both outcomes are broken for input where a merged region changes width mid-span, and I could not produce such a table from a real document.

## Also checked

- **`table.go:112` doc comment vs implementation** — they agree. Leading `w:tblHeader` rows are counted and emitted inside `<thead>` with `asHeader=true`, which writes `<th>`.

## Verification

```
gofmt -l .        # no output
go build ./...
go vet ./...
go test -race -timeout 40m ./...   # all packages ok
```

---
_Generated by [Claude Code](https://claude.ai/code/session_016mof7FFTU93fYt9KyLmeFm)_