### PR TITLE
fix(docx): correct XML/SIP/SDP block detection and inline image order

### DIFF
--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -81,6 +81,23 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 	var runTexts []string
 	var pendingWidthPx, pendingHeightPx int
 
+	// flushRunText moves the text accumulated so far in the current run into
+	// info.Runs, so that an inline image (or other non-text run entry) found
+	// mid-run lands after the text that precedes it instead of before it
+	// (issue #100). The run keeps its formatting for any text that follows
+	// the image within the same w:r.
+	flushRunText := func() {
+		if !inR {
+			return
+		}
+		if text := strings.Join(runTexts, ""); text != "" {
+			r := currentRun
+			r.Text = text
+			info.Runs = append(info.Runs, r)
+		}
+		runTexts = nil
+	}
+
 	depth := 1
 	for depth > 0 {
 		tok, err := d.Token()
@@ -104,6 +121,7 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 					if local == "oMathPara" {
 						delim = "$$"
 					}
+					flushRunText()
 					info.Runs = append(info.Runs, runInfo{Text: delim + latex + delim})
 				}
 				continue
@@ -122,6 +140,7 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 				if local == "group" {
 					hasGroup = true
 				}
+				flushRunText()
 				info.Images = append(info.Images, imgs...)
 				for i := range imgs {
 					info.Runs = append(info.Runs, runInfo{Image: &imgs[i]})
@@ -244,6 +263,7 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 						WidthPx:  pendingWidthPx,
 						HeightPx: pendingHeightPx,
 					}
+					flushRunText()
 					info.Images = append(info.Images, ref)
 					info.Runs = append(info.Runs, runInfo{Image: &ref})
 					pendingWidthPx, pendingHeightPx = 0, 0
@@ -260,6 +280,7 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 						WidthPx:  pendingWidthPx,
 						HeightPx: pendingHeightPx,
 					}
+					flushRunText()
 					info.Images = append(info.Images, ref)
 					info.Runs = append(info.Runs, runInfo{Image: &ref})
 					pendingWidthPx, pendingHeightPx = 0, 0

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -642,6 +642,40 @@ func TestParagraphToMarkdown_LeadingTabTrimmed(t *testing.T) {
 	}
 }
 
