### PR TITLE
feat(web): click-to-enlarge lightbox for section figures

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -121,6 +121,9 @@
         if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
             return;
         }
+        if (document.querySelector('dialog.lightbox[open]')) {
+            return;
+        }
         var active = document.activeElement;
         if (active && (active.isContentEditable || active.matches('input, textarea, select, button, [contenteditable], [role="button"], [role="textbox"], [role="combobox"], [role="listbox"]'))) {
             return;
@@ -134,6 +137,37 @@
             window.location.href = link.getAttribute('href');
         }
     });
+
+    // Image lightbox: figures are rendered at the document's display size,
+    // which is often smaller than the viewport, so clicking one opens a
+    // modal <dialog> scaled to fit the screen. The dialog is created lazily
+    // on first use and reused; a click anywhere closes it (clicks on the
+    // ::backdrop target the dialog itself), and Escape is native <dialog>
+    // behavior.
+    const sectionBody = document.querySelector('.section-body');
+    if (sectionBody) {
+        let lightbox = null;
+        sectionBody.addEventListener('click', function (e) {
+            const img = e.target.closest('img');
+            if (!img) {
+                return;
+            }
+            if (!lightbox) {
+                lightbox = document.createElement('dialog');
+                lightbox.className = 'lightbox';
+                lightbox.appendChild(document.createElement('img'));
+                lightbox.addEventListener('click', function () {
+                    lightbox.close();
+                });
+                document.body.appendChild(lightbox);
+            }
+            const large = lightbox.querySelector('img');
+            large.src = img.currentSrc || img.src;
+            large.alt = img.alt;
+            lightbox.setAttribute('aria-label', img.alt || 'Figure');
+            lightbox.showModal();
+        });
+    }
 
     // Render LaTeX math emitted by the DOCX converter. The server wraps each
     // equation in a <span class="math-inline|math-display"> whose text content

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -147,11 +147,7 @@
     const sectionBody = document.querySelector('.section-body');
     if (sectionBody) {
         let lightbox = null;
-        sectionBody.addEventListener('click', function (e) {
-            const img = e.target.closest('img');
-            if (!img) {
-                return;
-            }
+        const openLightbox = function (img) {
             if (!lightbox) {
                 lightbox = document.createElement('dialog');
                 lightbox.className = 'lightbox';
@@ -166,6 +162,24 @@
             large.alt = img.alt;
             lightbox.setAttribute('aria-label', img.alt || 'Figure');
             lightbox.showModal();
+        };
+        // Figures are focusable buttons so keyboard users can open the
+        // lightbox too; closing a <dialog> restores focus to the figure.
+        sectionBody.querySelectorAll('img').forEach(function (img) {
+            img.tabIndex = 0;
+            img.setAttribute('role', 'button');
+        });
+        sectionBody.addEventListener('click', function (e) {
+            const img = e.target.closest('img');
+            if (img) {
+                openLightbox(img);
+            }
+        });
+        sectionBody.addEventListener('keydown', function (e) {
+            if ((e.key === 'Enter' || e.key === ' ') && e.target.matches('img')) {
+                e.preventDefault();
+                openLightbox(e.target);
+            }
         });
     }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -614,6 +614,37 @@ mark {
     height: auto;
     border: 1px solid var(--border);
     border-radius: var(--radius);
+    cursor: zoom-in;
+}
+
+/* === Image lightbox === */
+/* Modal <dialog> for click-to-enlarge on section figures (see app.js). The
+   image scales to fill the viewport with object-fit: contain, so small
+   figures are enlarged too — the whole point of the dialog — without ever
+   cropping. */
+.lightbox {
+    width: calc(100vw - 48px);
+    height: calc(100vh - 48px);
+    max-width: none;
+    max-height: none;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: zoom-out;
+}
+
+.lightbox img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.lightbox::backdrop {
+    background: rgba(0, 0, 0, 0.75);
+}
+
+body:has(dialog.lightbox[open]) {
+    overflow: hidden;
 }
 
 .section-body figure {


### PR DESCRIPTION
## What

Clicking a figure on a section page now opens a modal `<dialog>` that scales the image to fit the viewport, since figures are rendered at the DOCX display size, which is often much smaller than the screen.

- `cursor: zoom-in` on section-body images signals the affordance.
- The dialog is created lazily on first click and reused; the enlarged image uses `object-fit: contain`, so small figures are scaled up without cropping or distortion.
- A click anywhere (image or `::backdrop`) closes it; Escape works via native `<dialog>` behavior; background scroll is locked with `body:has(dialog.lightbox[open])`.
- Left/Right prev-next section navigation is suppressed while the dialog is open so arrow keys don't navigate away under the overlay.

Using the native `<dialog>` top layer keeps the implementation small: no z-index management, and focus handling and Escape come for free.

## Verification

Exercised the flow headless-Chromium against a mirror of the deployed TS 23.501 §4.2.3 page: figure enlarges from 557x289 to 1232x740 (aspect ratio preserved), closes by click and by Escape, arrow-key navigation is suppressed while open and works again after close, and body scroll is locked while open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdRpMVDfTgFGKefmxsPPjr)_