### PR TITLE
fix(web): keep image aspect ratio instead of cropping

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -606,15 +606,14 @@ mark {
     border-radius: 3px;
 }
 
+/* The width/height attributes carry the DOCX display size, which rarely
+   matches the converted PNG's intrinsic size, so the height must stay auto
+   to keep the aspect ratio; a fixed box with object-fit would crop. */
 .section-body img {
     max-width: 100%;
+    height: auto;
     border: 1px solid var(--border);
     border-radius: var(--radius);
-}
-
-.section-body img[width][height] {
-    max-width: none;
-    object-fit: cover;
 }
 
 .section-body figure {


### PR DESCRIPTION
## Problem

Figures on section pages are visibly cut off, e.g. https://threegpp-mcp-70932063483.asia-northeast1.run.app/specs/TS%2023.501/sections/4.2.3.

The `width`/`height` attributes on `<img>` carry the display size recorded in the source DOCX, which rarely matches the intrinsic size of the PNG produced by EMF/WMF conversion (e.g. `image5.png` is 356x235 but the attributes say 629x345). The rule

```css
.section-body img[width][height] {
    max-width: none;
    object-fit: cover;
}
```

forced the image into that fixed box and `object-fit: cover` cropped whatever overflowed, cutting the top/bottom or sides off every figure whose attribute aspect ratio differs from the intrinsic one. `max-width: none` also let wide figures overflow the layout on narrow screens.

## Fix

Drop the fixed-box rule and add `height: auto` to `.section-body img`, so images render at the document's intended width (capped at the container width) with the height following the intrinsic aspect ratio — no cropping, no distortion.

## Verification

Rendered the affected figures locally with the updated stylesheet via headless Chromium: displayed aspect ratios now match the intrinsic ones (e.g. 627x414 vs intrinsic 356x235, ratio 1.514 vs 1.515) and the full diagrams are visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdRpMVDfTgFGKefmxsPPjr)_