+// A single run carrying both text and an inline drawing keeps document
+// order: the text before the image is emitted before it, and the text after
+// it lands in its own run with the same formatting (issue #100).
+func TestParseParagraph_TextAndImageInOneRun(t *testing.T) {
+	xml := `<w:p ` + wXMLNS + ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+		`<w:r><w:rPr><w:b/></w:rPr>` +
+		`<w:t xml:space="preserve">before </w:t>` +
+		`<w:drawing><a:blip r:embed="rId5"/></w:drawing>` +
+		`<w:t xml:space="preserve"> after</w:t>` +
+		`</w:r></w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Runs) != 3 {
+		t.Fatalf("Runs = %d, want 3 (text, image, text): %#v", len(info.Runs), info.Runs)
+	}
+	if info.Runs[0].Text != "before " || info.Runs[0].Image != nil {
+		t.Errorf("run[0] = %#v, want text %q", info.Runs[0], "before ")
+	}
+	if info.Runs[1].Image == nil || info.Runs[1].Image.RID != "rId5" {
+		t.Errorf("run[1] = %#v, want image rId5", info.Runs[1])
+	}
+	if info.Runs[2].Text != " after" || info.Runs[2].Image != nil {
+		t.Errorf("run[2] = %#v, want text %q", info.Runs[2], " after")
+	}
+	if !info.Runs[0].Bold || !info.Runs[2].Bold {
+		t.Errorf("expected the run formatting kept on both text segments, got %#v", info.Runs)
+	}
+	if info.Text != "before  after" {
+		t.Errorf("Text = %q, want %q", info.Text, "before  after")
+	}
+	if len(info.Images) != 1 || info.Images[0].RID != "rId5" {
+		t.Errorf("Images = %#v, want one rId5 entry", info.Images)
+	}
+}
+
 func TestParseParagraph_GroupShapeNoImage_SkipsLabels(t *testing.T) {
 	// A grouped VML diagram (v:group containing several v:shape/v:textbox
 	// labels) with no embedded picture anywhere inside it must not have its

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -19,6 +19,7 @@ package docx
 import (
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // sipMethodsPat lists the SIP request methods that may open an example
@@ -223,11 +224,40 @@ func sdpExampleStart(elements []bodyElement, idx int) (label, text string, ok bo
 }
 
 // wrappedValueLine reports whether line can be the wrapped remainder of a
-// backslash-folded value. A trailing period marks a sentence, not a value —
-// the same signal sdpFieldLine relies on — so a prose paragraph following a
-// folded value is not mistaken for its continuation (issue #101).
+// backslash-folded value, so a prose paragraph following a folded value is
+// not mistaken for its continuation (issue #101). Two signals mark prose: a
+// trailing period (a sentence end — the same signal sdpFieldLine relies on)
+// and a run of three or more consecutive purely-alphabetic words. Real
+// wrapped values are parameter tokens — "sprop-parameter-sets=" plus a
+// base64 blob (TS 26.234 A.1), "mode-change-period=2", folded
+// 3GPP-QoE-Metrics values like "metrics={…};rate=End" — whose tokens carry
+// '=', ';', digits, hyphens or braces, so three bare words in a row never
+// occur in them, while a natural-language sentence almost always has such a
+// run even without its final period.
 func wrappedValueLine(line string) bool {
-	return !strings.HasSuffix(strings.TrimSpace(line), ".")
+	line = strings.TrimSpace(line)
+	if strings.HasSuffix(line, ".") {
+		return false
+	}
+	bareRun := 0
+	for _, tok := range strings.Fields(line) {
+		bare := true
+		for _, r := range tok {
+			if !unicode.IsLetter(r) {
+				bare = false
+				break
+			}
+		}
+		if !bare {
+			bareRun = 0
+			continue
+		}
+		bareRun++
+		if bareRun >= 3 {
+			return false
+		}
+	}
+	return true
 }
 
 // sipMessageLinesFrom reports whether every non-blank line of text is

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -144,7 +144,13 @@ func sdpFieldLine(line string) bool {
 // backslash-continued line counts, e.g. the wrapped a=fmtp value in
 // TS 26.234 A.1).
 func sdpFieldLineCount(text string) (count int, allFields bool) {
-	prevContinued := false
+	return sdpFieldLinesFrom(text, false)
+}
+
+// sdpFieldLinesFrom is sdpFieldLineCount with the initial continuation state
+// supplied: prevContinued reports whether the line preceding text ended with
+// a backslash, exempting text's first line from the field-line check.
+func sdpFieldLinesFrom(text string, prevContinued bool) (count int, allFields bool) {
 	for _, ln := range strings.Split(text, "\n") {
 		ln = strings.TrimSpace(ln)
 		if ln == "" {
@@ -216,12 +222,40 @@ func sdpExampleStart(elements []bodyElement, idx int) (label, text string, ok bo
 	return label, rest, true
 }
 
+// wrappedValueLine reports whether line can be the wrapped remainder of a
+// backslash-folded value. A trailing period marks a sentence, not a value —
+// the same signal sdpFieldLine relies on — so a prose paragraph following a
+// folded value is not mistaken for its continuation (issue #101).
+func wrappedValueLine(line string) bool {
+	return !strings.HasSuffix(strings.TrimSpace(line), ".")
+}
+
+// sipMessageLinesFrom reports whether every non-blank line of text is
+// message-shaped (a SIP start, header or SDP field line), with a line
+// following a backslash-continued one exempt. prevContinued supplies the
+// continuation state of the line preceding text.
+func sipMessageLinesFrom(text string, prevContinued bool) bool {
+	for _, ln := range strings.Split(text, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			prevContinued = false
+			continue
+		}
+		if !prevContinued && !sipStartLine(ln) && !sipHeaderLine(ln) && !sdpFieldLine(ln) {
+			return false
+		}
+		prevContinued = strings.HasSuffix(ln, `\`)
+	}
+	return true
+}
+
 // sipBlockContinues reports whether the paragraph continues a SIP message
 // block: a blank line, another start line (back-to-back messages), a
-// header line, an SDP body line, or any line after a backslash-continued
-// one. Leading whitespace is ignored when matching — TS 23.700-19 indents
-// every message line with a tab — but indentation alone never continues a
-// block, since the surrounding prose is indented the same way.
+// header line, an SDP body line, or the wrapped remainder of a
+// backslash-continued line. Leading whitespace is ignored when matching —
+// TS 23.700-19 indents every message line with a tab — but indentation
+// alone never continues a block, since the surrounding prose is indented
+// the same way.
 func sipBlockContinues(info paragraphInfo, lastLine string) bool {
 	if len(info.Images) > 0 || info.SkippedDiagramLabels != nil {
 		return false
@@ -231,15 +265,22 @@ func sipBlockContinues(info paragraphInfo, lastLine string) bool {
 		return true
 	}
 	if strings.HasSuffix(strings.TrimSpace(lastLine), `\`) {
-		return true
+		// The backslash folds the value onto the first line of this
+		// paragraph only: that line is exempt from the shape check unless it
+		// reads like a sentence, and the remaining lines must still be
+		// message-shaped, so a value fold cannot pull a whole prose
+		// paragraph into the fence (issue #101).
+		first, rest, _ := strings.Cut(t, "\n")
+		return wrappedValueLine(first) &&
+			sipMessageLinesFrom(rest, strings.HasSuffix(strings.TrimSpace(first), `\`))
 	}
 	line := strings.TrimSpace(sipFirstLine(t))
 	return sipStartLine(line) || sipHeaderLine(line) || sdpFieldLine(line)
 }
 
 // sdpBlockContinues reports whether the paragraph continues a standalone
-// SDP block: a blank line, further field lines, or any line after a
-// backslash-continued one. SIP headers deliberately do not continue an
+// SDP block: a blank line, further field lines, or the wrapped remainder of
+// a backslash-continued line. SIP headers deliberately do not continue an
 // SDP-only block.
 func sdpBlockContinues(info paragraphInfo, lastLine string) bool {
 	if len(info.Images) > 0 || info.SkippedDiagramLabels != nil {
@@ -250,7 +291,14 @@ func sdpBlockContinues(info paragraphInfo, lastLine string) bool {
 		return true
 	}
 	if strings.HasSuffix(strings.TrimSpace(lastLine), `\`) {
-		return true
+		// Same first-line-only exemption as sipBlockContinues (issue #101):
+		// the remaining lines must still be SDP field lines.
+		first, rest, _ := strings.Cut(t, "\n")
+		if !wrappedValueLine(first) {
+			return false
+		}
+		_, allFields := sdpFieldLinesFrom(rest, strings.HasSuffix(strings.TrimSpace(first), `\`))
+		return allFields
 	}
 	_, allFields := sdpFieldLineCount(t)
 	return allFields

--- a/converter/docx/sipblock.go
+++ b/converter/docx/sipblock.go
@@ -223,32 +223,29 @@ func sdpExampleStart(elements []bodyElement, idx int) (label, text string, ok bo
 	return label, rest, true
 }
 
-// wrappedValueLine reports whether line can be the wrapped remainder of a
-// backslash-folded value, so a prose paragraph following a folded value is
-// not mistaken for its continuation (issue #101). Two signals mark prose: a
-// trailing period (a sentence end — the same signal sdpFieldLine relies on)
-// and a run of three or more consecutive purely-alphabetic words. Real
-// wrapped values are parameter tokens — "sprop-parameter-sets=" plus a
+// wrappedValueLine reports whether line looks like the wrapped remainder of
+// a backslash-folded value, so a prose paragraph following a folded value is
+// not mistaken for its continuation (issue #101). Rejecting prose shapes one
+// by one proved fragile ("Figure 1: message flow" has no sentence period and
+// its digit breaks any word-run test), so the check demands the positive
+// signal the genuine corpus folds share. The continuations this exemption
+// exists for are parameter-value tails — "sprop-parameter-sets=" plus a
 // base64 blob (TS 26.234 A.1), "mode-change-period=2", folded
-// 3GPP-QoE-Metrics values like "metrics={…};rate=End" — whose tokens carry
-// '=', ';', digits, hyphens or braces, so three bare words in a row never
-// occur in them, while a natural-language sentence almost always has such a
-// run even without its final period.
+// 3GPP-QoE-Metrics values like "metrics={…};rate=End" — which always carry
+// the '=' or ';' of the parameter syntax they continue, or are one unbroken
+// non-word token (a bare wrapped blob). Sentence shapes are still rejected
+// on top — a trailing period or three consecutive purely-alphabetic words —
+// so prose that quotes a parameter fragment ("The value mode-set=0 is used
+// by the UE") stays out even though it contains an '='.
 func wrappedValueLine(line string) bool {
 	line = strings.TrimSpace(line)
 	if strings.HasSuffix(line, ".") {
 		return false
 	}
+	fields := strings.Fields(line)
 	bareRun := 0
-	for _, tok := range strings.Fields(line) {
-		bare := true
-		for _, r := range tok {
-			if !unicode.IsLetter(r) {
-				bare = false
-				break
-			}
-		}
-		if !bare {
+	for _, tok := range fields {
+		if strings.ContainsFunc(tok, func(r rune) bool { return !unicode.IsLetter(r) }) {
 			bareRun = 0
 			continue
 		}
@@ -257,7 +254,10 @@ func wrappedValueLine(line string) bool {
 			return false
 		}
 	}
-	return true
+	if strings.ContainsAny(line, "=;") {
+		return true
+	}
+	return len(fields) == 1 && strings.ContainsFunc(fields[0], func(r rune) bool { return !unicode.IsLetter(r) })
 }
 
 // sipMessageLinesFrom reports whether every non-blank line of text is

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -525,6 +525,23 @@ func TestBlockContinues_BackslashContinuation(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "single-line prose without a trailing period does not continue",
+			text: "The above example shows the session setup",
+			want: false,
+		},
+		{
+			name: "folded QoE-metrics style remainder continues",
+			text: "metrics={Initial_Buffering_Duration|Rebuffering_Duration };rate=End",
+			want: true,
+		},
+		{
+			// Bare-word runs shorter than three, broken up by value tokens,
+			// stay accepted: only sentence-length word runs mark prose.
+			name: "value tokens interleaved with words continue",
+			text: "codec mode 0,2 change AMR",
+			want: true,
+		},
+		{
 			name: "prose after the wrapped remainder does not continue",
 			text: "mode-change-period=2\nThe session is then established as usual",
 			want: false,
@@ -539,6 +556,14 @@ func TestBlockContinues_BackslashContinuation(t *testing.T) {
 				t.Errorf("sdpBlockContinues(%q) = %v, want %v", tt.text, got, tt.want)
 			}
 		})
+	}
+
+	img := paragraphInfo{
+		Text: "v=0", Runs: []runInfo{{Text: "v=0"}},
+		Images: []imageRef{{RID: "rId1"}},
+	}
+	if sipBlockContinues(img, foldedLast) || sdpBlockContinues(img, foldedLast) {
+		t.Error("expected an image paragraph never to continue a block")
 	}
 }
 
@@ -565,6 +590,52 @@ func TestParseSections_SDPBackslashDoesNotSwallowProse(t *testing.T) {
 	}
 	if content[1] != "This clause describes how the session is established." {
 		t.Errorf("expected the prose paragraph after the fence, got %q", content[1])
+	}
+}
+
+// A one-line prose paragraph with no trailing period after a value fold has
+// no "remaining lines" for the shape check to reject, so the wrapped-line
+// test itself must spot the prose (PR #122 review finding on issue #101).
+func TestParseSections_SDPBackslashDoesNotSwallowUnpunctuatedProse(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tSDP"),
+		sipPara("v=0\no=ghost 1 1 IN IP4 10.0.0.1\ns=example\nt=0 0"),
+		sipPara(`a=fmtp:97 mode-set=0,2 \`),
+		sipPara("The above example shows the session setup"),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if strings.Contains(content[0], "The above example") {
+		t.Errorf("prose swallowed into the fence: %q", content[0])
+	}
+	if content[1] != "The above example shows the session setup" {
+		t.Errorf("expected the prose paragraph after the fence, got %q", content[1])
+	}
+}
+
+// The genuine TS 26.234 A.1 shape keeps working end to end: the wrapped
+// base64 remainder of a folded a=fmtp value stays inside the fence.
+func TestParseSections_SDPBackslashKeepsWrappedValue(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tSDP"),
+		sipPara("v=0\no=ghost 1 1 IN IP4 10.0.0.1\ns=example\nt=0 0"),
+		sipPara(`a=fmtp:96 packetization-mode=1; profile-level-id=64001e; \`),
+		sipPara("sprop-parameter-sets= Z2QAHpWQC0PaAfyQ,aOuOoA=="),
+		sipPara("The example is explained below."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "sprop-parameter-sets= Z2QAHpWQC0PaAfyQ,aOuOoA==") {
+		t.Errorf("expected the wrapped value inside the fence, got %q", content[0])
+	}
+	if content[1] != "The example is explained below." {
+		t.Errorf("expected trailing prose after the fence, got %q", content[1])
 	}
 }
 

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -495,6 +495,79 @@ func TestParseSections_SIPImageParagraphEndsBlock(t *testing.T) {
 	}
 }
 
+// A backslash-continued line only folds the first line of the next
+// paragraph into the block, and never a sentence: a prose paragraph after a
+// value fold must not be absorbed (issue #101).
+func TestBlockContinues_BackslashContinuation(t *testing.T) {
+	para := func(text string) paragraphInfo {
+		return paragraphInfo{Text: text, Runs: []runInfo{{Text: text}}}
+	}
+	const foldedLast = `a=fmtp:97 mode-set=0,2 \`
+
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{
+			name: "wrapped value remainder continues",
+			text: "sprop-parameter-sets= Z2QAHpWQC0PaAfyQ,aOuOoA==",
+			want: true,
+		},
+		{
+			name: "wrapped remainder followed by field lines continues",
+			text: "mode-change-period=2\na=control:rtsp://example.com/x",
+			want: true,
+		},
+		{
+			name: "prose sentence does not continue",
+			text: "This clause describes how the session is established.",
+			want: false,
+		},
+		{
+			name: "prose after the wrapped remainder does not continue",
+			text: "mode-change-period=2\nThe session is then established as usual",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sipBlockContinues(para(tt.text), foldedLast); got != tt.want {
+				t.Errorf("sipBlockContinues(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+			if got := sdpBlockContinues(para(tt.text), foldedLast); got != tt.want {
+				t.Errorf("sdpBlockContinues(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// Full-pipeline shape of issue #101: a backslash-wrapped SDP value followed
+// by a prose paragraph — the prose ends the block instead of being pulled
+// into the fence verbatim.
+func TestParseSections_SDPBackslashDoesNotSwallowProse(t *testing.T) {
+	elements := []bodyElement{
+		sipHeading("1\tSDP"),
+		sipPara("v=0\no=ghost 1 1 IN IP4 10.0.0.1\ns=example\nt=0 0"),
+		sipPara(`a=fmtp:97 mode-set=0,2 \`),
+		sipPara("This clause describes how the session is established."),
+	}
+	sections := sipParse(elements)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.HasPrefix(content[0], "```sdp\n") || !strings.Contains(content[0], `a=fmtp:97 mode-set=0,2 \`) {
+		t.Errorf("expected the folded field line inside the fence, got %q", content[0])
+	}
+	if strings.Contains(content[0], "This clause") {
+		t.Errorf("prose swallowed into the fence: %q", content[0])
+	}
+	if content[1] != "This clause describes how the session is established." {
+		t.Errorf("expected the prose paragraph after the fence, got %q", content[1])
+	}
+}
+
 func TestSDPFieldLineCount(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/converter/docx/sipblock_test.go
+++ b/converter/docx/sipblock_test.go
@@ -535,11 +535,46 @@ func TestBlockContinues_BackslashContinuation(t *testing.T) {
 			want: true,
 		},
 		{
-			// Bare-word runs shorter than three, broken up by value tokens,
-			// stay accepted: only sentence-length word runs mark prose.
-			name: "value tokens interleaved with words continue",
-			text: "codec mode 0,2 change AMR",
+			name: "single parameter token continues",
+			text: "mode-change-period=2",
 			want: true,
+		},
+		{
+			// A fold split right after "=", leaving the bare blob alone on
+			// the wrapped line.
+			name: "bare wrapped blob token continues",
+			text: "Z2QAHpWQC0PaAfyQ,aOuOoA",
+			want: true,
+		},
+		{
+			// The digit-bearing "1:" token breaks any consecutive-word test,
+			// so the positive parameter-syntax requirement has to reject it.
+			name: "figure caption does not continue",
+			text: "Figure 1: message flow",
+			want: false,
+		},
+		{
+			name: "table caption does not continue",
+			text: "Table 5.1: parameters",
+			want: false,
+		},
+		{
+			name: "step prose does not continue",
+			text: "Step 2: the UE sends",
+			want: false,
+		},
+		{
+			name: "short reference prose does not continue",
+			text: "See below",
+			want: false,
+		},
+		{
+			// Prose quoting a parameter fragment carries an '=' but is still
+			// sentence-shaped: the word-run rejection applies on top of the
+			// positive signal.
+			name: "prose quoting a parameter does not continue",
+			text: "The value mode-set=0 is used by the UE",
+			want: false,
 		},
 		{
 			name: "prose after the wrapped remainder does not continue",

--- a/converter/docx/xmlblock.go
+++ b/converter/docx/xmlblock.go
@@ -38,9 +38,22 @@ var (
 	// the mangled openers sometimes lose their closer entirely (TS 29.163
 	// carries "<!-Definition of simple types" with no "-->" at all), and a
 	// sticky comment state with no closer would swallow everything up to the
-	// next heading. The closer accepts mangled hyphen/dash forms.
+	// next heading. The closer accepts the mangled dash forms ("—>", "–>",
+	// hyphens folded into one dash) but not a bare "->": an arrow inside the
+	// comment text would end it early and leak whatever tags follow into the
+	// element depth (issue #111).
 	xmlCommentOpenRE  = regexp.MustCompile(`<!--`)
-	xmlCommentCloseRE = regexp.MustCompile(`(?:--|[-—–])>`)
+	xmlCommentCloseRE = regexp.MustCompile(`(?:--|[—–])>`)
+
+	// An unterminated "<…" only carries over to the next line when it looks
+	// like a genuine tag left open: an element tag, a processing instruction
+	// or a "<!NAME" markup declaration (a DOCTYPE identifier regularly spills
+	// onto the next line). A comment-shaped "<!-"/"<!—" is deliberately
+	// excluded — the mangled openers sometimes have no closer at all
+	// ("<!-Definition of simple types", TS 29.163) and must not go sticky,
+	// for the same reason the comment tracking above only trusts "<!--" —
+	// and so is a bare "<" in prose (issue #95).
+	xmlPendingTagRE = regexp.MustCompile(`^<(?:[/?]?[A-Za-z_]|![A-Za-z])`)
 )
 
 // xmlTrimmedText returns the paragraph's raw text (no markdown emphasis
@@ -99,7 +112,7 @@ type xmlLineTracker struct {
 	open      bool
 	inComment bool
 	depth     int    // element nesting depth of the captured lines
-	pending   string // unterminated tag text carried over from earlier lines
+	pending   string // unterminated tag text carried over from the previous line
 }
 
 // observe updates the tracker after line has been captured into the block.
@@ -115,15 +128,20 @@ func (t *xmlLineTracker) observe(line string) {
 		rest = rest[loc[1]:]
 	}
 	if t.pending != "" {
-		i := strings.IndexByte(rest, '>')
+		joined := t.pending + rest
+		t.pending = ""
+		i := xmlTagEnd(joined)
 		if i < 0 {
-			t.pending += rest
-			t.open = true
+			// The tag did not close on this line either. Carrying the state
+			// further would absorb every following paragraph until a stray
+			// ">" turns up (issue #95), so give up on the tag instead — the
+			// genuine attribute-spill case (TS 38.508-1) closes on the very
+			// next line.
+			t.open = false
 			return
 		}
-		t.observeTag(t.pending + rest[:i+1])
-		t.pending = ""
-		rest = rest[i+1:]
+		t.observeTag(joined[:i+1])
+		rest = joined[i+1:]
 	}
 	for {
 		i := strings.IndexByte(rest, '<')
@@ -141,16 +159,41 @@ func (t *xmlLineTracker) observe(line string) {
 			rest = rest[loc[1]+end[1]:]
 			continue
 		}
-		j := strings.IndexByte(rest, '>')
+		j := xmlTagEnd(rest)
 		if j < 0 {
-			t.pending = rest
-			t.open = true
+			if xmlPendingTagRE.MatchString(rest) {
+				t.pending = rest
+				t.open = true
+			} else {
+				t.open = false
+			}
 			return
 		}
 		t.observeTag(rest[:j+1])
 		rest = rest[j+1:]
 	}
 	t.open = false
+}
+
+// xmlTagEnd returns the index of the ">" closing the tag that starts at
+// s[0] == '<', skipping over quoted attribute values so that a ">" inside
+// one does not split the tag and leak element depth (issue #96). Returns -1
+// when the tag does not close within s.
+func xmlTagEnd(s string) int {
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '>':
+			return i
+		}
+	}
+	return -1
 }
 
 // observeTag adjusts the element depth for one complete "<…>" tag.

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -65,6 +65,98 @@ func TestXMLLineTracker(t *testing.T) {
 	}
 }
 
