### PR TITLE
feat(web): linkify bare same-spec clause references

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1251,9 +1251,10 @@ const secNum = `([A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 
 // bareRefChain matches zero or more coordinated references (", clause 4.3",
-// " and 4.4", " or Annex B") so bareTrailingQualRE and barePresentDocRE can
-// see through a list to the "of"/"in" that qualifies its every element.
-const bareRefChain = `(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+)?` + secNumRaw + `)*`
+// " and 4.4", ", and 4.4", "; or Annex B") so bareTrailingQualRE and
+// barePresentDocRE can see through a list to the "of"/"in" that qualifies its
+// every element.
+const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+)?` + secNumRaw + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"

--- a/db/db.go
+++ b/db/db.go
@@ -1250,6 +1250,11 @@ const secNum = `([A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 // secNumRaw is secNum without capture group, used for multi-section list matching.
 const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 
+// bareRefChain matches zero or more coordinated references (", clause 4.3",
+// " and 4.4", " or Annex B") so bareTrailingQualRE and barePresentDocRE can
+// see through a list to the "of"/"in" that qualifies its every element.
+const bareRefChain = `(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+)?` + secNumRaw + `)*`
+
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
 	tsRefRE = regexp.MustCompile(`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)(?:` + sp + `*[,;]?` + sp + `*(?:clause|section|subclause|[Aa]nnex)` + sp + `+` + secNum + `)?`)
@@ -1297,14 +1302,16 @@ var (
 	// bareTrailingQualRE matches an "of"/"in" continuation after a bare
 	// reference, which usually names another document ("clause 5.1 of
 	// TS 23.402", "clause 4.2 of [26]", "clause 4 of ITU-T Recommendation
-	// X.509"). RE2 has no lookahead, so it is applied to the text after a
+	// X.509"). The chain prefix looks through coordinated references so the
+	// first element of "clause 4.2 and clause 4.3 of TS 23.402" is rejected
+	// too. RE2 has no lookahead, so these are applied to the text after a
 	// bare match instead of being part of bareRefRE.
-	bareTrailingQualRE = regexp.MustCompile(`^` + sp + `+(?:of|in)` + sp + `+`)
+	bareTrailingQualRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp + `+`)
 
 	// barePresentDocRE matches the continuations that still mean the current
 	// document, re-allowing a bare reference bareTrailingQualRE would reject.
-	barePresentDocRE = regexp.MustCompile(`^` + sp + `+(?:of|in)` + sp +
-		`+(?:the` + sp + `+present` + sp + `+document|this` + sp + `+(?:specification|document))`)
+	barePresentDocRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp +
+		`+(?:the` + sp + `+present` + sp + `+(?:document|specification)|this` + sp + `+(?:specification|document))`)
 
 	// bareLeadingSpecRE matches a spec designator or bracket reference just
 	// before a bare reference ("TS 23.402 Clause 5.1", "RFC 3748 Section 3.1",

--- a/db/db.go
+++ b/db/db.go
@@ -1254,7 +1254,7 @@ const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 // " and 4.4", ", and 4.4", "; or Annex B") so bareTrailingQualRE and
 // barePresentDocRE can see through a list to the "of"/"in" that qualifies its
 // every element.
-const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+)?` + secNumRaw + `)*`
+const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
@@ -1314,6 +1314,11 @@ var (
 	barePresentDocRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp +
 		`+(?:the` + sp + `+present` + sp + `+(?:document|specification)|this` + sp + `+(?:specification|document))`)
 
+	// bareTrailingParenSpecRE matches a parenthesized designator right after a
+	// bare reference ("clause 4.2 (TS 23.402)"), tying it to that document.
+	bareTrailingParenSpecRE = regexp.MustCompile(`^` + sp + `*\(` + sp + `*(?:3GPP` + sp +
+		`+)?(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])`)
+
 	// bareLeadingSpecRE matches a spec designator or bracket reference before
 	// a bare reference — directly ("TS 23.402 Clause 5.1", "RFC 3748
 	// Section 3.1", "[19] Clause 6") or across a coordinated list
@@ -1323,7 +1328,7 @@ var (
 	bareLeadingSpecRE = regexp.MustCompile(
 		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])` +
 			`(?:` + sp + `+(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + bareRefChain + `)?` +
-			sp + `*[,;]?` + sp + `*(?:(?:and|or)` + sp + `+)?$`)
+			sp + `*[,;:]?` + sp + `*(?:(?:and|or)` + sp + `+)?$`)
 )
 
 // refExtractor converts regex submatch indices into (targetSpec, targetSection, ok).

--- a/db/db.go
+++ b/db/db.go
@@ -1307,11 +1307,12 @@ var (
 		`+(?:the` + sp + `+present` + sp + `+document|this` + sp + `+(?:specification|document))`)
 
 	// bareLeadingSpecRE matches a spec designator or bracket reference just
-	// before a bare reference ("TS 23.402 Clause 5.1", "[19] Clause 6") —
-	// qualified territory even when capitalization keeps the lowercase-only
-	// qualified patterns (and thus the overlap gate) from covering it.
+	// before a bare reference ("TS 23.402 Clause 5.1", "RFC 3748 Section 3.1",
+	// "[19] Clause 6") — qualified territory even when capitalization keeps
+	// the lowercase-only qualified patterns (and thus the overlap gate) from
+	// covering it.
 	bareLeadingSpecRE = regexp.MustCompile(
-		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|\[\d+[A-Za-z]*\])` + sp + `*[,;]?` + sp + `*$`)
+		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])` + sp + `*[,;]?` + sp + `*$`)
 )
 
 // refExtractor converts regex submatch indices into (targetSpec, targetSection, ok).

--- a/db/db.go
+++ b/db/db.go
@@ -1314,13 +1314,16 @@ var (
 	barePresentDocRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp +
 		`+(?:the` + sp + `+present` + sp + `+(?:document|specification)|this` + sp + `+(?:specification|document))`)
 
