### PR TITLE
chore: harden Makefile, Dockerfile, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
       - name: Build
@@ -21,12 +29,12 @@ jobs:
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.11.4
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,28 +3,33 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /3gpp-mcp /3gpp-mcp
 RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
-        SELECT="--latest"; \
+        set -- --latest; \
     else \
-        SELECT="--release ${RELEASE}"; \
+        set -- --release "${RELEASE}"; \
     fi \
-    && /3gpp-mcp build ${SELECT} \
+    && /3gpp-mcp build "$@" \
     --db /3gpp.db \
     --convert-doc \
     --convert-image \
@@ -32,10 +32,15 @@ RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
     --scrape-workers 4
 
 # 3) Final image: just the binary, the baked-in database, and CA certificates
-#    (needed for on-demand HTTPS fetches of versions not in the prebuilt DB).
+#    (needed for the HTTPS archive listing behind list_versions). On-demand
+#    fetching of versions not in the prebuilt DB does NOT work out of the box:
+#    it needs a writable cache and temp directory, which scratch lacks. To
+#    enable it, mount a writable volume and set HOME (or XDG_CACHE_HOME) and
+#    TMPDIR to point into it.
 FROM scratch
 COPY --from=db-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=go-builder /3gpp-mcp /3gpp-mcp
 COPY --from=db-builder /3gpp.db /3gpp.db
+USER 65532:65532
 ENTRYPOINT ["/3gpp-mcp"]
 CMD ["serve", "--db", "/3gpp.db"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 FROM golang:1.26-bookworm AS db-builder
 ARG RELEASE=latest
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libreoffice ca-certificates \
+    && apt-get install -y --no-install-recommends libreoffice ca-certificates sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /3gpp-mcp /3gpp-mcp
+# After the build, switch the database out of WAL mode: a read-only open of a
+# WAL-mode database must create -shm/-wal sidecars next to it, which the
+# non-root runtime user cannot do in the root-owned /. In DELETE mode the
+# baked-in database is readable with no write access at all.
 RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
         set -- --latest; \
     else \
@@ -29,7 +33,8 @@ RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
     --convert-doc \
     --convert-image \
     --timeout 120s \
-    --scrape-workers 4
+    --scrape-workers 4 \
+    && sqlite3 /3gpp.db 'PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;'
 
 # 3) Final image: just the binary, the baked-in database, and CA certificates
 #    (needed for the HTTPS archive listing behind list_versions). On-demand

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ release_flag = $(if $(filter latest,$(RELEASE)),--latest,--release $(RELEASE))
 
 # Build the MCP server
 build:
+	mkdir -p $(BIN_DIR)
 	go build -o $(BIN_DIR)/3gpp-mcp ./cmd/3gpp-mcp
 
 # Install the MCP server
@@ -20,6 +21,7 @@ install:
 
 # Import a single .docx file (usage: make import FILE=path/to/spec.docx)
 import: build
+	@test -n "$(FILE)" || { echo "usage: make import FILE=path/to/spec.docx"; exit 1; }
 	./$(BIN_DIR)/3gpp-mcp import --db $(DB_PATH) $(FILE)
 
 # Import all .docx files in SPECS_DIR
@@ -31,8 +33,9 @@ import-dir: build
 build-db: build
 	./$(BIN_DIR)/3gpp-mcp build $(release_flag) --db $(DB_PATH) --convert-doc
 
-# Download specs (download only, no conversion). Latest of every spec by
-# default; pass RELEASE=19 to restrict to a single release.
+# Download specs (no database import; legacy .doc files are converted to
+# .docx). Latest of every spec by default; pass RELEASE=19 to restrict to a
+# single release.
 download-specs: build
 	./$(BIN_DIR)/3gpp-mcp download $(release_flag) --output-dir $(SPECS_DIR) --convert-doc
 
@@ -46,7 +49,9 @@ update-specs: build
 
 # Show database info
 db-info:
-	@sqlite3 $(DB_PATH) "SELECT COUNT(*) || ' specs' FROM specs; SELECT COUNT(*) || ' sections' FROM sections;" 2>/dev/null || echo "Database not found: $(DB_PATH)"
+	@command -v sqlite3 >/dev/null || { echo "sqlite3 CLI not found"; exit 1; }
+	@test -f $(DB_PATH) || { echo "Database not found: $(DB_PATH)"; exit 1; }
+	@sqlite3 $(DB_PATH) "SELECT COUNT(*) || ' specs' FROM specs; SELECT COUNT(*) || ' sections' FROM sections;"
 
 # Start HTTP server with web viewer
 web: build
@@ -59,4 +64,4 @@ test:
 # Clean build artifacts
 clean:
 	rm -rf $(BIN_DIR)
-	rm -f data/3gpp.db
+	rm -f $(DB_PATH)

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ update-specs: build
 # Show database info
 db-info:
 	@command -v sqlite3 >/dev/null || { echo "sqlite3 CLI not found"; exit 1; }
-	@test -f $(DB_PATH) || { echo "Database not found: $(DB_PATH)"; exit 1; }
-	@sqlite3 $(DB_PATH) "SELECT COUNT(*) || ' specs' FROM specs; SELECT COUNT(*) || ' sections' FROM sections;"
+	@test -f "$(DB_PATH)" || { echo "Database not found: $(DB_PATH)"; exit 1; }
+	@sqlite3 "$(DB_PATH)" "SELECT COUNT(*) || ' specs' FROM specs; SELECT COUNT(*) || ' sections' FROM sections;"
 
 # Start HTTP server with web viewer
 web: build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ release_flag = $(if $(filter latest,$(RELEASE)),--latest,--release $(RELEASE))
 
 # Build the MCP server
 build:
-	mkdir -p $(BIN_DIR)
+	mkdir -p "$(BIN_DIR)"
 	go build -o $(BIN_DIR)/3gpp-mcp ./cmd/3gpp-mcp
 
 # Install the MCP server
@@ -63,5 +63,5 @@ test:
 
 # Clean build artifacts
 clean:
-	rm -rf $(BIN_DIR)
-	rm -f $(DB_PATH)
+	rm -rf "$(BIN_DIR)"
+	rm -f "$(DB_PATH)"


### PR DESCRIPTION
Build/infra hardening across the Makefile, Dockerfile, and GitHub workflows.

**Makefile**
- `build` creates `bin/` first, so `make clean && make build` works
- `clean` removes `$(DB_PATH)` instead of a hardcoded path; destructive commands and `db-info` quote `BIN_DIR`/`DB_PATH`
- `import` without `FILE` fails with a usage message; `db-info` distinguishes a missing sqlite3 CLI from a missing database

**Dockerfile**
- the final scratch stage runs as `USER 65532:65532`
- the baked database is switched to DELETE journal mode after the build: a read-only open of a WAL-mode database must create `-shm`/`-wal` sidecars, which the non-root user cannot do in the root-owned `/` (verified by reproducing the failure as UID 65532)
- `RELEASE` is passed via `set --` as a single argument instead of an unquoted `${SELECT}` expansion

**CI**
- top-level least-privilege `permissions:` blocks
- all actions pinned to the commit SHAs of the currently referenced tags (resolved via `git ls-remote`, with tag comments)
- `timeout-minutes` and `concurrency` added; release trigger scoped to `v*` tags

Reviewed with open-code-review (2 rounds); the WAL/non-root finding and quoting findings are fixed in the last two commits. `docker build` is unavailable in this environment, so the Dockerfile change was validated by reproducing the SQLite open behavior directly under UID 65532.

Closes #112
Closes #113
Closes #114

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn2P9TSfFhMruwNbVm9M4x)_