+// An unterminated "<" that is not a genuine tag start — a mangled comment
+// opener with no closer (TS 29.163) or a "<" in prose — must not keep the
+// block open and swallow every following paragraph (issue #95).
+func TestXMLLineTrackerUnterminatedNotSticky(t *testing.T) {
+	prose := paragraphInfo{
+		Text: "Ordinary prose paragraph.",
+		Runs: []runInfo{{Text: "Ordinary prose paragraph."}},
+	}
+
+	var tr xmlLineTracker
+	tr.observe(`<!-Definition of simple types`)
+	if tr.open {
+		t.Error("expected tracker closed after a mangled comment opener with no closer")
+	}
+	if matchXMLContinuation(prose, &tr) {
+		t.Error("expected prose not to continue the block")
+	}
+
+	tr = xmlLineTracker{}
+	tr.observe(`values where a < b hold`)
+	if tr.open {
+		t.Error("expected tracker closed after a '<' in prose")
+	}
+
+	// A genuine unterminated tag stays open for one continuation line only:
+	// when that line does not close it either, the tag is abandoned instead
+	// of absorbing everything up to the next stray ">".
+	tr = xmlLineTracker{}
+	tr.observe(`<mcpttinfo xmlns="urn:3gpp:ns:mcpttInfo:1.0"`)
+	if !tr.open {
+		t.Error("expected tracker open after an unterminated tag")
+	}
+	tr.observe(`this prose line has no closing angle bracket`)
+	if tr.open {
+		t.Error("expected the unterminated tag abandoned after a line with no '>'")
+	}
+	if matchXMLContinuation(prose, &tr) {
+		t.Error("expected prose not to continue the block after the tag is abandoned")
+	}
+}
+
+// A ">" inside a quoted attribute value does not end the tag early: the
+// element depth stays balanced and following prose is not absorbed
+// (issue #96).
+func TestXMLLineTrackerQuotedAngleBracket(t *testing.T) {
+	var tr xmlLineTracker
+	tr.observe(`<sig:Object MimeType="a>b" Encoding='c>d'/>`)
+	if tr.open || tr.depth != 0 {
+		t.Errorf("expected closed tracker with depth 0, got open=%v depth=%d", tr.open, tr.depth)
+	}
+	prose := paragraphInfo{
+		Text: "Ordinary prose after the element.",
+		Runs: []runInfo{{Text: "Ordinary prose after the element."}},
+	}
+	if matchXMLContinuation(prose, &tr) {
+		t.Error("expected prose not to continue the block")
+	}
+
+	// The quoted value may also span the continuation of a tag left open on
+	// the previous line.
+	tr = xmlLineTracker{}
+	tr.observe(`<elem attr="quote holding a >`)
+	if !tr.open {
+		t.Error("expected tracker open while the quote and tag are unterminated")
+	}
+	tr.observe(`still quoted" other="x">`)
+	if tr.open || tr.depth != 1 {
+		t.Errorf("expected the tag completed across the quote, got open=%v depth=%d", tr.open, tr.depth)
+	}
+}
+
+// An arrow inside a comment does not close it early (issue #111); the
+// mangled single-dash closers still do.
+func TestXMLLineTrackerCommentArrow(t *testing.T) {
+	var tr xmlLineTracker
+	tr.observe(`<!-- maps A -> B via <xs:element name="m"> -->`)
+	if tr.open || tr.inComment || tr.depth != 0 {
+		t.Errorf("expected the whole comment consumed, got open=%v inComment=%v depth=%d",
+			tr.open, tr.inComment, tr.depth)
+	}
+
+	tr = xmlLineTracker{}
+	tr.observe(`<!-- a comment with an arrow ->`)
+	if !tr.open || !tr.inComment {
+		t.Error("expected tracker still inside the comment after a bare '->'")
+	}
+	tr.observe(`closed with a mangled dash —>`)
+	if tr.open || tr.inComment {
+		t.Error("expected the mangled dash closer to end the comment")
+	}
+}
+
 // Element text content on its own paragraph (the <xs:documentation> text of
 // TS 24.423 clause 6.4) is absorbed while an element is open, and the fence
 // closes with the root element so trailing prose stays out.
