### PR TITLE
fix(tools): pagination, truncation, and error handling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ keeps unstemmed search until rebuilt.
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `get_references` | Get cross-references between specs and RFCs | `spec_id` (required), `section_number`, `direction` (`"outgoing"` or `"incoming"`), `include_subsections` |
+| `get_references` | Get cross-references between specs and RFCs | `spec_id` (required), `section_number`, `direction` (`"outgoing"` or `"incoming"`), `include_subsections`, `offset` |
 
 ### OpenAPI definitions
 

--- a/db/db.go
+++ b/db/db.go
@@ -425,7 +425,8 @@ func (d *DB) UpsertImage(img Image) error {
 	return err
 }
 
-// GetImage retrieves a single image by spec ID, version and name.
+// GetImage retrieves a single image by spec ID, version and name, or nil when
+// the spec holds no image of that name.
 // An empty version resolves to the version this database holds.
 func (d *DB) GetImage(specID, version, name string) (*Image, error) {
 	version, err := d.ResolveVersion(specID, version)
@@ -437,6 +438,9 @@ func (d *DB) GetImage(specID, version, name string) (*Image, error) {
 		"SELECT spec_id, version, name, mime_type, data, llm_readable FROM images WHERE spec_id = ? AND version = ? AND name = ?",
 		specID, version, name,
 	).Scan(&img.SpecID, &img.Version, &img.Name, &img.MIMEType, &img.Data, &img.LLMReadable)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("get image: %w", err)
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1638,9 +1638,12 @@ func TestImageCRUD(t *testing.T) {
 		t.Errorf("image bytes length = %d, want %d", len(got.Data), len(payload))
 	}
 
-	// Missing image.
-	if _, err := d.GetImage("TS 23.501", "", "missing.png"); err == nil {
-		t.Error("expected error for missing image")
+	// A missing image is nil without an error, so callers can distinguish
+	// "no such image" from a real failure.
+	if missing, err := d.GetImage("TS 23.501", "", "missing.png"); err != nil {
+		t.Errorf("GetImage(missing) returned error: %v", err)
+	} else if missing != nil {
+		t.Errorf("GetImage(missing) = %+v, want nil", missing)
 	}
 
 	// ListImages returns only the inserted image.

--- a/tools/get_image.go
+++ b/tools/get_image.go
@@ -27,9 +27,12 @@ func HandleGetImage(src *Source) func(ctx context.Context, req *mcp.CallToolRequ
 			return errorResult("name is required"), nil, nil
 		}
 
+		// A missing image comes back as a nil image, not an error, so an error
+		// here is a real failure (bad version, failed download, database
+		// trouble) and must not be labeled "not found".
 		img, res, err := src.GetImage(ctx, input.SpecID, input.Version, input.Name)
 		if err != nil {
-			return versionErrorResult(err, "image not found"), nil, nil
+			return versionErrorResult(err, "failed to get image"), nil, nil
 		}
 		if img == nil {
 			return errorResult(fmt.Sprintf("image %q not found in %s%s", input.Name, input.SpecID, versionSuffix(res))), nil, nil

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/higebu/3gpp-mcp/internal/specver"
@@ -86,12 +87,13 @@ func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolR
 		end = totalLines
 	}
 
-	charLimited := false
 	if maxChars > 0 {
 		charCount := 0
 		charEnd := end
 		for i := offset; i < end; i++ {
-			charCount += len(lines[i]) + 1
+			// Count characters, not bytes: max_chars is documented as a
+			// character limit and non-ASCII text must not truncate early.
+			charCount += utf8.RuneCountInString(lines[i]) + 1
 			if charCount > maxChars {
 				if i > offset {
 					charEnd = i
@@ -103,14 +105,14 @@ func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolR
 		}
 		if charEnd < end {
 			end = charEnd
-			charLimited = true
 		}
 	}
 
 	// Smart cut: extend to the next paragraph boundary (empty line).
-	// maxLines * 1.2 caps how far we look ahead. When the character budget
-	// decided the cut, extending would silently exceed it, so skip.
-	if !charLimited && end < totalLines {
+	// maxLines * 1.2 caps how far we look ahead. Extending would silently
+	// exceed a character budget — even one the window happened to fit
+	// exactly — so any max_chars disables the extension.
+	if maxChars <= 0 && end < totalLines {
 		linesUsed := end - offset
 		hardLimit := end + linesUsed/5
 		if hardLimit <= end {

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -189,6 +189,34 @@ func TestHandleGetImage(t *testing.T) {
 		if !result.IsError {
 			t.Error("expected error result for missing image")
 		}
+		text := getTextContent(result)
+		if !strings.Contains(text, `image "nonexistent.png" not found in TS 23.501`) {
+			t.Errorf("expected a clean not-found message, got: %s", text)
+		}
+		// The raw driver error ("sql: no rows in result set") must not leak.
+		if strings.Contains(text, "sql:") {
+			t.Errorf("message leaks a SQL error: %s", text)
+		}
+	})
+
+	t.Run("real failure is not labeled not-found", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID: "TS 99.999",
+			Name:   "image1.png",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Fatal("expected error result for an unknown spec")
+		}
+		text := getTextContent(result)
+		if !strings.HasPrefix(text, "failed to get image") {
+			t.Errorf("expected a neutral failure prefix, got: %s", text)
+		}
+		if strings.Contains(text, "image not found") {
+			t.Errorf("a lookup failure must not read as a definitive not-found: %s", text)
+		}
 	})
 
 	t.Run("empty spec_id", func(t *testing.T) {

--- a/tools/references.go
+++ b/tools/references.go
@@ -17,6 +17,7 @@ type GetReferencesInput struct {
 	SectionNumber      string `json:"section_number,omitempty" jsonschema:"Section number (e.g. 5.1.2). Required for outgoing direction."`
 	Direction          string `json:"direction,omitempty" jsonschema:"outgoing (default): references FROM this section to other specs. incoming: references TO this spec/section from other specs."`
 	IncludeSubsections bool   `json:"include_subsections,omitempty" jsonschema:"Include subsections when collecting outgoing references (default: false)"`
+	Offset             int    `json:"offset,omitempty" jsonschema:"Number of references to skip, for paging past a truncated response (default: 0)"`
 }
 
 var GetReferencesTool = &mcp.Tool{
@@ -29,7 +30,8 @@ Directions:
 - incoming: Find all sections that reference a given spec (and optionally a specific section).
   Requires spec_id. section_number is optional.
 
-Returns structured reference data including target spec, section, title (if available in DB), and context snippet.`,
+Returns structured reference data including target spec, section, title (if available in DB), and context snippet.
+Responses are capped at 500 references; a separate notice reports the total, and offset pages through the rest.`,
 }
 
 func HandleGetReferences(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input GetReferencesInput) (*mcp.CallToolResult, any, error) {
@@ -60,20 +62,48 @@ func HandleGetReferences(d *db.DB) func(ctx context.Context, req *mcp.CallToolRe
 
 		// A heavily-cited spec can have tens of thousands of incoming
 		// references; without a cap a single call would serialize them all.
+		// offset makes the rows beyond the cap reachable.
 		total := len(refs)
-		if total > MaxReferences {
-			refs = refs[:MaxReferences]
+		offset := input.Offset
+		if offset < 0 {
+			offset = 0
 		}
+		if offset >= total {
+			return referencesResult("[]",
+				fmt.Sprintf("[No references at offset %d. Total references: %d]", offset, total)), nil, nil
+		}
+		end := offset + MaxReferences
+		if end > total {
+			end = total
+		}
+		refs = refs[offset:end]
 
 		data, err := json.MarshalIndent(refs, "", "  ")
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to marshal: %v", err)), nil, nil
 		}
 
-		text := string(data)
-		if total > MaxReferences {
-			text += fmt.Sprintf("\n[Truncated: showing %d of %d references. Narrow the query with section_number.]", MaxReferences, total)
+		// The notice travels as its own content item so the JSON payload
+		// stays parseable even when the result is truncated.
+		notice := ""
+		if offset > 0 || end < total {
+			notice = fmt.Sprintf("[Showing references %d-%d of %d.", offset+1, end, total)
+			if end < total {
+				notice += fmt.Sprintf(" Use offset=%d to continue, or narrow the query with section_number.", end)
+			}
+			notice += "]"
 		}
-		return textResult(text), nil, nil
+		return referencesResult(string(data), notice), nil, nil
 	}
+}
+
+// referencesResult builds a result whose first content item is the JSON
+// payload; a non-empty notice is appended as a separate item so it never
+// corrupts the JSON.
+func referencesResult(payload, notice string) *mcp.CallToolResult {
+	res := textResult(payload)
+	if notice != "" {
+		res.Content = append(res.Content, &mcp.TextContent{Text: notice})
+	}
+	return res
 }

--- a/tools/source.go
+++ b/tools/source.go
@@ -168,12 +168,9 @@ func (s *Source) GetSection(ctx context.Context, specID, version, number string,
 		return nil, res, err
 	}
 	if res.Archived {
-		sections, err := s.Store.GetSection(specID, res.Version, number, includeSubsections)
-		if err == nil && len(sections) == 0 {
-			if err := s.textStillCached(specID, res); err != nil {
-				return nil, res, err
-			}
-		}
+		sections, err := s.archivedSections(specID, res, func() ([]db.Section, error) {
+			return s.Store.GetSection(specID, res.Version, number, includeSubsections)
+		})
 		return sections, res, err
 	}
 	sections, err := s.DB.GetSection(specID, res.Version, number, includeSubsections)
@@ -188,12 +185,9 @@ func (s *Source) AllSections(ctx context.Context, specID, version string) ([]db.
 		return nil, res, err
 	}
 	if res.Archived {
-		sections, err := s.Store.AllSections(specID, res.Version)
-		if err == nil && len(sections) == 0 {
-			if err := s.textStillCached(specID, res); err != nil {
-				return nil, res, err
-			}
-		}
+		sections, err := s.archivedSections(specID, res, func() ([]db.Section, error) {
+			return s.Store.AllSections(specID, res.Version)
+		})
 		return sections, res, err
 	}
 	sections, err := s.DB.AllSections(specID, res.Version)
@@ -207,12 +201,9 @@ func (s *Source) GetTOC(ctx context.Context, specID, version string) ([]db.Secti
 		return nil, res, err
 	}
 	if res.Archived {
-		sections, err := s.Store.GetTOC(specID, res.Version)
-		if err == nil && len(sections) == 0 {
-			if err := s.textStillCached(specID, res); err != nil {
-				return nil, res, err
-			}
-		}
+		sections, err := s.archivedSections(specID, res, func() ([]db.Section, error) {
+			return s.Store.GetTOC(specID, res.Version)
+		})
 		return sections, res, err
 	}
 	sections, err := s.DB.GetTOC(specID, res.Version)
@@ -266,19 +257,30 @@ func (s *Source) ListImages(ctx context.Context, specID, version string) ([]db.I
 	return infos, res, err
 }
 
-// textStillCached distinguishes "the version holds no such section" from "the
-// version was evicted between resolve and the read": a concurrent fetch's
-// eviction can drop it in that window, and answering a definitive not-found
-// then would hide content a retry recovers.
-func (s *Source) textStillCached(specID string, res Resolution) error {
-	cached, err := s.Store.Has(specID, res.Version)
-	if err != nil {
-		return err
+// archivedSections runs a section read against the version cache,
+// distinguishing "the version holds no such sections" from "the version was
+// evicted between resolve and the read": a concurrent fetch's eviction can
+// drop it in that window, and answering a definitive not-found then would
+// hide content a retry recovers. An empty read of an evicted version becomes
+// a retryable FetchInProgressError. When the entry is present after an empty
+// read, the read runs once more before the empty result is accepted — the
+// entry may be a fresh fetch that completed after the eviction, and its
+// content must not be masked by the stale empty read.
+func (s *Source) archivedSections(specID string, res Resolution, read func() ([]db.Section, error)) ([]db.Section, error) {
+	for range 2 {
+		sections, err := read()
+		if err != nil || len(sections) > 0 {
+			return sections, err
+		}
+		cached, err := s.Store.Has(specID, res.Version)
+		if err != nil {
+			return nil, err
+		}
+		if !cached {
+			return nil, &FetchInProgressError{SpecID: specID, Version: res.Version}
+		}
 	}
-	if !cached {
-		return &FetchInProgressError{SpecID: specID, Version: res.Version}
-	}
-	return nil
+	return nil, nil
 }
 
 // imagesStillCached distinguishes "the version holds no such images" from "the

--- a/tools/source.go
+++ b/tools/source.go
@@ -168,7 +168,7 @@ func (s *Source) GetSection(ctx context.Context, specID, version, number string,
 		return nil, res, err
 	}
 	if res.Archived {
-		sections, err := s.archivedSections(specID, res, func() ([]db.Section, error) {
+		sections, err := s.archivedSection(specID, res, number, includeSubsections, func() ([]db.Section, error) {
 			return s.Store.GetSection(specID, res.Version, number, includeSubsections)
 		})
 		return sections, res, err
@@ -257,30 +257,72 @@ func (s *Source) ListImages(ctx context.Context, specID, version string) ([]db.I
 	return infos, res, err
 }
 
-// archivedSections runs a section read against the version cache,
-// distinguishing "the version holds no such sections" from "the version was
-// evicted between resolve and the read": a concurrent fetch's eviction can
-// drop it in that window, and answering a definitive not-found then would
-// hide content a retry recovers. An empty read of an evicted version becomes
-// a retryable FetchInProgressError. When the entry is present after an empty
-// read, the read runs once more before the empty result is accepted — the
-// entry may be a fresh fetch that completed after the eviction, and its
-// content must not be masked by the stale empty read.
+// archivedSections runs a whole-version section read against the version
+// cache, converting an empty result into a retryable FetchInProgressError. A
+// successfully fetched version always holds at least one section
+// (pipeline.FetchVersion fails on a document that produced none), and the
+// cache writes and evicts a version's rows in one transaction, so a single
+// whole-version query reading empty proves the version was not cached at that
+// moment: a concurrent fetch's eviction dropped it between resolve and the
+// read. Answering a definitive not-found then would hide content a retry
+// re-fetches.
 func (s *Source) archivedSections(specID string, res Resolution, read func() ([]db.Section, error)) ([]db.Section, error) {
-	for range 2 {
-		sections, err := read()
-		if err != nil || len(sections) > 0 {
-			return sections, err
-		}
-		cached, err := s.Store.Has(specID, res.Version)
-		if err != nil {
-			return nil, err
-		}
-		if !cached {
-			return nil, &FetchInProgressError{SpecID: specID, Version: res.Version}
+	sections, err := read()
+	if err != nil {
+		return nil, err
+	}
+	if len(sections) == 0 {
+		return nil, &FetchInProgressError{SpecID: specID, Version: res.Version}
+	}
+	return sections, nil
+}
+
+// archivedSection reads one section (via read) from the version cache. An
+// empty per-number read is ambiguous — the version may genuinely lack the
+// section, or the read may have raced an eviction — so it is settled against
+// a whole-version TOC snapshot, which is atomic and empty exactly when the
+// version is not cached (see archivedSections). Every copy of a given version
+// holds the same sections, so the snapshot's verdict on the number is
+// definitive no matter how many evictions and re-fetches surround the reads.
+func (s *Source) archivedSection(specID string, res Resolution, number string, includeSubsections bool, read func() ([]db.Section, error)) ([]db.Section, error) {
+	sections, err := read()
+	if err != nil || len(sections) > 0 {
+		return sections, err
+	}
+
+	toc, err := s.archivedSections(specID, res, func() ([]db.Section, error) {
+		return s.Store.GetTOC(specID, res.Version)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !sectionInTOC(toc, number, includeSubsections) {
+		// A complete copy of the version lacks the section: definitively
+		// not found.
+		return nil, nil
+	}
+
+	// The snapshot holds the section, so the empty read was stale: an
+	// eviction hit between resolve and the read, and a fetch has since
+	// restored the version. Read again; if the eviction window reopens even
+	// here, tell the caller to retry rather than deny content that exists.
+	sections, err = read()
+	if err != nil || len(sections) > 0 {
+		return sections, err
+	}
+	return nil, &FetchInProgressError{SpecID: specID, Version: res.Version}
+}
+
+// sectionInTOC reports whether a TOC snapshot holds the section a read asked
+// for, mirroring the store's match: the exact number, or — with subsections —
+// any dotted descendant of it.
+func sectionInTOC(toc []db.Section, number string, includeSubsections bool) bool {
+	for _, sec := range toc {
+		if sec.Number == number || (includeSubsections && strings.HasPrefix(sec.Number, number+".")) {
+			return true
 		}
 	}
-	return nil, nil
+	return false
 }
 
 // imagesStillCached distinguishes "the version holds no such images" from "the

--- a/tools/source.go
+++ b/tools/source.go
@@ -169,6 +169,11 @@ func (s *Source) GetSection(ctx context.Context, specID, version, number string,
 	}
 	if res.Archived {
 		sections, err := s.Store.GetSection(specID, res.Version, number, includeSubsections)
+		if err == nil && len(sections) == 0 {
+			if err := s.textStillCached(specID, res); err != nil {
+				return nil, res, err
+			}
+		}
 		return sections, res, err
 	}
 	sections, err := s.DB.GetSection(specID, res.Version, number, includeSubsections)
@@ -184,6 +189,11 @@ func (s *Source) AllSections(ctx context.Context, specID, version string) ([]db.
 	}
 	if res.Archived {
 		sections, err := s.Store.AllSections(specID, res.Version)
+		if err == nil && len(sections) == 0 {
+			if err := s.textStillCached(specID, res); err != nil {
+				return nil, res, err
+			}
+		}
 		return sections, res, err
 	}
 	sections, err := s.DB.AllSections(specID, res.Version)
@@ -198,6 +208,11 @@ func (s *Source) GetTOC(ctx context.Context, specID, version string) ([]db.Secti
 	}
 	if res.Archived {
 		sections, err := s.Store.GetTOC(specID, res.Version)
+		if err == nil && len(sections) == 0 {
+			if err := s.textStillCached(specID, res); err != nil {
+				return nil, res, err
+			}
+		}
 		return sections, res, err
 	}
 	sections, err := s.DB.GetTOC(specID, res.Version)
@@ -249,6 +264,21 @@ func (s *Source) ListImages(ctx context.Context, specID, version string) ([]db.I
 	}
 	infos, err := s.DB.ListImages(specID, res.Version)
 	return infos, res, err
+}
+
+// textStillCached distinguishes "the version holds no such section" from "the
+// version was evicted between resolve and the read": a concurrent fetch's
+// eviction can drop it in that window, and answering a definitive not-found
+// then would hide content a retry recovers.
+func (s *Source) textStillCached(specID string, res Resolution) error {
+	cached, err := s.Store.Has(specID, res.Version)
+	if err != nil {
+		return err
+	}
+	if !cached {
+		return &FetchInProgressError{SpecID: specID, Version: res.Version}
+	}
+	return nil
 }
 
 // imagesStillCached distinguishes "the version holds no such images" from "the

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -187,10 +187,6 @@ func TestArchivedReadAfterEviction(t *testing.T) {
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
 		t.Fatalf("prime cache: %v", err)
 	}
-	res := Resolution{Version: "19.5.0", Archived: true}
-	if err := src.textStillCached("TS 23.501", res); err != nil {
-		t.Fatalf("textStillCached while cached: %v", err)
-	}
 
 	// Fetching another version pushes 19.5.0 out of the zero-byte cache.
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "20.2.0", "5.1", false); err != nil {
@@ -201,16 +197,101 @@ func TestArchivedReadAfterEviction(t *testing.T) {
 	}
 
 	// This is what the raced read sees: no rows, no error.
-	sections, err := store.GetSection("TS 23.501", "19.5.0", "5.1", false)
-	if err != nil || len(sections) != 0 {
-		t.Fatalf("read of an evicted version = %d sections, %v; want empty", len(sections), err)
+	res := Resolution{Version: "19.5.0", Archived: true}
+	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+		return store.GetSection("TS 23.501", "19.5.0", "5.1", false)
+	})
+	if len(sections) != 0 {
+		t.Fatalf("read of an evicted version returned %d sections, want none", len(sections))
 	}
 	var inProgress *FetchInProgressError
-	if err := src.textStillCached("TS 23.501", res); !errors.As(err, &inProgress) {
-		t.Fatalf("textStillCached after eviction = %v, want a FetchInProgressError", err)
+	if !errors.As(err, &inProgress) {
+		t.Fatalf("archivedSections after eviction = %v, want a FetchInProgressError", err)
 	}
 	if inProgress.Images {
 		t.Error("the error must name the version's text, not its images")
+	}
+}
+
+// TestArchivedSectionsRereadsAfterFreshFetch pins the recheck down against the
+// inverse race: the version is evicted (yielding the stale empty read) and a
+// fresh fetch completes before the cache re-check, so the entry is present
+// again. The stale empty result must not be accepted — the read runs once
+// more and returns the fresh content.
+func TestArchivedSectionsRereadsAfterFreshFetch(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	res := Resolution{Version: "19.5.0", Archived: true}
+	fresh := []db.Section{{SpecID: "TS 23.501", Version: "19.5.0", Number: "5.1", Content: "refetched"}}
+	reads := 0
+	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+		reads++
+		if reads == 1 {
+			// The eviction hit between resolve and this read; the re-fetch
+			// completed before the entry re-check.
+			return nil, nil
+		}
+		return fresh, nil
+	})
+	if err != nil {
+		t.Fatalf("archivedSections: %v", err)
+	}
+	if reads != 2 || len(sections) != 1 || sections[0].Content != "refetched" {
+		t.Fatalf("got %d reads, sections %+v; want the second read's content", reads, sections)
+	}
+}
+
+// TestArchivedSectionsEmptyStaysEmpty checks that a version the cache holds
+// but that genuinely lacks the requested sections still reads as empty with
+// no error, so callers keep answering a definitive not-found.
+func TestArchivedSectionsEmptyStaysEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	res := Resolution{Version: "19.5.0", Archived: true}
+	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+		return src.Store.GetSection("TS 23.501", "19.5.0", "99", false)
+	})
+	if err != nil || len(sections) != 0 {
+		t.Fatalf("archivedSections = %+v, %v; want empty with no error", sections, err)
+	}
+
+	// A read failure propagates as-is.
+	readErr := errors.New("cache read blew up")
+	if _, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+		return nil, readErr
+	}); !errors.Is(err, readErr) {
+		t.Fatalf("archivedSections with failing read = %v, want %v", err, readErr)
+	}
+}
+
+// TestArchivedSectionsCacheCheckError checks that a failure of the cache
+// re-check itself surfaces instead of being swallowed into a not-found.
+func TestArchivedSectionsCacheCheckError(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	// Closing the store makes Store.Has fail on the next call.
+	if err := src.Store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	res := Resolution{Version: "19.5.0", Archived: true}
+	_, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("expected the cache check failure to surface")
+	}
+	var inProgress *FetchInProgressError
+	if errors.As(err, &inProgress) {
+		t.Fatalf("a cache check failure must not read as a fetch in progress: %v", err)
 	}
 }
 

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -187,6 +187,10 @@ func TestArchivedReadAfterEviction(t *testing.T) {
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
 		t.Fatalf("prime cache: %v", err)
 	}
+	// While cached, the whole-version reads serve the content.
+	if sections, res, err := src.AllSections(context.Background(), "TS 23.501", "19.5.0"); err != nil || !res.Archived || len(sections) != 1 {
+		t.Fatalf("AllSections while cached = %d sections, %+v, %v; want one archived section", len(sections), res, err)
+	}
 
 	// Fetching another version pushes 19.5.0 out of the zero-byte cache.
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "20.2.0", "5.1", false); err != nil {
@@ -196,10 +200,11 @@ func TestArchivedReadAfterEviction(t *testing.T) {
 		t.Fatalf("expected 19.5.0 to be evicted (cached=%v, err=%v)", cached, err)
 	}
 
-	// This is what the raced read sees: no rows, no error.
+	// This is what raced whole-version and per-number reads see: no rows,
+	// no error. Both must report a retryable in-progress fetch.
 	res := Resolution{Version: "19.5.0", Archived: true}
 	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
-		return store.GetSection("TS 23.501", "19.5.0", "5.1", false)
+		return store.AllSections("TS 23.501", "19.5.0")
 	})
 	if len(sections) != 0 {
 		t.Fatalf("read of an evicted version returned %d sections, want none", len(sections))
@@ -211,14 +216,20 @@ func TestArchivedReadAfterEviction(t *testing.T) {
 	if inProgress.Images {
 		t.Error("the error must name the version's text, not its images")
 	}
+
+	if _, err := src.archivedSection("TS 23.501", res, "5.1", false, func() ([]db.Section, error) {
+		return store.GetSection("TS 23.501", "19.5.0", "5.1", false)
+	}); !errors.As(err, &inProgress) {
+		t.Fatalf("archivedSection after eviction = %v, want a FetchInProgressError", err)
+	}
 }
 
-// TestArchivedSectionsRereadsAfterFreshFetch pins the recheck down against the
-// inverse race: the version is evicted (yielding the stale empty read) and a
-// fresh fetch completes before the cache re-check, so the entry is present
-// again. The stale empty result must not be accepted — the read runs once
-// more and returns the fresh content.
-func TestArchivedSectionsRereadsAfterFreshFetch(t *testing.T) {
+// TestArchivedSectionStaleReadRecovers pins the eviction-and-restore race: the
+// per-number read returns a stale empty result because an eviction hit it, but
+// a fetch restored the version before the TOC snapshot. The snapshot proves
+// the section exists, so the read runs again and returns the content instead
+// of a definitive not-found.
+func TestArchivedSectionStaleReadRecovers(t *testing.T) {
 	d := setupTestDB(t)
 	src := sourceWithStore(t, d, cannedFetcher)
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
@@ -226,29 +237,30 @@ func TestArchivedSectionsRereadsAfterFreshFetch(t *testing.T) {
 	}
 
 	res := Resolution{Version: "19.5.0", Archived: true}
-	fresh := []db.Section{{SpecID: "TS 23.501", Version: "19.5.0", Number: "5.1", Content: "refetched"}}
 	reads := 0
-	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+	sections, err := src.archivedSection("TS 23.501", res, "5.1", false, func() ([]db.Section, error) {
 		reads++
 		if reads == 1 {
-			// The eviction hit between resolve and this read; the re-fetch
-			// completed before the entry re-check.
+			// The eviction hit this read; the restoring fetch completed
+			// before the snapshot below.
 			return nil, nil
 		}
-		return fresh, nil
+		return src.Store.GetSection("TS 23.501", "19.5.0", "5.1", false)
 	})
 	if err != nil {
-		t.Fatalf("archivedSections: %v", err)
+		t.Fatalf("archivedSection: %v", err)
 	}
-	if reads != 2 || len(sections) != 1 || sections[0].Content != "refetched" {
-		t.Fatalf("got %d reads, sections %+v; want the second read's content", reads, sections)
+	if reads != 2 || len(sections) != 1 || !strings.Contains(sections[0].Content, "Archived text") {
+		t.Fatalf("got %d reads, sections %+v; want the restored content", reads, sections)
 	}
 }
 
-// TestArchivedSectionsEmptyStaysEmpty checks that a version the cache holds
-// but that genuinely lacks the requested sections still reads as empty with
-// no error, so callers keep answering a definitive not-found.
-func TestArchivedSectionsEmptyStaysEmpty(t *testing.T) {
+// TestArchivedSectionRacedTwiceStaysRetryable pins the exhaustion behavior:
+// when evictions and restores race BOTH reads (each returns a stale empty
+// result while the TOC snapshot shows the section exists), the caller gets a
+// retryable fetch-in-progress error — existing content must never be reported
+// as definitively missing.
+func TestArchivedSectionRacedTwiceStaysRetryable(t *testing.T) {
 	d := setupTestDB(t)
 	src := sourceWithStore(t, d, cannedFetcher)
 	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
@@ -256,42 +268,51 @@ func TestArchivedSectionsEmptyStaysEmpty(t *testing.T) {
 	}
 
 	res := Resolution{Version: "19.5.0", Archived: true}
-	sections, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
+	// Both reads race an eviction window; the version itself is restored each
+	// time, so the TOC snapshot holds section 5.1 throughout. Also exercises
+	// the subsection match: the read asks for parent section 5 with
+	// subsections, which only 5.1 satisfies.
+	reads := 0
+	sections, err := src.archivedSection("TS 23.501", res, "5", true, func() ([]db.Section, error) {
+		reads++
+		return nil, nil
+	})
+	if reads != 2 || len(sections) != 0 {
+		t.Fatalf("got %d reads, %d sections; want two raced empty reads", reads, len(sections))
+	}
+	var inProgress *FetchInProgressError
+	if !errors.As(err, &inProgress) {
+		t.Fatalf("archivedSection raced twice = %v, want a FetchInProgressError", err)
+	}
+}
+
+// TestArchivedSectionEmptyStaysEmpty checks that a section the cached version
+// genuinely lacks still reads as empty with no error — the TOC snapshot names
+// every section the version has, so callers keep answering a definitive
+// not-found — and that read failures propagate from both helpers.
+func TestArchivedSectionEmptyStaysEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	res := Resolution{Version: "19.5.0", Archived: true}
+	sections, err := src.archivedSection("TS 23.501", res, "99", false, func() ([]db.Section, error) {
 		return src.Store.GetSection("TS 23.501", "19.5.0", "99", false)
 	})
 	if err != nil || len(sections) != 0 {
-		t.Fatalf("archivedSections = %+v, %v; want empty with no error", sections, err)
+		t.Fatalf("archivedSection = %+v, %v; want empty with no error", sections, err)
 	}
 
-	// A read failure propagates as-is.
+	// A read failure propagates as-is from both helpers.
 	readErr := errors.New("cache read blew up")
-	if _, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
-		return nil, readErr
-	}); !errors.Is(err, readErr) {
+	failing := func() ([]db.Section, error) { return nil, readErr }
+	if _, err := src.archivedSections("TS 23.501", res, failing); !errors.Is(err, readErr) {
 		t.Fatalf("archivedSections with failing read = %v, want %v", err, readErr)
 	}
-}
-
-// TestArchivedSectionsCacheCheckError checks that a failure of the cache
-// re-check itself surfaces instead of being swallowed into a not-found.
-func TestArchivedSectionsCacheCheckError(t *testing.T) {
-	d := setupTestDB(t)
-	src := sourceWithStore(t, d, cannedFetcher)
-	// Closing the store makes Store.Has fail on the next call.
-	if err := src.Store.Close(); err != nil {
-		t.Fatalf("close store: %v", err)
-	}
-
-	res := Resolution{Version: "19.5.0", Archived: true}
-	_, err := src.archivedSections("TS 23.501", res, func() ([]db.Section, error) {
-		return nil, nil
-	})
-	if err == nil {
-		t.Fatal("expected the cache check failure to surface")
-	}
-	var inProgress *FetchInProgressError
-	if errors.As(err, &inProgress) {
-		t.Fatalf("a cache check failure must not read as a fetch in progress: %v", err)
+	if _, err := src.archivedSection("TS 23.501", res, "5.1", false, failing); !errors.Is(err, readErr) {
+		t.Fatalf("archivedSection with failing read = %v, want %v", err, readErr)
 	}
 }
 

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -132,6 +133,84 @@ func TestGetSectionFetchesArchivedVersion(t *testing.T) {
 	}
 	if !res.Archived || len(toc) != 1 {
 		t.Errorf("GetTOC = %+v, %+v; want one archived section", toc, res)
+	}
+}
+
+// TestGetSectionArchivedMissingSection checks that a section the cached
+// version genuinely does not hold stays a definitive versioned not-found —
+// the eviction re-check must not turn it into a retry hint.
+func TestGetSectionArchivedMissingSection(t *testing.T) {
+	d := setupTestDB(t)
+	src := sourceWithStore(t, d, cannedFetcher)
+	handler := HandleGetSection(src)
+
+	result, _, err := handler(context.Background(), nil, GetSectionInput{
+		SpecID:        "TS 23.501",
+		SectionNumber: "99",
+		Version:       "19.5.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result for a missing archived section")
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, "section 99 not found in TS 23.501 v19.5.0") {
+		t.Errorf("expected a versioned not-found message, got: %s", text)
+	}
+}
+
+// TestArchivedReadAfterEviction covers the window between resolve and the
+// store read: a fetch of another version can evict the resolved one there, so
+// an empty read of an evicted version must become a retryable
+// fetch-in-progress error rather than a definitive not-found.
+func TestArchivedReadAfterEviction(t *testing.T) {
+	d := setupTestDB(t)
+	store, err := versionstore.Open(versionstore.Options{
+		Path:    filepath.Join(t.TempDir(), "versions.db"),
+		Fetcher: cannedFetcher,
+		// Zero keeps only the newest fetch, so caching a second version
+		// evicts the first through the real eviction path.
+		LimitBytes: 0,
+	})
+	if err != nil {
+		t.Fatalf("versionstore.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	src := NewSource(d)
+	src.Store = store
+	src.Client = archiveClient(t)
+	src.UseCache = false
+	src.Budget = 5 * time.Second
+
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "19.5.0", "5.1", false); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	res := Resolution{Version: "19.5.0", Archived: true}
+	if err := src.textStillCached("TS 23.501", res); err != nil {
+		t.Fatalf("textStillCached while cached: %v", err)
+	}
+
+	// Fetching another version pushes 19.5.0 out of the zero-byte cache.
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "20.2.0", "5.1", false); err != nil {
+		t.Fatalf("fetch evicting version: %v", err)
+	}
+	if cached, err := store.Has("TS 23.501", "19.5.0"); err != nil || cached {
+		t.Fatalf("expected 19.5.0 to be evicted (cached=%v, err=%v)", cached, err)
+	}
+
+	// This is what the raced read sees: no rows, no error.
+	sections, err := store.GetSection("TS 23.501", "19.5.0", "5.1", false)
+	if err != nil || len(sections) != 0 {
+		t.Fatalf("read of an evicted version = %d sections, %v; want empty", len(sections), err)
+	}
+	var inProgress *FetchInProgressError
+	if err := src.textStillCached("TS 23.501", res); !errors.As(err, &inProgress) {
+		t.Fatalf("textStillCached after eviction = %v, want a FetchInProgressError", err)
+	}
+	if inProgress.Images {
+		t.Error("the error must name the version's text, not its images")
 	}
 }
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -658,6 +658,22 @@ func TestHandleGetReferences(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid direction", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetReferencesInput{
+			SpecID:    "TS 24.229",
+			Direction: "sideways",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.IsError {
+			t.Error("expected error result for an invalid direction")
+		}
+		if text := getTextContent(result); !strings.Contains(text, "invalid direction") {
+			t.Errorf("expected the direction error, got: %s", text)
+		}
+	})
+
 	t.Run("outgoing without section", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, GetReferencesInput{
 			SpecID:    "TS 24.229",
@@ -1010,6 +1026,25 @@ func TestHandleGetReferences_Truncation(t *testing.T) {
 		notice := result.Content[1].(*mcp.TextContent).Text
 		if !strings.Contains(notice, fmt.Sprintf("[Showing references %d-%d of %d.]", MaxReferences+1, MaxReferences+10, MaxReferences+10)) {
 			t.Errorf("notice = %q, want the final range without a continue hint", notice)
+		}
+	})
+
+	t.Run("negative offset treated as zero", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetReferencesInput{
+			SpecID: "TS 23.501", Direction: "incoming", Offset: -7,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var page []map[string]any
+		if err := json.Unmarshal([]byte(getTextContent(result)), &page); err != nil {
+			t.Fatalf("payload is not valid JSON: %v", err)
+		}
+		if len(page) != MaxReferences {
+			t.Errorf("expected the first page of %d references, got %d", MaxReferences, len(page))
+		}
+		if len(result.Content) != 2 || !strings.Contains(result.Content[1].(*mcp.TextContent).Text, "[Showing references 1-") {
+			t.Errorf("expected the first-page notice, got: %+v", result.Content)
 		}
 	})
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -555,6 +555,29 @@ func TestPaginateText(t *testing.T) {
 		}
 	})
 
+	t.Run("max_chars is not exceeded when the window fits it exactly", func(t *testing.T) {
+		// Five 5-char lines fill the 30-char budget without truncation, so
+		// the budget never "decided the cut" — the smart cut must still not
+		// extend to the paragraph boundary at line 6, which would exceed it.
+		exactContent := "11111\n22222\n33333\n44444\n55555\n\nrest here"
+		result := paginateText(exactContent, 0, 5, 30)
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 1-5 of 7]") {
+			t.Errorf("expected the exact-fit budget to hold at 5 lines, got: %s", text)
+		}
+	})
+
+	t.Run("max_chars counts characters, not bytes", func(t *testing.T) {
+		// Each line is 5 runes (15 bytes); a 12-char budget must fit two
+		// lines (2 x (5+1) = 12), not cut after one as byte counting would.
+		runeContent := "あいうえお\nかきくけこ\nさしすせそ"
+		result := paginateText(runeContent, 0, 10, 12)
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 1-2 of 3]") {
+			t.Errorf("expected 2 lines within a 12-character budget, got: %s", text)
+		}
+	})
+
 	t.Run("max_chars is not exceeded by smart cut", func(t *testing.T) {
 		// The char budget cuts at line 5 (5 lines x 6 chars = 30); the
 		// paragraph boundary at line 6 is within the smart-cut lookahead

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -947,8 +948,9 @@ func TestHandleGetOpenAPI_FilteredPagination(t *testing.T) {
 }
 
 // TestHandleGetReferences_Truncation verifies the response cap: a spec-wide
-// incoming query over a heavily-cited spec is cut at MaxReferences with a
-// notice instead of serializing every row.
+// incoming query over a heavily-cited spec is cut at MaxReferences, the JSON
+// payload stays parseable, the truncation notice travels as its own content
+// item, and offset reaches the rows beyond the cap.
 func TestHandleGetReferences_Truncation(t *testing.T) {
 	d := setupTestDB(t)
 	handler := HandleGetReferences(d)
@@ -972,10 +974,73 @@ func TestHandleGetReferences_Truncation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	text := getTextContent(result)
-	if !strings.Contains(text, fmt.Sprintf("[Truncated: showing %d of %d references", MaxReferences, MaxReferences+10)) {
-		t.Errorf("expected a truncation notice, got tail: %s", text[len(text)-200:])
+	var page []map[string]any
+	if err := json.Unmarshal([]byte(text), &page); err != nil {
+		t.Fatalf("truncated payload is not valid JSON: %v", err)
 	}
-	if got := strings.Count(text, `"source_spec_id"`); got != MaxReferences {
-		t.Errorf("expected %d serialized references, got %d", MaxReferences, got)
+	if len(page) != MaxReferences {
+		t.Errorf("expected %d serialized references, got %d", MaxReferences, len(page))
 	}
+	if len(result.Content) != 2 {
+		t.Fatalf("expected the notice as a second content item, got %d items", len(result.Content))
+	}
+	notice := result.Content[1].(*mcp.TextContent).Text
+	want := fmt.Sprintf("[Showing references 1-%d of %d. Use offset=%d to continue", MaxReferences, MaxReferences+10, MaxReferences)
+	if !strings.Contains(notice, want) {
+		t.Errorf("notice = %q, want it to contain %q", notice, want)
+	}
+
+	t.Run("offset reaches the remaining references", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetReferencesInput{
+			SpecID: "TS 23.501", Direction: "incoming", Offset: MaxReferences,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var rest []map[string]any
+		if err := json.Unmarshal([]byte(getTextContent(result)), &rest); err != nil {
+			t.Fatalf("offset payload is not valid JSON: %v", err)
+		}
+		if len(rest) != 10 {
+			t.Errorf("expected the 10 remaining references, got %d", len(rest))
+		}
+		if len(result.Content) != 2 {
+			t.Fatalf("expected a range notice, got %d content items", len(result.Content))
+		}
+		notice := result.Content[1].(*mcp.TextContent).Text
+		if !strings.Contains(notice, fmt.Sprintf("[Showing references %d-%d of %d.]", MaxReferences+1, MaxReferences+10, MaxReferences+10)) {
+			t.Errorf("notice = %q, want the final range without a continue hint", notice)
+		}
+	})
+
+	t.Run("offset past the end", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetReferencesInput{
+			SpecID: "TS 23.501", Direction: "incoming", Offset: MaxReferences * 10,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if text := getTextContent(result); text != "[]" {
+			t.Errorf("expected an empty JSON array payload, got: %s", text)
+		}
+		if len(result.Content) != 2 || !strings.Contains(result.Content[1].(*mcp.TextContent).Text, "No references at offset") {
+			t.Errorf("expected an out-of-range notice, got: %+v", result.Content)
+		}
+	})
+
+	t.Run("untruncated result has a single JSON content item", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, GetReferencesInput{
+			SpecID: "TS 33.203", Direction: "incoming",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Content) != 1 {
+			t.Errorf("expected no notice for an untruncated result, got %d content items", len(result.Content))
+		}
+		var page []map[string]any
+		if err := json.Unmarshal([]byte(getTextContent(result)), &page); err != nil {
+			t.Fatalf("payload is not valid JSON: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Fixes four robustness issues in the MCP tool handlers.

- `paginateText` no longer exceeds `max_chars` via the paragraph-boundary extension, and counts runes instead of bytes so non-ASCII text is not cut early
- `get_image` no longer leaks raw SQL errors as "not found"; real failures are reported as `failed to get image` while a missing image gets a clean version-aware message
- `get_references` returns the truncation notice as a separate MCP content item so the JSON payload stays parseable, and gains an `offset` parameter to reach references beyond the 500-entry cap
- archived text reads re-check the version cache after an empty result and return a retryable fetch-in-progress error when the entry was concurrently evicted by the LRU

Reviewed with open-code-review; no findings.

Closes #97
Closes #103
Closes #104
Closes #107

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn2P9TSfFhMruwNbVm9M4x)_