### PR TITLE
fix: versionstore and pipeline fetch/cache correctness

### DIFF
--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -392,6 +392,13 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 	} else {
 		fmt.Println("Fetching spec list from 3GPP archive...")
 		entries, err = pipeline.FetchSpecList(ctx, client, seriesFilter, useCache, scrapeConcurrency)
+		var partial *pipeline.PartialSpecListError
+		if errors.As(err, &partial) {
+			// Proceeding would silently drop every spec under the failed
+			// directories from the result, so a build or download from this
+			// list would be quietly incomplete.
+			log.Fatalf("Aborting: %v; rerun to retry", partial)
+		}
 		if err != nil {
 			log.Fatalf("Failed to fetch spec list: %v", err)
 		}
@@ -638,6 +645,13 @@ func cmdUpdate(args []string) {
 	} else {
 		fmt.Println("Fetching spec list from 3GPP archive...")
 		entries, err = pipeline.FetchSpecList(ctx, client, nil, useCache, *scrapeWorkers)
+	}
+	// A partial list is survivable here: a spec missing from it is skipped
+	// rather than deleted, so the cost is missed updates until the next run.
+	var partial *pipeline.PartialSpecListError
+	if errors.As(err, &partial) {
+		log.Printf("warning: %v; specs under the failed directories will not be updated this run", partial)
+		err = nil
 	}
 	if err != nil {
 		_ = os.Remove(newPath)

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -359,6 +359,13 @@ func cmdConvertDir(args []string) {
 // terminating the test process.
 var exit = os.Exit
 
+// newHTTPClient builds the client used for archive scraping and downloads.
+// It is a variable so tests can point commands that construct their own
+// client, such as update, at a mock archive server.
+var newHTTPClient = func(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}
+
 // requireSelector exits unless at least one spec selector flag was provided.
 func requireSelector(release int, latest bool, spec, series string) {
 	if release != 0 || latest || spec != "" || series != "" {
@@ -397,7 +404,9 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 			// Proceeding would silently drop every spec under the failed
 			// directories from the result, so a build or download from this
 			// list would be quietly incomplete.
-			log.Fatalf("Aborting: %v; rerun to retry", partial)
+			log.Printf("Aborting: %v; rerun to retry", partial)
+			exit(1)
+			return nil
 		}
 		if err != nil {
 			log.Fatalf("Failed to fetch spec list: %v", err)
@@ -635,7 +644,7 @@ func cmdUpdate(args []string) {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
-	client := &http.Client{Timeout: *timeout}
+	client := newHTTPClient(*timeout)
 	useCache := !*noCache
 
 	// Fetch latest versions from FTP

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -702,6 +704,117 @@ func TestCmdUpdate_AllUpToDate(t *testing.T) {
 	})
 	if !strings.Contains(out, "All specs are up to date") {
 		t.Errorf("expected 'All specs are up to date' message, got: %s", out)
+	}
+}
+
+// partialArchive serves a mock archive where 23.501 lists one zip and 23.502
+// fails, so a full scrape assembles a partial spec list.
+func partialArchive(t *testing.T, healthyZip string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ftp/Specs/archive/" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc("/ftp/Specs/archive/23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23.501/">23.501</a>`+"\n"+`<a href="23.502/">23.502</a>`+"\n")
+	})
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `<a href="%s">%s</a>`+"\n", healthyZip, healthyZip)
+	})
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.502/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// captureLog runs fn and returns whatever it wrote through the log package.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	fn()
+	return buf.String()
+}
+
+// TestResolveSpecs_PartialSpecListAborts verifies that a scrape which lost
+// some directory listings aborts the command instead of quietly producing an
+// incomplete database from the partial list.
+func TestResolveSpecs_PartialSpecListAborts(t *testing.T) {
+	ts := partialArchive(t, "23501-k10.zip")
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	exitCode := -1
+	orig := exit
+	exit = func(code int) { exitCode = code }
+	t.Cleanup(func() { exit = orig })
+
+	logged := captureLog(t, func() {
+		_ = captureStdout(t, func() {
+			specs := resolveSpecs(context.Background(), client, "", "", "23", 0, false, 0)
+			if specs != nil {
+				t.Errorf("expected nil specs after an abort, got %d", len(specs))
+			}
+		})
+	})
+	if exitCode != 1 {
+		t.Errorf("exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(logged, "spec list is incomplete") {
+		t.Errorf("log = %q, want the incomplete-list abort message", logged)
+	}
+}
+
+// TestCmdUpdate_PartialSpecListWarns verifies that update survives a partial
+// spec list with a warning: a spec missing from the list is merely skipped,
+// so aborting the whole run would be needlessly strict.
+func TestCmdUpdate_PartialSpecListWarns(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update.db")
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	if err := d.UpsertSpec(db.Spec{
+		ID:           "TS 23.501",
+		Title:        "System architecture",
+		Version:      "20.1.0",
+		VersionToken: "k10",
+		Release:      "20",
+		Series:       "23",
+	}); err != nil {
+		t.Fatalf("upsert spec: %v", err)
+	}
+	d.Close()
+
+	// The healthy listing offers an OLDER version (j60 = v19.6.0), so the run
+	// finds nothing to update and finishes without downloading anything.
+	ts := partialArchive(t, "23501-j60.zip")
+	origClient := newHTTPClient
+	newHTTPClient = func(timeout time.Duration) *http.Client {
+		return &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+	}
+	t.Cleanup(func() { newHTTPClient = origClient })
+
+	var out string
+	logged := captureLog(t, func() {
+		out = captureStdout(t, func() {
+			cmdUpdate([]string{"-db", dbPath, "-no-cache"})
+		})
+	})
+	if !strings.Contains(logged, "will not be updated this run") {
+		t.Errorf("log = %q, want the partial-list warning", logged)
+	}
+	if !strings.Contains(out, "All specs are up to date") {
+		t.Errorf("output = %q, want the run to continue to completion", out)
 	}
 }
 

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -100,10 +100,14 @@ func ResolveVersion(ctx context.Context, client *http.Client, specID, version st
 // A dotted version is never a release selector, so "18.6.0" does not match.
 // Without a prefix, only one or two digits count: a three-digit string such
 // as "920" is a base-36 archive token (9.2.0), not a request for Rel-920.
+// A bare "R"/"r" prefix is not accepted either: 'r' is base-36 digit 27, so
+// an r-prefixed three-character string such as "r18" is the archive token for
+// v27.1.8, and treating it as "Rel-18" would silently resolve the wrong
+// document. Such strings fall through to exact-token matching instead.
 func releaseRequest(s string) (int, bool) {
 	trimmed := s
 	prefixed := false
-	for _, prefix := range []string{"Rel-", "rel-", "REL-", "R", "r"} {
+	for _, prefix := range []string{"Rel-", "rel-", "REL-"} {
 		if len(trimmed) > len(prefix) && trimmed[:len(prefix)] == prefix {
 			trimmed = trimmed[len(prefix):]
 			prefixed = true

--- a/converter/pipeline/ondemand_test.go
+++ b/converter/pipeline/ondemand_test.go
@@ -85,6 +85,44 @@ func TestResolveVersion(t *testing.T) {
 	}
 }
 
+// TestResolveVersionRel27Token checks that an r-prefixed archive token resolves
+// exactly: 'r' is base-36 digit 27, so once Rel-27 archives exist, "r18" names
+// v27.1.8 and must not be read as a "Rel-18" release selector.
+func TestResolveVersionRel27Token(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, _ *http.Request) {
+		for _, name := range []string{"23501-i60.zip", "23501-r18.zip", "23501-r20.zip"} {
+			fmt.Fprintf(w, `<a href="%s">%s</a>`+"\n", name, name)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	tests := []struct {
+		name    string
+		request string
+		want    string
+	}{
+		{name: "exact r token", request: "r18", want: "r18"},
+		{name: "uppercase r token", request: "R18", want: "r18"},
+		{name: "dotted Rel-27 version", request: "27.1.8", want: "r18"},
+		{name: "release selector picks newest in Rel-27", request: "Rel-27", want: "r20"},
+		{name: "bare release number still selects Rel-18", request: "18", want: "i60"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv, _, err := ResolveVersion(context.Background(), client, "TS 23.501", tt.request, false)
+			if err != nil {
+				t.Fatalf("ResolveVersion(%q): %v", tt.request, err)
+			}
+			if sv.Version != tt.want {
+				t.Errorf("ResolveVersion(%q) = %q, want %q", tt.request, sv.Version, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveVersionUnknownSpec(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
@@ -108,7 +146,7 @@ func TestReleaseRequest(t *testing.T) {
 		{"18", 18, true},
 		{"Rel-18", 18, true},
 		{"rel-18", 18, true},
-		{"R18", 18, true},
+		{"REL-27", 27, true},
 		{"18.6.0", 0, false},
 		{"i60", 0, false},
 		{"", 0, false},
@@ -118,6 +156,10 @@ func TestReleaseRequest(t *testing.T) {
 		{"920", 0, false},
 		{"100", 0, false},
 		{"Rel-920", 920, true},
+		// 'r' is base-36 digit 27, so "r18" is the archive token for v27.1.8;
+		// a bare R/r prefix must not turn it into a Rel-18 selector.
+		{"r18", 0, false},
+		{"R18", 0, false},
 	}
 	for _, tt := range tests {
 		got, ok := releaseRequest(tt.in)

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -224,9 +224,29 @@ func FetchSpecZips(ctx context.Context, client *http.Client, specID string, useC
 	return entries, nil
 }
 
+// PartialSpecListError reports that a spec list was assembled while some
+// directory listings failed to fetch. The entries returned alongside it are
+// valid but incomplete: every spec under a failed directory is missing, so a
+// database built from them would silently lack those specs. Callers decide
+// whether that is fatal — a build should abort, while an update may proceed
+// and merely miss some updates until the next run.
+type PartialSpecListError struct {
+	// FailedListings is the number of directory listings that failed to fetch.
+	FailedListings int
+}
+
+func (e *PartialSpecListError) Error() string {
+	return fmt.Sprintf("spec list is incomplete: %d directory listing(s) failed to fetch", e.FailedListings)
+}
+
 // FetchSpecList scrapes the 3GPP FTP directory for all spec zip files.
 // If useCache is true, results are cached to disk with a 24h TTL.
 // scrapeConcurrency controls parallel HTTP requests; 0 uses defaultConcurrency().
+//
+// When some directory listings fail, the entries assembled so far are returned
+// together with a *PartialSpecListError, so callers can tell a complete list
+// from one that is silently missing specs. A cancelled context is reported as
+// ctx.Err() rather than as a partial list.
 func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []string, useCache bool, scrapeConcurrency int) ([]string, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
@@ -338,10 +358,19 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 	log.Printf("Total: %d spec versions found", len(entries))
 
 	// A list missing the specs whose listings failed to fetch must not be
-	// cached: every build within the TTL would silently skip them.
+	// cached: every build within the TTL would silently skip them. The caller
+	// gets the partial entries plus an error naming the gap, so it can decide
+	// whether to proceed.
 	if failed := fetchFailures.Load(); failed > 0 {
+		// A cancelled context fails every remaining fetch; that is an abort,
+		// not a partial scrape.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		log.Printf("warning: %d directory listing(s) failed to fetch; not caching this partial spec list", failed)
-	} else if useCache {
+		return entries, &PartialSpecListError{FailedListings: int(failed)}
+	}
+	if useCache {
 		if err := SaveCache(cacheKey, entries); err != nil {
 			log.Printf("warning: failed to save cache: %v", err)
 		}

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -358,8 +359,10 @@ func TestFetchSpecList_Race(t *testing.T) {
 }
 
 // TestFetchSpecList_PartialNotCached verifies that a spec list assembled
-// while some directory listings failed to fetch is not written to the cache:
-// every build within the TTL would otherwise silently miss those specs.
+// while some directory listings failed to fetch is not written to the cache —
+// every build within the TTL would otherwise silently miss those specs — and
+// that the caller is told the list is incomplete instead of seeing a success:
+// a build from a silently partial list produces an incomplete database.
 func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	cacheHome := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", cacheHome)
@@ -389,9 +392,14 @@ func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
 
 	entries, err := FetchSpecList(context.Background(), client, nil, true, 2)
-	if err != nil {
-		t.Fatalf("FetchSpecList: %v", err)
+	var partial *PartialSpecListError
+	if !errors.As(err, &partial) {
+		t.Fatalf("FetchSpecList err = %v, want *PartialSpecListError", err)
 	}
+	if partial.FailedListings != 1 {
+		t.Errorf("FailedListings = %d, want 1", partial.FailedListings)
+	}
+	// The healthy entries still come back so a caller may choose to proceed.
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry from the healthy spec, got %d", len(entries))
 	}
@@ -399,5 +407,39 @@ func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
 	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
 		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_CancelReturnsContextError verifies that a scrape aborted
+// by context cancellation reports ctx.Err() instead of funnelling the failed
+// fetches into a partial-list result.
+func TestFetchSpecList_CancelReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != archivePath {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23.001/">23.001</a>`+"\n")
+	})
+	// The zip listing cancels the scrape mid-flight, as Ctrl-C would.
+	mux.HandleFunc(archivePath+"23_series/23.001/", func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+		http.Error(w, "shutting down", http.StatusInternalServerError)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	if _, err := FetchSpecList(ctx, client, nil, false, 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("FetchSpecList err = %v, want context.Canceled", err)
 	}
 }

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -399,6 +399,9 @@ func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	if partial.FailedListings != 1 {
 		t.Errorf("FailedListings = %d, want 1", partial.FailedListings)
 	}
+	if msg := partial.Error(); !strings.Contains(msg, "1 directory listing(s)") {
+		t.Errorf("Error() = %q, want it to name the failed listing count", msg)
+	}
 	// The healthy entries still come back so a caller may choose to proceed.
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry from the healthy spec, got %d", len(entries))
@@ -407,6 +410,47 @@ func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
 	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
 		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_CompleteListIsCached verifies that a scrape with no
+// failed listings still saves its result to the cache: only a partial list is
+// barred from it.
+func TestFetchSpecList_CompleteListIsCached(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != archivePath {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23.001/">23.001</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/23.001/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="23001-a00.zip">23001-a00.zip</a>`+"\n")
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	entries, err := FetchSpecList(context.Background(), client, nil, true, 2)
+	if err != nil {
+		t.Fatalf("FetchSpecList: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Errorf("complete spec list should be cached; stat err = %v", err)
 	}
 }
 

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -329,6 +329,35 @@ func TestEnsureImagesPropagatesFetchError(t *testing.T) {
 	}
 }
 
+// TestEnsureImagesRecoversFetcherPanic checks that a panic on the detached
+// image fetch goroutine is reported as an error instead of killing the
+// process, and that a later call can retry.
+func TestEnsureImagesRecoversFetcherPanic(t *testing.T) {
+	var calls atomic.Int32
+	s := openImageStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		if calls.Add(1) == 1 {
+			panic("slice bounds out of range")
+		}
+		return fakeImages(8), nil
+	})
+	ensureVersion(t, s, "TS 23.501", "18.6.0")
+
+	err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("EnsureImages = %v, want an error reporting the panic", err)
+	}
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); fetched {
+		t.Error("a panicked fetch must not mark images as fetched")
+	}
+	// The inflight slot must be released so a later call starts a fresh fetch.
+	if err := s.EnsureImages(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("EnsureImages retry after panic: %v", err)
+	}
+	if fetched, _ := s.HasImages("TS 23.501", "18.6.0"); !fetched {
+		t.Error("retry after a panicked fetch did not cache the images")
+	}
+}
+
 // TestImageBytesCountTowardLimit checks that image blobs join the eviction
 // account and that an evicted version takes its images with it.
 func TestImageBytesCountTowardLimit(t *testing.T) {

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -524,6 +524,14 @@ func (s *Store) Ensure(ctx context.Context, specID, version string, sv *pipeline
 // run performs one fetch and publishes its outcome to everyone waiting on it.
 func (s *Store) run(ctx context.Context, key, specID, version string, sv *pipeline.SpecVersion, f *fetch) {
 	defer func() {
+		// The pipeline parses untrusted third-party binaries on a goroutine
+		// detached from any request, so a parser panic here would take down the
+		// whole server. Recover before close(f.done) publishes the outcome, and
+		// set f.err first so waiters do not report success for content that was
+		// never cached.
+		if r := recover(); r != nil {
+			f.err = fmt.Errorf("version fetch for %s v%s panicked: %v", specID, version, r)
+		}
 		s.mu.Lock()
 		delete(s.inflight, key)
 		s.mu.Unlock()
@@ -671,6 +679,11 @@ func (s *Store) EnsureImages(ctx context.Context, specID, version string, sv *pi
 // waiting on it.
 func (s *Store) runImages(ctx context.Context, key, specID, version string, sv *pipeline.SpecVersion, f *fetch) {
 	defer func() {
+		// Same as run: recover a parser panic on this detached goroutine, and
+		// set f.err before close(f.done) publishes the outcome.
+		if r := recover(); r != nil {
+			f.err = fmt.Errorf("image fetch for %s v%s panicked: %v", specID, version, r)
+		}
 		s.mu.Lock()
 		delete(s.inflight, key)
 		s.mu.Unlock()

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -532,6 +532,9 @@ func (s *Store) run(ctx context.Context, key, specID, version string, sv *pipeli
 		// never cached.
 		if r := recover(); r != nil {
 			f.err = fmt.Errorf("version fetch for %s v%s panicked: %v", specID, version, r)
+			// The fetch is detached, so the last waiter is often gone by
+			// the time a panic fires; log it or it is lost entirely.
+			log.Printf("warning: %v", f.err)
 		}
 		s.mu.Lock()
 		delete(s.inflight, key)
@@ -684,6 +687,7 @@ func (s *Store) runImages(ctx context.Context, key, specID, version string, sv *
 		// set f.err before close(f.done) publishes the outcome.
 		if r := recover(); r != nil {
 			f.err = fmt.Errorf("image fetch for %s v%s panicked: %v", specID, version, r)
+			log.Printf("warning: %v", f.err)
 		}
 		s.mu.Lock()
 		delete(s.inflight, key)

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -313,6 +313,7 @@ func (s *Store) CachedVersions(specID string) ([]string, error) {
 
 // GetSpec returns the cached spec record for a version.
 func (s *Store) GetSpec(specID, version string) (*db.Spec, error) {
+	s.touch(specID, version)
 	var spec db.Spec
 	err := s.conn.QueryRow(
 		"SELECT id, version, COALESCE(version_token, ''), title, COALESCE(release, ''), COALESCE(series, '') FROM specs WHERE id = ? AND version = ?",

--- a/versionstore/versionstore_test.go
+++ b/versionstore/versionstore_test.go
@@ -306,6 +306,41 @@ func TestEnsureRecoversFetcherPanic(t *testing.T) {
 	}
 }
 
+// TestGetSpecTouchesLRU checks that reading the spec record refreshes the
+// entry's LRU timestamp like every other cached-read path, so a version read
+// mainly through GetSpec is not evicted ahead of less-recently-used entries.
+func TestGetSpecTouchesLRU(t *testing.T) {
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		spec, sections := fakeSpec("placeholder", "placeholder", 8)
+		return spec, sections, nil
+	})
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	// Age the entry, then read it through GetSpec.
+	if _, err := s.conn.Exec(
+		"UPDATE cache_entries SET last_used_at = 1 WHERE spec_id = ? AND version = ?",
+		"TS 23.501", "18.6.0",
+	); err != nil {
+		t.Fatalf("age entry: %v", err)
+	}
+	if spec, err := s.GetSpec("TS 23.501", "18.6.0"); err != nil || spec == nil {
+		t.Fatalf("GetSpec = %+v, %v", spec, err)
+	}
+
+	var lastUsed int64
+	if err := s.conn.QueryRow(
+		"SELECT last_used_at FROM cache_entries WHERE spec_id = ? AND version = ?",
+		"TS 23.501", "18.6.0",
+	).Scan(&lastUsed); err != nil {
+		t.Fatalf("read last_used_at: %v", err)
+	}
+	if lastUsed == 1 {
+		t.Error("GetSpec did not touch the LRU timestamp")
+	}
+}
+
 // TestEvictionDropsLeastRecentlyUsed fills the cache past its limit and checks
 // that the oldest entry goes and the newest stays.
 func TestEvictionDropsLeastRecentlyUsed(t *testing.T) {

--- a/versionstore/versionstore_test.go
+++ b/versionstore/versionstore_test.go
@@ -275,6 +275,37 @@ func TestEnsurePropagatesFetchError(t *testing.T) {
 	}
 }
 
+// TestEnsureRecoversFetcherPanic checks that a panic on the detached fetch
+// goroutine is reported as an error instead of killing the process: the
+// pipeline parses untrusted binaries, and no per-request recovery applies to
+// a goroutine deliberately detached from the request.
+func TestEnsureRecoversFetcherPanic(t *testing.T) {
+	var calls atomic.Int32
+	s := openStore(t, DefaultLimitBytes, func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+		if calls.Add(1) == 1 {
+			panic("slice bounds out of range")
+		}
+		spec, sections := fakeSpec("TS 23.501", "18.6.0", 8)
+		return spec, sections, nil
+	})
+
+	err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("Ensure = %v, want an error reporting the panic", err)
+	}
+	// The panic must not leave a cache entry claiming content that never landed.
+	if has, _ := s.Has("TS 23.501", "18.6.0"); has {
+		t.Error("a panicked fetch left a cache entry")
+	}
+	// The inflight slot must be released so a later call starts a fresh fetch.
+	if err := s.Ensure(context.Background(), "TS 23.501", "18.6.0", entry("23.501"), time.Minute); err != nil {
+		t.Fatalf("Ensure retry after panic: %v", err)
+	}
+	if has, _ := s.Has("TS 23.501", "18.6.0"); !has {
+		t.Error("retry after a panicked fetch did not cache the version")
+	}
+}
+
 // TestEvictionDropsLeastRecentlyUsed fills the cache past its limit and checks
 // that the oldest entry goes and the newest stays.
 func TestEvictionDropsLeastRecentlyUsed(t *testing.T) {


### PR DESCRIPTION
Fixes four fetch/cache correctness issues in `versionstore` and `converter/pipeline`.

- detached fetch goroutines recover panics, publish them via the fetch error, and log them (the last waiter is often gone by the time a conversion panic fires), so a parser panic no longer takes down the server
- a partial spec-list fetch is reported via a typed `PartialSpecListError`: `build`/`download` abort instead of producing an incomplete database, `update` warns and continues
- `GetSpec` touches the LRU timestamp like every other read path, so a frequently-read version is no longer evicted first
- `releaseRequest` no longer treats bare `r`/`R` prefixes as release selectors, so base-36 archive tokens like `r18` (= v27.1.8) resolve exactly; only `Rel-`/`rel-` and 1-2 digit numbers select a release

Reviewed with open-code-review; the one finding (lost panic trace) is fixed in the last commit.

Closes #93
Closes #98
Closes #108
Closes #109

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn2P9TSfFhMruwNbVm9M4x)_