@@ -143,6 +235,36 @@ func TestParseSections_XMLBlockUnstyled(t *testing.T) {
 	}
 	if content[2] != "Trailing prose." {
 		t.Errorf("expected trailing prose intact, got %q", content[2])
+	}
+}
+
+// A mangled comment opener with no closer (the TS 29.163 shape the comment
+// tracking guards against) must not keep the block open through its pending
+// state: the following prose stays outside the fence (issue #95).
+func TestParseSections_XMLUnterminatedNotSwallowingProse(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("F.3\tXML schema"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<!-Definition of simple types`),
+		xmlTestPara("This prose paragraph must stay outside the fence."),
+		xmlTestPara("And so must this one, even without a '>' anywhere."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected fence + two prose paragraphs, got %v", content)
+	}
+	if !strings.Contains(content[0], "<!-Definition of simple types") {
+		t.Errorf("expected the mangled comment line inside the fence, got %q", content[0])
+	}
+	if strings.Contains(content[0], "prose") {
+		t.Errorf("prose swallowed into the fence: %q", content[0])
+	}
+	if content[1] != "This prose paragraph must stay outside the fence." {
+		t.Errorf("expected first prose paragraph intact, got %q", content[1])
 	}
 }
 

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -58,8 +58,11 @@ const DefaultFileName = "versions.db"
 // SIP/SDP fences (```sip / ```sdp) for syntax highlighting, generation 7
 // makes OMML math render in math mode (n-ary operators separated from their
 // operand, "~" and "^" escaped through \text{}) and stops a backslash
-// continuation from pulling prose after a blank line into an SDP fence.
-const cacheSchemaVersion = 7
+// continuation from pulling prose after a blank line into an SDP fence,
+// generation 8 hardens XML fence tracking against malformed markup, limits
+// sip/sdp backslash continuation to the wrapped line, and emits run text
+// before an inline image in the same run.
+const cacheSchemaVersion = 8
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search


### PR DESCRIPTION
Fixes five converter bugs in `converter/docx`.

**XML block state machine** (`xmlblock.go`)
- an unterminated `<` no longer keeps the fence open and swallows following prose: a pending tag is only carried over when the fragment looks like a genuine tag start, and is abandoned if the next line does not close it
- `>` inside a quoted attribute no longer leaks element depth or over-extends the fence (quote-aware tag-end scanning, including across a line break)
- `xmlCommentCloseRE` no longer closes an XML comment at a bare `->` (the mangled em/en-dash closers are kept)

**Other**
- an inline image is emitted after the text that precedes it in the same run: `before [image] after` now parses as three ordered runs
- backslash continuation in sip/sdp detection covers only the wrapped line, not a whole prose paragraph; sentence-ending lines are rejected and the remaining lines must still be message-shaped

Conversion output changes, so `versionstore.cacheSchemaVersion` is bumped to 8 (old version caches are wiped on open) and a database rebuild picks up the corrected fences.

Reviewed with open-code-review; no findings.

Closes #95
Closes #96
Closes #100
Closes #101
Closes #111

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn2P9TSfFhMruwNbVm9M4x)_