-	// bareLeadingSpecRE matches a spec designator or bracket reference just
-	// before a bare reference ("TS 23.402 Clause 5.1", "RFC 3748 Section 3.1",
-	// "[19] Clause 6") — qualified territory even when capitalization keeps
-	// the lowercase-only qualified patterns (and thus the overlap gate) from
-	// covering it.
+	// bareLeadingSpecRE matches a spec designator or bracket reference before
+	// a bare reference — directly ("TS 23.402 Clause 5.1", "RFC 3748
+	// Section 3.1", "[19] Clause 6") or across a coordinated list
+	// ("TS 23.402 clause 4.2 and clause 5.1") — qualified territory even when
+	// the lowercase-only qualified patterns (and thus the overlap gate) do
+	// not cover the element itself.
 	bareLeadingSpecRE = regexp.MustCompile(
-		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])` + sp + `*[,;]?` + sp + `*$`)
+		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])` +
+			`(?:` + sp + `+(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + bareRefChain + `)?` +
+			sp + `*[,;]?` + sp + `*(?:(?:and|or)` + sp + `+)?$`)
 )
 
 // refExtractor converts regex submatch indices into (targetSpec, targetSection, ok).

--- a/db/db.go
+++ b/db/db.go
@@ -1279,6 +1279,39 @@ var (
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
+
+	// bareRefRE matches a reference with no spec designator: "clause 4.2",
+	// "Subclause 5.15.2", "Annex B". Such a reference means the current
+	// document, so it is linkified only when it does not overlap a qualified
+	// match and the surrounding context does not tie it to another document
+	// (bareLeadingSpecRE, bareTrailingQualRE). Sentence-initial capitals are
+	// common in this form, so both cases are accepted.
+	bareRefRE = regexp.MustCompile(`\b(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+` + secNum)
+
+	// bareMultiRefRE matches a bare multi-section list: "clauses 4.2, 4.3 and 4.4".
+	// Groups: 1=section-list.
+	bareMultiRefRE = regexp.MustCompile(
+		`\b(?:[Cc]lauses|[Ss]ubclauses|[Ss]ections|[Aa]nnexe?s)` + sp + `+` +
+			`(` + secNumRaw + `(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `)\b`)
+
+	// bareTrailingQualRE matches an "of"/"in" continuation after a bare
+	// reference, which usually names another document ("clause 5.1 of
+	// TS 23.402", "clause 4.2 of [26]", "clause 4 of ITU-T Recommendation
+	// X.509"). RE2 has no lookahead, so it is applied to the text after a
+	// bare match instead of being part of bareRefRE.
+	bareTrailingQualRE = regexp.MustCompile(`^` + sp + `+(?:of|in)` + sp + `+`)
+
+	// barePresentDocRE matches the continuations that still mean the current
+	// document, re-allowing a bare reference bareTrailingQualRE would reject.
+	barePresentDocRE = regexp.MustCompile(`^` + sp + `+(?:of|in)` + sp +
+		`+(?:the` + sp + `+present` + sp + `+document|this` + sp + `+(?:specification|document))`)
+
+	// bareLeadingSpecRE matches a spec designator or bracket reference just
+	// before a bare reference ("TS 23.402 Clause 5.1", "[19] Clause 6") —
+	// qualified territory even when capitalization keeps the lowercase-only
+	// qualified patterns (and thus the overlap gate) from covering it.
+	bareLeadingSpecRE = regexp.MustCompile(
+		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|\[\d+[A-Za-z]*\])` + sp + `*[,;]?` + sp + `*$`)
 )
 
 // refExtractor converts regex submatch indices into (targetSpec, targetSection, ok).

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -146,10 +146,15 @@ func htmlLink(text, url string) string {
 // LinkifyRefs replaces spec/RFC/bracket references in Markdown content with Markdown links.
 // bracketMap maps bracket numbers (e.g. "19") to spec IDs (e.g. "TS 33.203"); pass nil to skip.
 // urlFor is called with (targetSpec, targetSection) and returns a URL string.
+// sectionExists enables bare same-document references ("clause 4.2" with no
+// spec designator): a bare reference is linkified only when sectionExists
+// reports its section number present in the current document, and urlFor is
+// then called with an empty targetSpec meaning "the current spec". Pass nil
+// to skip bare references.
 // References inside existing Markdown links, fenced code blocks and inline
 // code spans are not replaced: goldmark renders code verbatim, so a rewritten
 // reference there would show up as literal link syntax.
-func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec, section string) string) string {
+func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec, section string) string, sectionExists func(section string) bool) string {
 	// Build list of excluded regions: existing Markdown links, fenced code
 	// blocks and inline code spans.
 	var excluded []region
@@ -267,13 +272,81 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 		}
 	}
 
+	// Bare same-document references, lowest priority: only where no qualified
+	// candidate matched and the context does not tie the reference to another
+	// document.
+	if sectionExists != nil {
+		overlapsAny := func(start, end int) bool {
+			for _, c := range candidates {
+				if start < c.end && c.start < end {
+					return true
+				}
+			}
+			return false
+		}
+		qualifiedElsewhere := func(start, end int) bool {
+			tail := content[end:]
+			if bareTrailingQualRE.MatchString(tail) && !barePresentDocRE.MatchString(tail) {
+				return true
+			}
+			head := content[:start]
+			// bareLeadingSpecRE is anchored at $; a short tail keeps the scan
+			// cheap. A cut-off leading rune can only lose a match, and only
+			// for a designator further away than any it would ever match.
+			if len(head) > 48 {
+				head = head[len(head)-48:]
+			}
+			return bareLeadingSpecRE.MatchString(head)
+		}
+		for _, m := range bareMultiRefRE.FindAllStringSubmatchIndex(content, -1) {
+			if isExcluded(m[0], m[1]) || overlapsAny(m[0], m[1]) || qualifiedElsewhere(m[0], m[1]) {
+				continue
+			}
+			mkLink := linkFor(m[0], m[1])
+			linkedAny := false
+			linked := secNumListRE.ReplaceAllStringFunc(content[m[2]:m[3]], func(sec string) string {
+				if !sectionExists(sec) {
+					return sec
+				}
+				linkedAny = true
+				return mkLink(sec, urlFor("", sec))
+			})
+			if !linkedAny {
+				continue
+			}
+			candidates = append(candidates, candidate{
+				start: m[0],
+				end:   m[1],
+				text:  content[m[0]:m[2]] + linked,
+			})
+		}
+		for _, m := range bareRefRE.FindAllStringSubmatchIndex(content, -1) {
+			sec := content[m[2]:m[3]]
+			if !sectionExists(sec) {
+				continue
+			}
+			if isExcluded(m[0], m[1]) || overlapsAny(m[0], m[1]) || qualifiedElsewhere(m[0], m[1]) {
+				continue
+			}
+			matchText := content[m[0]:m[1]]
+			candidates = append(candidates, candidate{
+				start: m[0],
+				end:   m[1],
+				text:  linkFor(m[0], m[1])(matchText, urlFor("", sec)),
+			})
+		}
+	}
+
 	if len(candidates) == 0 {
 		return content
 	}
 
-	// Sort by start position.
+	// Sort by start position; on a tie the longer match wins deterministically.
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].start < candidates[j].start
+		if candidates[i].start != candidates[j].start {
+			return candidates[i].start < candidates[j].start
+		}
+		return candidates[i].end > candidates[j].end
 	})
 
 	// Remove overlapping candidates (keep first/earliest).

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -293,8 +293,8 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			// bareLeadingSpecRE is anchored at $; a short tail keeps the scan
 			// cheap. A cut-off leading rune can only lose a match, and only
 			// for a designator further away than any it would ever match.
-			if len(head) > 48 {
-				head = head[len(head)-48:]
+			if len(head) > 128 {
+				head = head[len(head)-128:]
 			}
 			return bareLeadingSpecRE.MatchString(head)
 		}

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -321,11 +321,11 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			})
 		}
 		for _, m := range bareRefRE.FindAllStringSubmatchIndex(content, -1) {
-			sec := content[m[2]:m[3]]
-			if !sectionExists(sec) {
+			if isExcluded(m[0], m[1]) || overlapsAny(m[0], m[1]) || qualifiedElsewhere(m[0], m[1]) {
 				continue
 			}
-			if isExcluded(m[0], m[1]) || overlapsAny(m[0], m[1]) || qualifiedElsewhere(m[0], m[1]) {
+			sec := content[m[2]:m[3]]
+			if !sectionExists(sec) {
 				continue
 			}
 			matchText := content[m[0]:m[1]]

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -289,12 +289,16 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			if bareTrailingQualRE.MatchString(tail) && !barePresentDocRE.MatchString(tail) {
 				return true
 			}
+			if bareTrailingParenSpecRE.MatchString(tail) {
+				return true
+			}
 			head := content[:start]
-			// bareLeadingSpecRE is anchored at $; a short tail keeps the scan
-			// cheap. A cut-off leading rune can only lose a match, and only
-			// for a designator further away than any it would ever match.
-			if len(head) > 128 {
-				head = head[len(head)-128:]
+			// bareLeadingSpecRE is anchored at $; a bounded window keeps the
+			// scan cheap. The bound is best-effort: a coordinated list longer
+			// than the window hides its designator and the trailing elements
+			// linkify as same-document, but no realistic list comes close.
+			if len(head) > 512 {
+				head = head[len(head)-512:]
 			}
 			return bareLeadingSpecRE.MatchString(head)
 		}

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -523,6 +523,11 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See clause [4.2](/specs/TS 23.402/sections/4.2) and [5.1](/specs/TS 23.402/sections/5.1) of [TS 23.402](/specs/TS 23.402).",
 		},
 		{
+			name:  "trailing element after spec-first list not linked bare",
+			input: "See TS 23.402 clause 4.2 and clause 5.1 for details.",
+			want:  "See [TS 23.402 clause 4.2](/specs/TS 23.402/sections/4.2) and clause 5.1 for details.",
+		},
+		{
 			name:  "oxford comma list of TS not linked bare",
 			input: "See clause 4.2, 5.1, and 5.15.2 of TS 23.402.",
 			want:  "See clause 4.2, 5.1, and 5.15.2 of [TS 23.402](/specs/TS 23.402).",

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -73,7 +73,7 @@ func TestLinkifyRefs_TS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor)
+			got := LinkifyRefs(tt.input, nil, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -105,7 +105,7 @@ func TestLinkifyRefs_RFC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor)
+			got := LinkifyRefs(tt.input, nil, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -148,7 +148,7 @@ func TestLinkifyRefs_Bracket(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, bracketMap, urlFor)
+			got := LinkifyRefs(tt.input, bracketMap, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -210,7 +210,7 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor)
+			got := LinkifyRefs(tt.input, nil, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -221,7 +221,7 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 func TestLinkifyRefs_NilBracketMap(t *testing.T) {
 	// Bracket refs should NOT be replaced when bracketMap is nil.
 	input := "See [19] clause 6 for details."
-	got := LinkifyRefs(input, nil, urlFor)
+	got := LinkifyRefs(input, nil, urlFor, nil)
 	if got != input {
 		t.Errorf("expected no change with nil bracketMap, got %q", got)
 	}
@@ -230,7 +230,7 @@ func TestLinkifyRefs_NilBracketMap(t *testing.T) {
 func TestLinkifyRefs_ExistingLink(t *testing.T) {
 	// References inside existing Markdown links should not be double-replaced.
 	input := "See [TS 23.501 clause 5](/specs/TS%2023.501/sections/5) for details."
-	got := LinkifyRefs(input, nil, urlFor)
+	got := LinkifyRefs(input, nil, urlFor, nil)
 	if got != input {
 		t.Errorf("existing link was modified:\n got:  %q\n want: %q", got, input)
 	}
@@ -238,7 +238,7 @@ func TestLinkifyRefs_ExistingLink(t *testing.T) {
 
 func TestLinkifyRefs_NoRef(t *testing.T) {
 	input := "This text has no spec references."
-	got := LinkifyRefs(input, nil, urlFor)
+	got := LinkifyRefs(input, nil, urlFor, nil)
 	if got != input {
 		t.Errorf("expected no change, got %q", got)
 	}
@@ -246,7 +246,7 @@ func TestLinkifyRefs_NoRef(t *testing.T) {
 
 func TestLinkifyRefs_MultipleRefs(t *testing.T) {
 	input := "See TS 23.501 and RFC 3748 for details."
-	got := LinkifyRefs(input, nil, urlFor)
+	got := LinkifyRefs(input, nil, urlFor, nil)
 	want := "See [TS 23.501](/specs/TS 23.501) and [RFC 3748](https://www.rfc-editor.org/rfc/rfc3748) for details."
 	if got != want {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
@@ -338,7 +338,7 @@ func TestLinkifyRefs_CodeRegions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor)
+			got := LinkifyRefs(tt.input, nil, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -377,7 +377,7 @@ func TestLinkifyRefs_InsideTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor)
+			got := LinkifyRefs(tt.input, nil, urlFor, nil)
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -405,5 +405,202 @@ func TestRegionHelpers(t *testing.T) {
 	}
 	if got := regionEnd(regs, 3); got != 4 {
 		t.Errorf("regionEnd(3) = %d, want 4 (pos+1 fallback)", got)
+	}
+}
+
+// bareSectionSet reports the section numbers the fake current document has.
+func bareSectionSet(section string) bool {
+	switch section {
+	case "4.2", "5.1", "5.15.2", "5.15.3", "B", "B.1":
+		return true
+	}
+	return false
+}
+
+// bareURLFor resolves the empty-spec sentinel to the current spec, mirroring
+// the web viewer's urlFor closure.
+func bareURLFor(spec, section string) string {
+	if spec == "" {
+		spec = "TS 23.501"
+	}
+	return urlFor(spec, section)
+}
+
+func TestLinkifyRefs_BareRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "bare clause",
+			input: "as described in clause 4.2 with details.",
+			want:  "as described in [clause 4.2](/specs/TS 23.501/sections/4.2) with details.",
+		},
+		{
+			name:  "sentence-initial capital",
+			input: "Clause 4.2 describes this.",
+			want:  "[Clause 4.2](/specs/TS 23.501/sections/4.2) describes this.",
+		},
+		{
+			name:  "bare subclause",
+			input: "See subclause 5.15.2.",
+			want:  "See [subclause 5.15.2](/specs/TS 23.501/sections/5.15.2).",
+		},
+		{
+			name:  "bare annex",
+			input: "See Annex B for details.",
+			want:  "See [Annex B](/specs/TS 23.501/sections/B) for details.",
+		},
+		{
+			name:  "bare annex with subsection",
+			input: "See Annex B.1 for details.",
+			want:  "See [Annex B.1](/specs/TS 23.501/sections/B.1) for details.",
+		},
+		{
+			name:  "nonexistent section stays plain",
+			input: "See clause 9.9.9 for details.",
+			want:  "See clause 9.9.9 for details.",
+		},
+		{
+			name:  "keyword inside a longer word stays plain",
+			input: "the intersection 4.2 metres wide",
+			want:  "the intersection 4.2 metres wide",
+		},
+		{
+			name:  "of-TS form keeps qualified link",
+			input: "As defined in clause 5.1 of TS 23.402.",
+			want:  "As defined in [clause 5.1 of TS 23.402](/specs/TS 23.402/sections/5.1).",
+		},
+		{
+			name:  "spec-first form keeps qualified link",
+			input: "See TS 23.402 clause 5.1 for details.",
+			want:  "See [TS 23.402 clause 5.1](/specs/TS 23.402/sections/5.1) for details.",
+		},
+		{
+			name:  "capitalized of-TS form not linked bare",
+			input: "Clause 5.1 of TS 23.402 applies.",
+			want:  "Clause 5.1 of [TS 23.402](/specs/TS 23.402) applies.",
+		},
+		{
+			name:  "capitalized after spec not linked bare",
+			input: "See TS 23.402 Clause 5.1.",
+			want:  "See [TS 23.402](/specs/TS 23.402) Clause 5.1.",
+		},
+		{
+			name:  "in-TS form not linked bare",
+			input: "as specified in clause 4.2 in TS 23.502.",
+			want:  "as specified in clause 4.2 in [TS 23.502](/specs/TS 23.502).",
+		},
+		{
+			name:  "of ITU-T recommendation not linked",
+			input: "clause 4.2 of ITU-T Recommendation X.509 applies.",
+			want:  "clause 4.2 of ITU-T Recommendation X.509 applies.",
+		},
+		{
+			name:  "of present document links",
+			input: "as specified in clause 4.2 of the present document.",
+			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) of the present document.",
+		},
+		{
+			name:  "in this specification links",
+			input: "as specified in clause 4.2 in this specification.",
+			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) in this specification.",
+		},
+		{
+			name:  "this clause without number stays plain",
+			input: "as described in this clause.",
+			want:  "as described in this clause.",
+		},
+		{
+			name:  "bare plural list",
+			input: "See clauses 5.15.2 and 5.15.3.",
+			want:  "See clauses [5.15.2](/specs/TS 23.501/sections/5.15.2) and [5.15.3](/specs/TS 23.501/sections/5.15.3).",
+		},
+		{
+			name:  "bare plural list with comma",
+			input: "See clauses 4.2, 5.15.2 and 5.15.3.",
+			want:  "See clauses [4.2](/specs/TS 23.501/sections/4.2), [5.15.2](/specs/TS 23.501/sections/5.15.2) and [5.15.3](/specs/TS 23.501/sections/5.15.3).",
+		},
+		{
+			name:  "bare plural links only existing sections",
+			input: "See clauses 5.15.2 and 9.9.",
+			want:  "See clauses [5.15.2](/specs/TS 23.501/sections/5.15.2) and 9.9.",
+		},
+		{
+			name:  "bare plural with no existing section stays plain",
+			input: "See clauses 9.8 and 9.9.",
+			want:  "See clauses 9.8 and 9.9.",
+		},
+		{
+			name:  "plural of-TS form keeps qualified links",
+			input: "See clauses 5.15.2 and 5.15.3 of TS 23.402.",
+			want:  "See clauses [5.15.2](/specs/TS 23.402/sections/5.15.2) and [5.15.3](/specs/TS 23.402/sections/5.15.3) of [TS 23.402](/specs/TS 23.402).",
+		},
+		{
+			name:  "bare ref in table cell becomes HTML anchor",
+			input: "<table><tr><td>see clause 4.2</td></tr></table>",
+			want:  `<table><tr><td>see <a href="/specs/TS 23.501/sections/4.2">clause 4.2</a></td></tr></table>`,
+		},
+		{
+			name:  "bare ref in fenced code stays plain",
+			input: "```\nclause 4.2\n```\n",
+			want:  "```\nclause 4.2\n```\n",
+		},
+		{
+			name:  "bare ref in existing link stays plain",
+			input: "[clause 4.2](/specs/TS%2023.501/sections/4.2)",
+			want:  "[clause 4.2](/specs/TS%2023.501/sections/4.2)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, nil, bareURLFor, bareSectionSet)
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinkifyRefs_BareRefsWithBracketMap(t *testing.T) {
+	bracketMap := map[string]string{"19": "TS 33.203"}
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "bracket-first form keeps qualified link",
+			input: "See [19] clause 5.1 for details.",
+			want:  "See [[19] clause 5.1](/specs/TS 33.203/sections/5.1) for details.",
+		},
+		{
+			name:  "capitalized after bracket not linked bare",
+			input: "See [19] Clause 5.1.",
+			want:  "See [19] Clause 5.1.",
+		},
+		{
+			name:  "of-bracket form not linked bare",
+			input: "see clause 4.2 of [19].",
+			want:  "see clause 4.2 of [19].",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, bracketMap, bareURLFor, bareSectionSet)
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// A nil sectionExists must disable bare linkification entirely.
+func TestLinkifyRefs_BareRefsNilGate(t *testing.T) {
+	input := "as described in clause 4.2 with details."
+	got := LinkifyRefs(input, nil, bareURLFor, nil)
+	if got != input {
+		t.Errorf("expected no change with nil sectionExists, got %q", got)
 	}
 }

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -488,6 +488,11 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See [TS 23.402](/specs/TS 23.402) Clause 5.1.",
 		},
 		{
+			name:  "capitalized after RFC not linked bare",
+			input: "See RFC 3748 Section 5.1.",
+			want:  "See [RFC 3748](https://www.rfc-editor.org/rfc/rfc3748) Section 5.1.",
+		},
+		{
 			name:  "in-TS form not linked bare",
 			input: "as specified in clause 4.2 in TS 23.502.",
 			want:  "as specified in clause 4.2 in [TS 23.502](/specs/TS 23.502).",

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -528,6 +528,21 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See [TS 23.402 clause 4.2](/specs/TS 23.402/sections/4.2) and clause 5.1 for details.",
 		},
 		{
+			name:  "parenthesized designator not linked bare",
+			input: "See clause 4.2 (TS 23.402).",
+			want:  "See clause 4.2 ([TS 23.402](/specs/TS 23.402)).",
+		},
+		{
+			name:  "colon after spec not linked bare",
+			input: "See TS 23.402: Clause 5.1.",
+			want:  "See [TS 23.402](/specs/TS 23.402): Clause 5.1.",
+		},
+		{
+			name:  "mixed singular plural list of TS not linked bare",
+			input: "See clause 4.2 and clauses 5.1, 5.15.2 of TS 23.402.",
+			want:  "See clause 4.2 and clauses 5.1, 5.15.2 of [TS 23.402](/specs/TS 23.402).",
+		},
+		{
 			name:  "oxford comma list of TS not linked bare",
 			input: "See clause 4.2, 5.1, and 5.15.2 of TS 23.402.",
 			want:  "See clause 4.2, 5.1, and 5.15.2 of [TS 23.402](/specs/TS 23.402).",

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -508,6 +508,31 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) of the present document.",
 		},
 		{
+			name:  "of present specification links",
+			input: "as specified in clause 4.2 of the present specification.",
+			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) of the present specification.",
+		},
+		{
+			name:  "coordinated list of TS not linked bare",
+			input: "See clause 4.2 and clause 5.1 of TS 23.402.",
+			want:  "See clause 4.2 and [clause 5.1 of TS 23.402](/specs/TS 23.402/sections/5.1).",
+		},
+		{
+			name:  "coordinated bare numbers of TS keep qualified links",
+			input: "See clause 4.2 and 5.1 of TS 23.402.",
+			want:  "See clause [4.2](/specs/TS 23.402/sections/4.2) and [5.1](/specs/TS 23.402/sections/5.1) of [TS 23.402](/specs/TS 23.402).",
+		},
+		{
+			name:  "coordinated list of present document links all",
+			input: "See clause 4.2 and clause 5.1 of the present document.",
+			want:  "See [clause 4.2](/specs/TS 23.501/sections/4.2) and [clause 5.1](/specs/TS 23.501/sections/5.1) of the present document.",
+		},
+		{
+			name:  "coordinated list without qualifier links all",
+			input: "See clause 4.2 and clause 5.1 for details.",
+			want:  "See [clause 4.2](/specs/TS 23.501/sections/4.2) and [clause 5.1](/specs/TS 23.501/sections/5.1) for details.",
+		},
+		{
 			name:  "in this specification links",
 			input: "as specified in clause 4.2 in this specification.",
 			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) in this specification.",

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -523,6 +523,11 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See clause [4.2](/specs/TS 23.402/sections/4.2) and [5.1](/specs/TS 23.402/sections/5.1) of [TS 23.402](/specs/TS 23.402).",
 		},
 		{
+			name:  "oxford comma list of TS not linked bare",
+			input: "See clause 4.2, 5.1, and 5.15.2 of TS 23.402.",
+			want:  "See clause 4.2, 5.1, and 5.15.2 of [TS 23.402](/specs/TS 23.402).",
+		},
+		{
 			name:  "coordinated list of present document links all",
 			input: "See clause 4.2 and clause 5.1 of the present document.",
 			want:  "See [clause 4.2](/specs/TS 23.501/sections/4.2) and [clause 5.1](/specs/TS 23.501/sections/5.1) of the present document.",

--- a/web/asn1lexer_test.go
+++ b/web/asn1lexer_test.go
@@ -119,7 +119,7 @@ func TestASN1LexerHyphenatedIdentifierNotSplit(t *testing.T) {
 
 func TestRenderMarkdownHighlightsASN1(t *testing.T) {
 	content := "```asn1\nRRCSetup ::= SEQUENCE {}\n```"
-	got := renderMarkdown(content, "TS 38.331", "", nil)
+	got := renderMarkdown(content, "TS 38.331", "", nil, nil)
 	if !strings.Contains(got, "chroma") {
 		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
 	}

--- a/web/diameterlexer_test.go
+++ b/web/diameterlexer_test.go
@@ -88,7 +88,7 @@ func TestDiameterLexerDigitLeadingNameNotSplit(t *testing.T) {
 
 func TestRenderMarkdownHighlightsDiameter(t *testing.T) {
 	content := "```diameter\n< Session-Id >\n{ Origin-Host }\n```"
-	got := renderMarkdown(content, "TS 29.272", "", nil)
+	got := renderMarkdown(content, "TS 29.272", "", nil, nil)
 	if !strings.Contains(got, "chroma") {
 		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -344,7 +344,15 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, r *http.Request, specID,
 		openAPIs, _ = h.db.ListOpenAPI(r.Context(), specID)
 		refs, _ = h.db.GetReferences(r.Context(), specID, "", number, db.DirectionOutgoing, false)
 	}
-	rendered := renderSections(sections, specID, urlVersion, bracketMap)
+	// Bare "clause 4.2"-style references linkify only to sections this spec
+	// (and version) actually has; the TOC is already in hand.
+	secNums := make(map[string]bool, len(toc))
+	for _, s := range toc {
+		secNums[s.Number] = true
+	}
+	rendered := renderSections(sections, specID, urlVersion, bracketMap, func(number string) bool {
+		return secNums[number]
+	})
 	prev, next := adjacentSections(toc, number)
 
 	data := specData{
@@ -573,14 +581,14 @@ func (h *handler) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 // Helper functions
 
-func renderSections(sections []db.Section, specID, version string, bracketMap map[string]string) []sectionRendered {
+func renderSections(sections []db.Section, specID, version string, bracketMap map[string]string, sectionExists func(string) bool) []sectionRendered {
 	rendered := make([]sectionRendered, len(sections))
 	for i, s := range sections {
 		rendered[i] = sectionRendered{
 			Number:  s.Number,
 			Title:   s.Title,
 			Level:   s.Level,
-			Content: template.HTML(renderMarkdown(s.Content, specID, version, bracketMap)), //nolint:gosec
+			Content: template.HTML(renderMarkdown(s.Content, specID, version, bracketMap, sectionExists)), //nolint:gosec
 		}
 	}
 	return rendered

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -63,8 +63,10 @@ func init() {
 
 // renderMarkdown converts Markdown content to HTML, rewriting image:// URLs
 // and linkifying inline spec/RFC references. A non-empty version is carried
-// on every image URL so an archived version serves its own images.
-func renderMarkdown(content, specID, version string, bracketMap map[string]string) string {
+// on every image URL and every same-spec section link so an archived version
+// serves its own images and stays within itself when followed. sectionExists
+// gates bare same-document references ("clause 4.2"); pass nil to skip them.
+func renderMarkdown(content, specID, version string, bracketMap map[string]string, sectionExists func(string) bool) string {
 	// Linkify spec references before image/figure rewrites to avoid processing HTML attributes.
 	content = db.LinkifyRefs(content, bracketMap, func(spec, section string) string {
 		if strings.HasPrefix(spec, "RFC ") {
@@ -74,12 +76,18 @@ func renderMarkdown(content, specID, version string, bracketMap map[string]strin
 			}
 			return u
 		}
+		if spec == "" { // bare reference: the current spec
+			spec = specID
+		}
 		u := "/specs/" + url.PathEscape(spec)
 		if section != "" {
 			u += "/sections/" + section
 		}
+		if version != "" && spec == specID {
+			u += "?version=" + url.QueryEscape(version)
+		}
 		return u
-	})
+	}, sectionExists)
 	escapedSpec := url.PathEscape(specID)
 	imageURL := func(name string) string {
 		src := "/specs/" + escapedSpec + "/images/" + url.PathEscape(name)

--- a/web/siplexer_test.go
+++ b/web/siplexer_test.go
@@ -113,7 +113,7 @@ func TestRenderMarkdownHighlightsSIPAndSDP(t *testing.T) {
 		{"```sip\nINVITE sip:bob@example.net SIP/2.0\nVia: SIP/2.0/UDP pc33.example.com\n```", ">INVITE</span>"},
 		{"```sdp\nv=0\no=- 4567 1234 IN IP4 1.1.1.1\n```", ">v</span>"},
 	} {
-		got := renderMarkdown(tt.content, "TS 24.228", "", nil)
+		got := renderMarkdown(tt.content, "TS 24.228", "", nil, nil)
 		if !strings.Contains(got, "chroma") {
 			t.Errorf("renderMarkdown(%q) = %q, want chroma-highlighted output", tt.content, got)
 		}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -74,7 +74,7 @@ func TestRenderMarkdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderMarkdown(tt.content, tt.specID, "", nil)
+			result := renderMarkdown(tt.content, tt.specID, "", nil, nil)
 			if !strings.Contains(result, tt.want) {
 				t.Errorf("renderMarkdown() = %q, want to contain %q", result, tt.want)
 			}
@@ -88,7 +88,7 @@ func TestRenderMarkdown(t *testing.T) {
 func TestRenderMarkdown_MathProtected(t *testing.T) {
 	t.Run("paragraph matrix keeps backslashes", func(t *testing.T) {
 		content := `$\begin{matrix} 1 & j \\ -1 & j \end{matrix}$`
-		got := renderMarkdown(content, "TS 38.211", "", nil)
+		got := renderMarkdown(content, "TS 38.211", "", nil, nil)
 		want := `<span class="math-inline">\begin{matrix} 1 &amp; j \\ -1 &amp; j \end{matrix}</span>`
 		if !strings.Contains(got, want) {
 			t.Errorf("math not protected, got:\n%s", got)
@@ -98,7 +98,7 @@ func TestRenderMarkdown_MathProtected(t *testing.T) {
 	t.Run("pre-escaped table-cell math normalizes ampersand", func(t *testing.T) {
 		// Table HTML from the docx converter has already HTML-escaped & → &amp;.
 		content := `<table><tbody><tr><td>$1 &amp; 2$</td></tr></tbody></table>`
-		got := renderMarkdown(content, "TS 38.211", "", nil)
+		got := renderMarkdown(content, "TS 38.211", "", nil, nil)
 		// The span's inner HTML must be single-escaped so textContent is "1 & 2".
 		want := `<span class="math-inline">1 &amp; 2</span>`
 		if !strings.Contains(got, want) {
@@ -116,7 +116,7 @@ func TestRenderMarkdown_MathProtected(t *testing.T) {
 func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 	t.Run("fenced block keeps dollars", func(t *testing.T) {
 		content := "```asn1\nprice ::= $100 and $200\n```\n"
-		got := renderMarkdown(content, "TS 23.501", "", nil)
+		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 		// Chroma may tokenize around the dollars, so assert on the characters
 		// rather than the contiguous string.
 		if strings.Count(got, "$") != 2 {
@@ -133,7 +133,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 
 	t.Run("inline code keeps dollars, surrounding math still works", func(t *testing.T) {
 		content := "Set `$PATH` and `$HOME` first; the value $x^2$ is math."
-		got := renderMarkdown(content, "TS 23.501", "", nil)
+		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 		if !strings.Contains(got, "<code>$PATH</code>") || !strings.Contains(got, "<code>$HOME</code>") {
 			t.Errorf("inline code must keep its dollars, got:\n%s", got)
 		}
@@ -144,7 +144,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 
 	t.Run("angle brackets in code stay code", func(t *testing.T) {
 		content := "```\na <SUPI> in code\n```\n\nand `<NSSAI>` inline."
-		got := renderMarkdown(content, "TS 23.501", "", nil)
+		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 		if !strings.Contains(got, "&lt;SUPI&gt;") {
 			t.Errorf("code block angle brackets must be goldmark-escaped, got:\n%s", got)
 		}
@@ -163,7 +163,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 // substituted.
 func TestRenderMarkdown_PlaceholderLiteralUntouched(t *testing.T) {
 	content := "Literal token xxkatexmathxx0xxkatexmathxx in prose.\n\nAnd math $a+b$ after it."
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, "xxkatexmathxx0xxkatexmathxx") {
 		t.Errorf("literal placeholder-lookalike text must survive verbatim, got:\n%s", got)
 	}
@@ -864,7 +864,7 @@ func TestIsExternalRef(t *testing.T) {
 // text flows through htmlpkg.EscapeString before reaching the template.
 func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
 	content := `![alt"onload=x("y")](image://fig.png?w=600&h=400)`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if strings.Contains(got, `alt"onload`) {
 		t.Errorf("alt text should be HTML-escaped, got:\n%s", got)
 	}
@@ -879,7 +879,7 @@ func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
 // must reach the browser as visible text, never as markup.
 func TestRenderMarkdown_RawHTMLEscaped(t *testing.T) {
 	content := "Inline <b>bold</b> and <script>alert(1)</script> here."
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if strings.Contains(got, "<script>") {
 		t.Errorf("raw <script> must not pass through, got:\n%s", got)
 	}
@@ -899,7 +899,7 @@ func TestRenderMarkdown_RawHTMLEscaped(t *testing.T) {
 // must stay visible as text.
 func TestRenderMarkdown_AngleBracketPlaceholderVisible(t *testing.T) {
 	content := "The identifier <SUPI> is used here."
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, "&lt;SUPI&gt;") {
 		t.Errorf("expected <SUPI> to survive as escaped text, got:\n%s", got)
 	}
@@ -913,7 +913,7 @@ func TestRenderMarkdown_AngleBracketPlaceholderVisible(t *testing.T) {
 // through attributes or a non-relative src.
 func TestRenderMarkdown_EventHandlerStripped(t *testing.T) {
 	content := `Before <img src=x onerror=alert(1)> after, and <a href="javascript:alert(2)">link</a>.`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if strings.Contains(got, "onerror") {
 		t.Errorf("event handler attribute must be stripped, got:\n%s", got)
 	}
@@ -934,7 +934,7 @@ func TestRenderMarkdown_ExternalHrefStripped(t *testing.T) {
 	content := `<a href="https://evil.example/p">x</a> <a href="//evil.example/p">y</a> ` +
 		`<a href="http://evil.example/p">z</a> ` +
 		"See RFC 3748 and TS 23.501 for details."
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if strings.Contains(got, `href="https://evil`) || strings.Contains(got, `href="//`) ||
 		strings.Contains(got, `href="http://`) {
 		t.Errorf("no anchor may carry an external href, got:\n%s", got)
@@ -1060,7 +1060,7 @@ func TestNewMathToken_RandFailure(t *testing.T) {
 	if a == b {
 		t.Errorf("fallback tokens must be unique, got %q twice", a)
 	}
-	got := renderMarkdown("Inline $x_1$ math.", "TS 23.501", "", nil)
+	got := renderMarkdown("Inline $x_1$ math.", "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, "katex-math") && !strings.Contains(got, "math") {
 		t.Errorf("math must still render under the fallback token, got:\n%s", got)
 	}
@@ -1071,7 +1071,7 @@ func TestNewMathToken_RandFailure(t *testing.T) {
 
 // TestRenderMarkdown_UnknownLanguageFence pins the chroma fallback lexer path.
 func TestRenderMarkdown_UnknownLanguageFence(t *testing.T) {
-	got := renderMarkdown("```zzznotalanguage\nplain <text>\n```\n", "TS 23.501", "", nil)
+	got := renderMarkdown("```zzznotalanguage\nplain <text>\n```\n", "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, "plain") {
 		t.Errorf("unknown-language fence must still render its content, got:\n%s", got)
 	}
@@ -1086,7 +1086,7 @@ func TestRenderMarkdown_UnknownLanguageFence(t *testing.T) {
 func TestRenderMarkdown_TableMarkupSurvivesSanitizer(t *testing.T) {
 	content := `<table><thead><tr><th colspan="2">Head</th></tr></thead>` +
 		`<tbody><tr><td rowspan="2">A</td><td><img src="image://fig.png?w=200&h=100" alt="diag" width="200" height="100"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, `colspan="2"`) {
 		t.Errorf("expected colspan to survive, got:\n%s", got)
 	}
@@ -1104,7 +1104,7 @@ func TestRenderMarkdown_TableMarkupSurvivesSanitizer(t *testing.T) {
 // correctly in the web viewer.
 func TestRenderMarkdown_SubSupPassthrough(t *testing.T) {
 	content := "n_78<sup>1</sup> and H<sub>2</sub>O"
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, "<sup>1</sup>") {
 		t.Errorf("expected <sup> to pass through, got:\n%s", got)
 	}
@@ -1118,7 +1118,7 @@ func TestRenderMarkdown_SubSupPassthrough(t *testing.T) {
 // converter) are rewritten to a real /specs/<id>/images/<name> URL.
 func TestRenderMarkdown_HTMLImageRewrite(t *testing.T) {
 	content := `<table><tbody><tr><td><img src="image://fig.png?w=200&h=100" alt="diag" width="200" height="100"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 	if !strings.Contains(got, `src="/specs/TS%2023.501/images/fig.png"`) {
 		t.Errorf("expected image:// to be rewritten to spec-relative URL, got:\n%s", got)
 	}
@@ -1137,7 +1137,7 @@ func TestRenderMarkdown_HTMLImageRewrite(t *testing.T) {
 // the served attribute has to round-trip back to the stored basename.
 func TestRenderMarkdown_HTMLImageRewriteSpecialChars(t *testing.T) {
 	content := `<table><tbody><tr><td><img src="image://Figure A&B's diagram.png?w=200&h=100" alt="diag"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil)
+	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
 
 	const want = "Figure A&B's diagram.png"
 	prefix := `src="/specs/TS%2023.501/images/`
@@ -1993,4 +1993,53 @@ func TestHandleCompare_FamilyIDSuggestsParts(t *testing.T) {
 	if !strings.Contains(body, "has multiple parts") || !strings.Contains(body, "TS 38.101-1") {
 		t.Errorf("expected the parts hint naming TS 38.101-1, got:\n%s", body)
 	}
+}
+
+// TestRenderMarkdown_BareClauseRefs verifies bare same-spec references link to
+// the current spec, gated by sectionExists, and carry the version query on
+// archived pages.
+func TestRenderMarkdown_BareClauseRefs(t *testing.T) {
+	exists := func(section string) bool { return section == "4.2" }
+
+	t.Run("bare clause links within the current spec", func(t *testing.T) {
+		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "", nil, exists)
+		if want := `<a href="/specs/TS%2023.501/sections/4.2">clause 4.2</a>`; !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("bare clause carries the version on archived pages", func(t *testing.T) {
+		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "18.5.0", nil, exists)
+		if want := `<a href="/specs/TS%2023.501/sections/4.2?version=18.5.0">clause 4.2</a>`; !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("qualified same-spec ref carries the version too", func(t *testing.T) {
+		got := renderMarkdown("See TS 23.501 clause 5.1 for details.", "TS 23.501", "18.5.0", nil, exists)
+		if want := `<a href="/specs/TS%2023.501/sections/5.1?version=18.5.0">TS 23.501 clause 5.1</a>`; !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("qualified other-spec ref stays canonical", func(t *testing.T) {
+		got := renderMarkdown("See TS 23.502 clause 4.3 for details.", "TS 23.501", "18.5.0", nil, exists)
+		if want := `<a href="/specs/TS%2023.502/sections/4.3">TS 23.502 clause 4.3</a>`; !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("nonexistent section stays plain", func(t *testing.T) {
+		got := renderMarkdown("See clause 9.9 for details.", "TS 23.501", "", nil, exists)
+		if strings.Contains(got, `href="/specs/TS%2023.501/sections/9.9"`) {
+			t.Errorf("nonexistent section must not link, got:\n%s", got)
+		}
+	})
+
+	t.Run("nil sectionExists disables bare linking", func(t *testing.T) {
+		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "", nil, nil)
+		if strings.Contains(got, `href="/specs/TS%2023.501/sections/4.2"`) {
+			t.Errorf("bare ref must not link with nil sectionExists, got:\n%s", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

In the web viewer, bare references like "clause 4.2", "subclause 5.15.2" or "Annex B" (e.g. in TS 23.501 §5.15.1) were plain text. They now link to the referenced section within the current spec.

## Changes

- `db.LinkifyRefs` gains a `sectionExists` parameter (nil disables the feature, keeping MCP tool output unchanged). Bare references call `urlFor` with an empty spec meaning "the current spec".
- A bare match is accepted only when:
  - the section number exists in the spec's TOC (no dead links, works for archived versions),
  - it does not overlap a qualified match (`TS x clause y`, `clause y of TS x`, `[N] clause y`, `RFC n section m`),
  - surrounding context does not tie it to another document: trailing `of`/`in` continuations (`clause 5.1 of TS 23.402`, `clause 4.2 of [26]`), parenthesized designators (`clause 4.2 (TS 23.402)`), leading designators (`TS 23.402 Clause 5.1`, `RFC 3748 Section 3.1`, `[19] Clause 6`), including across coordinated lists (`clause 4.2 and clause 4.3 of TS 23.402`, oxford commas, mixed singular/plural keywords). "of the present document/specification" still links.
- Plural lists (`clauses 5.15.2 and 5.15.3`) link each existing section individually.
- Same-spec section links now carry `?version=` on archived pages so navigation stays within the viewed version.
- Overlap resolution sort is now deterministic (start asc, end desc).
- Rendering-time only: no DB schema change, no rebuild, `ExtractReferences`/`spec_references` untouched.

Design bias: false negatives (a reference left unlinked) are accepted; false positives (a link to the wrong document) are rejected. Known accepted false negatives: `clause 4.2 in combination with ...`-style continuations.

## Testing

- New table-driven tests in `db/linkify_test.go` (bare hit/miss, precedence vs all qualified forms, context guards, plural lists, tables, code regions).
- New `web` tests for same-spec links and `?version=` propagation.
- `go test -short ./...`, `gofmt`, `go vet` all pass. Reviewed with open-code-review (5 rounds); all confirmed findings fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeQzirA3Kr2xxULRBbioAo)_