### PR TITLE
feat(web): mark unresolved section references

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1251,10 +1251,10 @@ const secNum = `([A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 
 // bareRefChain matches zero or more coordinated references (", clause 4.3",
-// " and 4.4", ", and 4.4", "; or Annex B") so bareTrailingQualRE and
-// barePresentDocRE can see through a list to the "of"/"in" that qualifies its
-// every element.
-const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)*`
+// " and 4.4", ", and 4.4", "; or Annex B", " and in clause 4.12.2a") so
+// bareTrailingQualRE and barePresentDocRE can see through a list to the
+// "of"/"in" that qualifies its every element.
+const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
@@ -1282,6 +1282,16 @@ var (
 		`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)` + sp + `+` +
 			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + sp + `+` +
 			`(` + secNumRaw + `(?:(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `))\b`)
+
+	// tsCoordPrefixRefRE matches a coordinated list that repeats the keyword
+	// per element before naming the spec — "clause 4.12.2 and in
+	// clause 4.12.2a of TS 23.502" — which tsMultiPrefixRefRE (bare-number
+	// lists) does not cover. Every element belongs to the named spec.
+	// Groups: 1=reference-list, 2=TS|TR, 3=spec-number.
+	tsCoordPrefixRefRE = regexp.MustCompile(
+		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw +
+			`(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw + `)+)` +
+			sp + `+(?:of|in)` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
@@ -1362,18 +1372,19 @@ func rfcExtractor(m []int, content string) (string, string, bool) {
 }
 
 // multiRefExtractor converts regex submatch indices into replacement text containing multiple links.
-// urlFor is called with (targetSpec, targetSection) and returns a URL string.
-// mkLink renders a single link from (linkText, url); it lets the caller choose
-// Markdown or HTML link syntax depending on the surrounding context.
+// opts resolves target URLs and validates target sections (see
+// LinkifyRefsOpts.resolveTarget). mkLink renders a single link from
+// (linkText, url, title); it lets the caller choose Markdown or HTML link
+// syntax depending on the surrounding context.
 // Returns (replacementText, ok). When ok is false, the match is skipped.
-type multiRefExtractor func(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool)
+type multiRefExtractor func(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool)
 
 // multiRefSpecSections extracts (spec, []sections) from a multi-section regex match.
 // Returns ("", nil, false) if fewer than 2 sections are found.
 type multiRefSpecSections func(m []int, content string) (string, []string, bool)
 
 // tsMultiPrefixMRExtractor handles "clauses 8.2 and 16.11 of TS 23.402 [45]".
-func tsMultiPrefixMRExtractor(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool) {
+func tsMultiPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
 	keyword := content[m[2]:m[3]]
 	secList := content[m[4]:m[5]]
 	specType := content[m[6]:m[7]]
@@ -1386,9 +1397,10 @@ func tsMultiPrefixMRExtractor(m []int, content string, urlFor func(string, strin
 	}
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
-		return mkLink(sec, urlFor(spec, sec))
+		u, title := opts.resolveTarget(spec, sec)
+		return mkLink(sec, u, title)
 	})
-	specLink := mkLink(specType+" "+specNum, urlFor(spec, ""))
+	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""), "")
 	result := keyword + " " + linkedSecList + " of " + specLink
 
 	if m[10] >= 0 {
@@ -1410,8 +1422,23 @@ func tsMultiPrefixSpecSections(m []int, content string) (string, []string, bool)
 	return spec, sections, true
 }
 
+// tsCoordPrefixMRExtractor handles "clause 4.12.2 and in clause 4.12.2a of
+// TS 23.502": each keyword-prefixed element links to the named spec. The
+// original text — separators, prepositions, the optional 3GPP prefix — is
+// kept intact around the links.
+func tsCoordPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
+	spec := content[m[4]:m[5]] + " " + content[m[6]:m[7]]
+	linked := bareRefRE.ReplaceAllStringFunc(content[m[2]:m[3]], func(ref string) string {
+		sec := bareRefRE.FindStringSubmatch(ref)[1]
+		u, title := opts.resolveTarget(spec, sec)
+		return ref[:len(ref)-len(sec)] + mkLink(sec, u, title)
+	})
+	specLink := mkLink(content[m[4]:m[7]], opts.URLFor(spec, ""), "")
+	return linked + content[m[3]:m[4]] + specLink, true
+}
+
 // tsMultiMRExtractor handles "TS 23.402 clauses 8.2 and 16.11".
-func tsMultiMRExtractor(m []int, content string, urlFor func(string, string) string, mkLink func(text, url string) string) (string, bool) {
+func tsMultiMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
 	specType := content[m[2]:m[3]]
 	specNum := content[m[4]:m[5]]
 	keyword := content[m[6]:m[7]]
@@ -1424,9 +1451,10 @@ func tsMultiMRExtractor(m []int, content string, urlFor func(string, string) str
 	}
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
-		return mkLink(sec, urlFor(spec, sec))
+		u, title := opts.resolveTarget(spec, sec)
+		return mkLink(sec, u, title)
 	})
-	specLink := mkLink(specType+" "+specNum, urlFor(spec, ""))
+	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""), "")
 	return specLink + " " + keyword + " " + linkedSecList, true
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -1487,6 +1487,21 @@ func tsCoordPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mk
 	return linked + content[m[3]:m[4]] + specLink, true
 }
 
+// tsCoordPrefixSpecSections extracts spec and sections from a coordinated
+// keyword-per-element list for ExtractReferences.
+func tsCoordPrefixSpecSections(m []int, content string) (string, []string, bool) {
+	spec := content[m[4]:m[5]] + " " + content[m[6]:m[7]]
+	list := content[m[2]:m[3]]
+	var sections []string
+	for _, em := range coordElemRE.FindAllStringSubmatchIndex(list, -1) {
+		sections = append(sections, list[em[2]:em[3]])
+	}
+	if len(sections) < 2 {
+		return "", nil, false
+	}
+	return spec, sections, true
+}
+
 // tsMultiMRExtractor handles "TS 23.402 clauses 8.2 and 16.11".
 func tsMultiMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url string) string) (string, bool) {
 	specType := content[m[2]:m[3]]
@@ -1563,6 +1578,7 @@ func ExtractReferences(sourceSpecID, sectionNumber, content string, bracketMap m
 		re      *regexp.Regexp
 		extract multiRefSpecSections
 	}{
+		{tsCoordPrefixRefRE, tsCoordPrefixSpecSections},
 		{tsMultiPrefixRefRE, tsMultiPrefixSpecSections},
 		{tsMultiRefRE, tsMultiSpecSections},
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -743,6 +743,33 @@ func (d *DB) GetTOC(ctx context.Context, specID, version string) ([]Section, err
 // AllSections returns every section of a spec version, content included, in
 // document order. An empty version resolves to the version this database
 // holds; a version it does not hold yields no rows.
+// SectionNumbers returns the set of section numbers of the database version
+// of a spec and that version — a light existence index for cross-reference
+// validation, without loading titles or content. An unknown spec returns an
+// empty set and no error.
+func (d *DB) SectionNumbers(ctx context.Context, specID string) (map[string]bool, string, error) {
+	rows, err := d.conn.QueryContext(ctx,
+		"SELECT number, version FROM sections WHERE spec_id = ?", specID)
+	if err != nil {
+		return nil, "", fmt.Errorf("section numbers: %w", err)
+	}
+	defer rows.Close()
+
+	numbers := make(map[string]bool)
+	version := ""
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n, &version); err != nil {
+			return nil, "", fmt.Errorf("scan section number: %w", err)
+		}
+		numbers[n] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("section numbers: iterate: %w", err)
+	}
+	return numbers, version, nil
+}
+
 func (d *DB) AllSections(ctx context.Context, specID, version string) ([]Section, error) {
 	version, err := d.ResolveVersion(ctx, specID, version)
 	if errors.Is(err, ErrNoVersion) {
@@ -1250,11 +1277,18 @@ const secNum = `([A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 // secNumRaw is secNum without capture group, used for multi-section list matching.
 const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 
+// coordElemTail matches the reference part of one coordinated-list element:
+// an optional preposition-plus-keyword or bare keyword, then a section
+// number. A preposition requires a keyword after it ("and in clause 4.12.2a"
+// but not "and in 2024") so a bare number after "of"/"in" is never read as a
+// section reference.
+const coordElemTail = `(?:(?:of|in)` + sp + `+(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+|(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?)` + secNumRaw
+
 // bareRefChain matches zero or more coordinated references (", clause 4.3",
 // " and 4.4", ", and 4.4", "; or Annex B", " and in clause 4.12.2a") so
 // bareTrailingQualRE and barePresentDocRE can see through a list to the
 // "of"/"in" that qualifies its every element.
-const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)*`
+const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*` + coordElemTail + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
@@ -1293,7 +1327,7 @@ var (
 	// Groups: 1=reference-list, 2=TS|TR, 3=spec-number.
 	tsCoordPrefixRefRE = regexp.MustCompile(
 		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw +
-			`(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)+)` +
+			`(?:` + sp + `*(?:,|and|or)` + sp + `*` + coordElemTail + `)+)` +
 			sp + `+(?:of|in)` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.

--- a/db/db.go
+++ b/db/db.go
@@ -1283,18 +1283,27 @@ var (
 			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + sp + `+` +
 			`(` + secNumRaw + `(?:(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `))\b`)
 
-	// tsCoordPrefixRefRE matches a coordinated list that repeats the keyword
-	// per element before naming the spec — "clause 4.12.2 and in
-	// clause 4.12.2a of TS 23.502" — which tsMultiPrefixRefRE (bare-number
-	// lists) does not cover. Every element belongs to the named spec.
+	// tsCoordPrefixRefRE matches a coordinated list whose elements may repeat
+	// the keyword and a preposition before naming the spec —
+	// "clause 4.12.2 and in clause 4.12.2a of TS 23.502",
+	// "clause 8.2 and in clauses 8.3 and 8.4 of TS 23.402" — which
+	// tsMultiPrefixRefRE (bare-number lists) does not cover. Every element
+	// belongs to the named spec. Where both patterns match the same range,
+	// candidate collection order decides (this pattern first).
 	// Groups: 1=reference-list, 2=TS|TR, 3=spec-number.
 	tsCoordPrefixRefRE = regexp.MustCompile(
 		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw +
-			`(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw + `)+)` +
+			`(?:` + sp + `*(?:,|and|or)` + sp + `*(?:(?:of|in)` + sp + `+)?(?:(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + `)+)` +
 			sp + `+(?:of|in)` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
+
+	// coordElemRE extracts one element of a coordinated list matched by
+	// tsCoordPrefixRefRE, sharing its keyword classes (plural forms included,
+	// unlike bareRefRE; the keyword is optional, as in the list pattern).
+	// Group 1 = section number.
+	coordElemRE = regexp.MustCompile(`\b(?:(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+)?` + secNum)
 
 	// bareRefRE matches a reference with no spec designator: "clause 4.2",
 	// "Subclause 5.15.2", "Annex B". Such a reference means the current
@@ -1374,17 +1383,18 @@ func rfcExtractor(m []int, content string) (string, string, bool) {
 // multiRefExtractor converts regex submatch indices into replacement text containing multiple links.
 // opts resolves target URLs and validates target sections (see
 // LinkifyRefsOpts.resolveTarget). mkLink renders a single link from
-// (linkText, url, title); it lets the caller choose Markdown or HTML link
-// syntax depending on the surrounding context.
+// (linkText, url); it lets the caller choose Markdown or HTML link syntax
+// depending on the surrounding context. Elements whose target section is
+// missing render with unresolvedLink instead.
 // Returns (replacementText, ok). When ok is false, the match is skipped.
-type multiRefExtractor func(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool)
+type multiRefExtractor func(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url string) string) (string, bool)
 
 // multiRefSpecSections extracts (spec, []sections) from a multi-section regex match.
 // Returns ("", nil, false) if fewer than 2 sections are found.
 type multiRefSpecSections func(m []int, content string) (string, []string, bool)
 
 // tsMultiPrefixMRExtractor handles "clauses 8.2 and 16.11 of TS 23.402 [45]".
-func tsMultiPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
+func tsMultiPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url string) string) (string, bool) {
 	keyword := content[m[2]:m[3]]
 	secList := content[m[4]:m[5]]
 	specType := content[m[6]:m[7]]
@@ -1398,9 +1408,12 @@ func tsMultiPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mk
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
 		u, title := opts.resolveTarget(spec, sec)
-		return mkLink(sec, u, title)
+		if title != "" {
+			return unresolvedLink(sec, u, title)
+		}
+		return mkLink(sec, u)
 	})
-	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""), "")
+	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""))
 	result := keyword + " " + linkedSecList + " of " + specLink
 
 	if m[10] >= 0 {
@@ -1426,19 +1439,22 @@ func tsMultiPrefixSpecSections(m []int, content string) (string, []string, bool)
 // TS 23.502": each keyword-prefixed element links to the named spec. The
 // original text — separators, prepositions, the optional 3GPP prefix — is
 // kept intact around the links.
-func tsCoordPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
+func tsCoordPrefixMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url string) string) (string, bool) {
 	spec := content[m[4]:m[5]] + " " + content[m[6]:m[7]]
-	linked := bareRefRE.ReplaceAllStringFunc(content[m[2]:m[3]], func(ref string) string {
-		sec := bareRefRE.FindStringSubmatch(ref)[1]
+	linked := coordElemRE.ReplaceAllStringFunc(content[m[2]:m[3]], func(ref string) string {
+		sec := coordElemRE.FindStringSubmatch(ref)[1]
 		u, title := opts.resolveTarget(spec, sec)
-		return ref[:len(ref)-len(sec)] + mkLink(sec, u, title)
+		if title != "" {
+			return ref[:len(ref)-len(sec)] + unresolvedLink(sec, u, title)
+		}
+		return ref[:len(ref)-len(sec)] + mkLink(sec, u)
 	})
-	specLink := mkLink(content[m[4]:m[7]], opts.URLFor(spec, ""), "")
+	specLink := mkLink(content[m[4]:m[7]], opts.URLFor(spec, ""))
 	return linked + content[m[3]:m[4]] + specLink, true
 }
 
 // tsMultiMRExtractor handles "TS 23.402 clauses 8.2 and 16.11".
-func tsMultiMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url, title string) string) (string, bool) {
+func tsMultiMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink func(text, url string) string) (string, bool) {
 	specType := content[m[2]:m[3]]
 	specNum := content[m[4]:m[5]]
 	keyword := content[m[6]:m[7]]
@@ -1452,9 +1468,12 @@ func tsMultiMRExtractor(m []int, content string, opts *LinkifyRefsOpts, mkLink f
 
 	linkedSecList := secNumListRE.ReplaceAllStringFunc(secList, func(sec string) string {
 		u, title := opts.resolveTarget(spec, sec)
-		return mkLink(sec, u, title)
+		if title != "" {
+			return unresolvedLink(sec, u, title)
+		}
+		return mkLink(sec, u)
 	})
-	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""), "")
+	specLink := mkLink(specType+" "+specNum, opts.URLFor(spec, ""))
 	return specLink + " " + keyword + " " + linkedSecList, true
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2133,3 +2133,24 @@ func TestQueryMethodsHonorContext(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractReferences_CoordinatedList(t *testing.T) {
+	// Coordinated keyword-per-element list: every element belongs to the
+	// named spec and must be indexed.
+	content := "Registration is described in clause 4.12.2 and in clause 4.12.2a of TS 23.502, respectively."
+
+	refs := ExtractReferences("TS 23.501", "4.2.8.1", content, nil)
+
+	for _, want := range []string{"4.12.2", "4.12.2a"} {
+		found := false
+		for _, r := range refs {
+			if r.TargetSpec == "TS 23.502" && r.TargetSection == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected reference to TS 23.502 section %s, got refs: %+v", want, refs)
+		}
+	}
+}

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -236,6 +236,9 @@ func (o *LinkifyRefsOpts) resolveTarget(spec, section string) (url, title string
 // code spans are not replaced: goldmark renders code verbatim, so a rewritten
 // reference there would show up as literal link syntax.
 func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
+	if opts.URLFor == nil { // URLFor is the one mandatory option
+		return content
+	}
 	bracketMap, urlFor, sectionExists := opts.BracketMap, opts.URLFor, opts.SectionExists
 	// Build list of excluded regions: existing Markdown links, fenced code
 	// blocks and inline code spans.

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -132,23 +132,26 @@ func regionEnd(regions []region, pos int) int {
 	return pos + 1
 }
 
-// mdLink renders a Markdown link. A non-empty title becomes the link's title
-// attribute (tooltip).
-func mdLink(text, url, title string) string {
-	if title != "" {
-		return "[" + text + "](" + url + ` "` + strings.ReplaceAll(title, `"`, "'") + `")`
-	}
+// mdLink renders a Markdown link.
+func mdLink(text, url string) string {
 	return "[" + text + "](" + url + ")"
 }
 
 // htmlLink renders an HTML anchor. Used inside raw HTML blocks (e.g. tables)
 // where goldmark would not process Markdown link syntax.
-func htmlLink(text, url, title string) string {
-	attr := ""
-	if title != "" {
-		attr = ` title="` + htmlpkg.EscapeString(title) + `"`
-	}
-	return `<a href="` + htmlpkg.EscapeString(url) + `"` + attr + `>` + htmlpkg.EscapeString(text) + `</a>`
+func htmlLink(text, url string) string {
+	return `<a href="` + htmlpkg.EscapeString(url) + `">` + htmlpkg.EscapeString(text) + `</a>`
+}
+
+// unresolvedLink renders an anchor for a reference whose target section does
+// not exist in the stored version of the target spec: the URL degrades to the
+// spec's top page and the title explains why. Emitted as raw HTML in both
+// body text and tables — the class carries the visual marker, which Markdown
+// link syntax cannot express — and allowlisted by the web sanitizer in
+// exactly this form.
+func unresolvedLink(text, url, title string) string {
+	return `<a class="ref-unresolved" href="` + htmlpkg.EscapeString(url) +
+		`" title="` + htmlpkg.EscapeString(title) + `">` + htmlpkg.EscapeString(text) + `</a>`
 }
 
 // unresolvedSpan marks reference text whose target section does not exist,
@@ -276,7 +279,7 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 		i = end
 	}
 
-	linkFor := func(start, end int) func(text, url, title string) string {
+	linkFor := func(start, end int) func(text, url string) string {
 		for _, r := range htmlRegions {
 			if start >= r.start && end <= r.end {
 				return htmlLink
@@ -287,9 +290,15 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 
 	type candidate struct {
 		start, end int
-		text       string
+		// idx is the collection order, which encodes pattern precedence:
+		// it breaks ties between candidates covering the exact same range.
+		idx  int
+		text string
 	}
 	var candidates []candidate
+	addCandidate := func(start, end int, text string) {
+		candidates = append(candidates, candidate{start: start, end: end, idx: len(candidates), text: text})
+	}
 
 	// Multi-section patterns (produce multiple links per match, checked first).
 	multiPatterns := []struct {
@@ -309,11 +318,7 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 			if !ok {
 				continue
 			}
-			candidates = append(candidates, candidate{
-				start: m[0],
-				end:   m[1],
-				text:  text,
-			})
+			addCandidate(m[0], m[1], text)
 		}
 	}
 
@@ -344,11 +349,13 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 			}
 			u, title := opts.resolveTarget(targetSpec, targetSection)
 			matchText := content[m[0]:m[1]]
-			candidates = append(candidates, candidate{
-				start: m[0],
-				end:   m[1],
-				text:  linkFor(m[0], m[1])(matchText, u, title),
-			})
+			text := ""
+			if title != "" {
+				text = unresolvedLink(matchText, u, title)
+			} else {
+				text = linkFor(m[0], m[1])(matchText, u)
+			}
+			addCandidate(m[0], m[1], text)
 		}
 	}
 
@@ -391,13 +398,9 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 				if !sectionExists(sec) {
 					return unresolvedSpan(sec, bareRefTitle(sec, opts.CurrentLabel))
 				}
-				return mkLink(sec, urlFor("", sec), "")
+				return mkLink(sec, urlFor("", sec))
 			})
-			candidates = append(candidates, candidate{
-				start: m[0],
-				end:   m[1],
-				text:  content[m[0]:m[2]] + linked,
-			})
+			addCandidate(m[0], m[1], content[m[0]:m[2]]+linked)
 		}
 		for _, m := range bareRefRE.FindAllStringSubmatchIndex(content, -1) {
 			if isExcluded(m[0], m[1]) || overlapsAny(m[0], m[1]) || qualifiedElsewhere(m[0], m[1]) {
@@ -407,18 +410,14 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 			matchText := content[m[0]:m[1]]
 			text := ""
 			if sectionExists(sec) {
-				text = linkFor(m[0], m[1])(matchText, urlFor("", sec), "")
+				text = linkFor(m[0], m[1])(matchText, urlFor("", sec))
 			} else {
 				// A bare reference is same-document by construction, so a
 				// missing section is worth surfacing: mark it instead of
 				// leaving silently ambiguous plain text.
 				text = unresolvedSpan(matchText, bareRefTitle(sec, opts.CurrentLabel))
 			}
-			candidates = append(candidates, candidate{
-				start: m[0],
-				end:   m[1],
-				text:  text,
-			})
+			addCandidate(m[0], m[1], text)
 		}
 	}
 
@@ -426,12 +425,16 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 		return content
 	}
 
-	// Sort by start position; on a tie the longer match wins deterministically.
+	// Sort by start position; on a tie the longer match wins, then the
+	// earlier-collected candidate (pattern precedence) — fully deterministic.
 	sort.Slice(candidates, func(i, j int) bool {
 		if candidates[i].start != candidates[j].start {
 			return candidates[i].start < candidates[j].start
 		}
-		return candidates[i].end > candidates[j].end
+		if candidates[i].end != candidates[j].end {
+			return candidates[i].end > candidates[j].end
+		}
+		return candidates[i].idx < candidates[j].idx
 	})
 
 	// Remove overlapping candidates (keep first/earliest).

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -132,29 +132,108 @@ func regionEnd(regions []region, pos int) int {
 	return pos + 1
 }
 
-// mdLink renders a Markdown link.
-func mdLink(text, url string) string {
+// mdLink renders a Markdown link. A non-empty title becomes the link's title
+// attribute (tooltip).
+func mdLink(text, url, title string) string {
+	if title != "" {
+		return "[" + text + "](" + url + ` "` + strings.ReplaceAll(title, `"`, "'") + `")`
+	}
 	return "[" + text + "](" + url + ")"
 }
 
 // htmlLink renders an HTML anchor. Used inside raw HTML blocks (e.g. tables)
 // where goldmark would not process Markdown link syntax.
-func htmlLink(text, url string) string {
-	return `<a href="` + htmlpkg.EscapeString(url) + `">` + htmlpkg.EscapeString(text) + `</a>`
+func htmlLink(text, url, title string) string {
+	attr := ""
+	if title != "" {
+		attr = ` title="` + htmlpkg.EscapeString(title) + `"`
+	}
+	return `<a href="` + htmlpkg.EscapeString(url) + `"` + attr + `>` + htmlpkg.EscapeString(text) + `</a>`
 }
 
-// LinkifyRefs replaces spec/RFC/bracket references in Markdown content with Markdown links.
-// bracketMap maps bracket numbers (e.g. "19") to spec IDs (e.g. "TS 33.203"); pass nil to skip.
-// urlFor is called with (targetSpec, targetSection) and returns a URL string.
-// sectionExists enables bare same-document references ("clause 4.2" with no
-// spec designator): a bare reference is linkified only when sectionExists
-// reports its section number present in the current document, and urlFor is
-// then called with an empty targetSpec meaning "the current spec". Pass nil
-// to skip bare references.
+// unresolvedSpan marks reference text whose target section does not exist,
+// with a tooltip explaining why. Emitted as raw HTML in both body text and
+// tables: goldmark passes inline <span> through and the sanitizer allowlists
+// class and title on span.
+func unresolvedSpan(text, title string) string {
+	return `<span class="ref-unresolved" title="` + htmlpkg.EscapeString(title) + `">` +
+		htmlpkg.EscapeString(text) + `</span>`
+}
+
+// crossRefTitle explains a cross-spec reference whose section is missing from
+// the database's version of the target spec.
+func crossRefTitle(spec, section, version string) string {
+	label := spec
+	if version != "" {
+		label += " v" + version
+	}
+	return "Section " + section + " does not exist in " + label +
+		" — the text may reference a different version of " + spec + "; linked to the specification instead"
+}
+
+// bareRefTitle explains a bare same-document reference whose section does not
+// exist in the current document.
+func bareRefTitle(section, label string) string {
+	if label == "" {
+		label = "this document"
+	}
+	return "Section " + section + " does not exist in " + label +
+		" — possibly a stale or incorrect reference in the source text"
+}
+
+// LinkifyRefsOpts configures LinkifyRefs.
+type LinkifyRefsOpts struct {
+	// BracketMap maps bracket numbers (e.g. "19") to spec IDs (e.g.
+	// "TS 33.203"); nil skips bracket references.
+	BracketMap map[string]string
+	// URLFor returns the URL for (targetSpec, targetSection). An empty
+	// targetSpec means the current spec (bare references); an empty
+	// targetSection means the spec itself.
+	URLFor func(spec, section string) string
+	// SectionExists reports whether the current document has a section.
+	// nil disables bare same-document references ("clause 4.2" with no spec
+	// designator) entirely. A bare reference whose section exists links via
+	// URLFor("", section); one whose section is missing is marked with
+	// unresolvedSpan instead — a bare reference is same-document by
+	// construction, so a missing target is an error in the source text.
+	SectionExists func(section string) bool
+	// CurrentLabel names the current document in unresolved bare-reference
+	// tooltips (e.g. "TS 23.501 v20.2.0"). Empty means "this document".
+	CurrentLabel string
+	// TargetInfo reports whether targetSpec contains targetSection, and
+	// targetSpec's display version. ok=false means the spec cannot be
+	// validated (not in the database) and the reference links as-is.
+	// nil disables cross-spec validation. A reference whose target section is
+	// missing links to the spec's top page with an explanatory tooltip: the
+	// database holds one version per spec, so section numbers in the citing
+	// text can lag or lead the stored version of the target spec.
+	TargetInfo func(spec, section string) (exists bool, version string, ok bool)
+}
+
+// resolveTarget returns the URL and tooltip title for a reference to
+// (spec, section), degrading to the spec's top page when the section does not
+// exist in the database's version of the target spec. RFC references are
+// never validated.
+func (o *LinkifyRefsOpts) resolveTarget(spec, section string) (url, title string) {
+	url = o.URLFor(spec, section)
+	if o.TargetInfo == nil || section == "" || strings.HasPrefix(spec, "RFC ") {
+		return url, ""
+	}
+	exists, version, ok := o.TargetInfo(spec, section)
+	if !ok || exists {
+		return url, ""
+	}
+	return o.URLFor(spec, ""), crossRefTitle(spec, section, version)
+}
+
+// LinkifyRefs replaces spec/RFC/bracket references in Markdown content with
+// Markdown links (HTML anchors inside raw HTML table blocks, where goldmark
+// would not process Markdown link syntax).
 // References inside existing Markdown links, fenced code blocks and inline
 // code spans are not replaced: goldmark renders code verbatim, so a rewritten
 // reference there would show up as literal link syntax.
-func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec, section string) string, sectionExists func(section string) bool) string {
+func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
+	bracketMap, urlFor, sectionExists := opts.BracketMap, opts.URLFor, opts.SectionExists
 	// Build list of excluded regions: existing Markdown links, fenced code
 	// blocks and inline code spans.
 	var excluded []region
@@ -197,7 +276,7 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 		i = end
 	}
 
-	linkFor := func(start, end int) func(text, url string) string {
+	linkFor := func(start, end int) func(text, url, title string) string {
 		for _, r := range htmlRegions {
 			if start >= r.start && end <= r.end {
 				return htmlLink
@@ -217,6 +296,7 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 		re      *regexp.Regexp
 		extract multiRefExtractor
 	}{
+		{tsCoordPrefixRefRE, tsCoordPrefixMRExtractor},
 		{tsMultiPrefixRefRE, tsMultiPrefixMRExtractor},
 		{tsMultiRefRE, tsMultiMRExtractor},
 	}
@@ -225,7 +305,7 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			if isExcluded(m[0], m[1]) {
 				continue
 			}
-			text, ok := pat.extract(m, content, urlFor, linkFor(m[0], m[1]))
+			text, ok := pat.extract(m, content, &opts, linkFor(m[0], m[1]))
 			if !ok {
 				continue
 			}
@@ -262,12 +342,12 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 			if isExcluded(m[0], m[1]) {
 				continue
 			}
-			u := urlFor(targetSpec, targetSection)
+			u, title := opts.resolveTarget(targetSpec, targetSection)
 			matchText := content[m[0]:m[1]]
 			candidates = append(candidates, candidate{
 				start: m[0],
 				end:   m[1],
-				text:  linkFor(m[0], m[1])(matchText, u),
+				text:  linkFor(m[0], m[1])(matchText, u, title),
 			})
 		}
 	}
@@ -307,17 +387,12 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 				continue
 			}
 			mkLink := linkFor(m[0], m[1])
-			linkedAny := false
 			linked := secNumListRE.ReplaceAllStringFunc(content[m[2]:m[3]], func(sec string) string {
 				if !sectionExists(sec) {
-					return sec
+					return unresolvedSpan(sec, bareRefTitle(sec, opts.CurrentLabel))
 				}
-				linkedAny = true
-				return mkLink(sec, urlFor("", sec))
+				return mkLink(sec, urlFor("", sec), "")
 			})
-			if !linkedAny {
-				continue
-			}
 			candidates = append(candidates, candidate{
 				start: m[0],
 				end:   m[1],
@@ -329,14 +404,20 @@ func LinkifyRefs(content string, bracketMap map[string]string, urlFor func(spec,
 				continue
 			}
 			sec := content[m[2]:m[3]]
-			if !sectionExists(sec) {
-				continue
-			}
 			matchText := content[m[0]:m[1]]
+			text := ""
+			if sectionExists(sec) {
+				text = linkFor(m[0], m[1])(matchText, urlFor("", sec), "")
+			} else {
+				// A bare reference is same-document by construction, so a
+				// missing section is worth surfacing: mark it instead of
+				// leaving silently ambiguous plain text.
+				text = unresolvedSpan(matchText, bareRefTitle(sec, opts.CurrentLabel))
+			}
 			candidates = append(candidates, candidate{
 				start: m[0],
 				end:   m[1],
-				text:  linkFor(m[0], m[1])(matchText, urlFor("", sec)),
+				text:  text,
 			})
 		}
 	}

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -10,6 +10,10 @@ import (
 // existingLinkRE matches Markdown link syntax [text](url) to avoid double-linking.
 var existingLinkRE = regexp.MustCompile(`\[[^\]]*\]\([^)]*\)`)
 
+// tableRegionOpenRE matches a converter-emitted table opener: each table is
+// its own block, so a real opener sits at the start of a line.
+var tableRegionOpenRE = regexp.MustCompile(`(?m)^<table[\s>]`)
+
 // region is a half-open byte range [start, end) within a content string.
 type region struct{ start, end int }
 
@@ -143,6 +147,16 @@ func htmlLink(text, url string) string {
 	return `<a href="` + htmlpkg.EscapeString(url) + `">` + htmlpkg.EscapeString(text) + `</a>`
 }
 
+// markerText escapes reference text for use inside an unresolved-reference
+// marker, folding newlines to spaces: the reference regexes can match across
+// a line break (sp includes \s), but the web sanitizer relies on markers
+// never spanning lines, so the invariant is enforced here at generation.
+func markerText(text string) string {
+	text = strings.ReplaceAll(text, "\r", " ")
+	text = strings.ReplaceAll(text, "\n", " ")
+	return htmlpkg.EscapeString(text)
+}
+
 // unresolvedLink renders an anchor for a reference whose target section does
 // not exist in the stored version of the target spec: the URL degrades to the
 // spec's top page and the title explains why. Emitted as raw HTML in both
@@ -151,7 +165,7 @@ func htmlLink(text, url string) string {
 // exactly this form.
 func unresolvedLink(text, url, title string) string {
 	return `<a class="ref-unresolved" href="` + htmlpkg.EscapeString(url) +
-		`" title="` + htmlpkg.EscapeString(title) + `">` + htmlpkg.EscapeString(text) + `</a>`
+		`" title="` + htmlpkg.EscapeString(title) + `">` + markerText(text) + `</a>`
 }
 
 // unresolvedSpan marks reference text whose target section does not exist,
@@ -160,7 +174,7 @@ func unresolvedLink(text, url, title string) string {
 // class and title on span.
 func unresolvedSpan(text, title string) string {
 	return `<span class="ref-unresolved" title="` + htmlpkg.EscapeString(title) + `">` +
-		htmlpkg.EscapeString(text) + `</span>`
+		markerText(text) + `</span>`
 }
 
 // crossRefTitle explains a cross-spec reference whose section is missing from
@@ -262,16 +276,19 @@ func LinkifyRefs(content string, opts LinkifyRefsOpts) string {
 	// Build list of raw-HTML block regions (tables). goldmark does not process
 	// Markdown link syntax inside raw HTML blocks, so references in these regions
 	// must be emitted as HTML anchors instead of Markdown links. The DOCX→HTML
-	// pipeline always emits lowercase <table>/</table> tags, so search content
-	// directly: lowercasing first could shift byte offsets for rare Unicode
-	// characters whose lowercase form has a different byte length.
+	// pipeline always emits lowercase <table>/</table> tags with each table as
+	// its own block, so a real opener sits at the start of a line (see
+	// tableRegionOpenRE) — prose mentioning "<table>" mid-sentence does not
+	// open a region. Search content directly: lowercasing first could shift
+	// byte offsets for rare Unicode characters whose lowercase form has a
+	// different byte length.
 	var htmlRegions []region
 	for i := 0; i < len(content); {
-		open := strings.Index(content[i:], "<table")
-		if open < 0 {
+		loc := tableRegionOpenRE.FindStringIndex(content[i:])
+		if loc == nil {
 			break
 		}
-		open += i
+		open := i + loc[0]
 		rel := strings.Index(content[open:], "</table>")
 		if rel < 0 {
 			htmlRegions = append(htmlRegions, region{open, len(content)})

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -798,3 +798,14 @@ func TestLinkifyRefs_NilURLFor(t *testing.T) {
 		t.Errorf("expected no change with nil URLFor, got %q", got)
 	}
 }
+
+// A reference matched across a line break must not produce a multi-line
+// marker: the web sanitizer relies on markers staying on one line.
+func TestLinkifyRefs_MarkerFoldsNewline(t *testing.T) {
+	input := "See clause\n9.9 for details."
+	want := `See <span class="ref-unresolved" title="Section 9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">clause 9.9</span> for details.`
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -778,3 +778,23 @@ func TestLinkifyRefs_CoordPluralKeyword(t *testing.T) {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
 	}
 }
+
+// A bare number directly after a preposition is not a section reference:
+// the coordinated patterns require a keyword after "of"/"in".
+func TestLinkifyRefs_PrepositionNeedsKeyword(t *testing.T) {
+	input := "See clause 4.1 and in 2024 of TS 23.501."
+	want := "See clause 4.1 and in 2024 of [TS 23.501](/specs/TS 23.501)."
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
+// URLFor is the one mandatory option; without it LinkifyRefs is a no-op
+// instead of a panic.
+func TestLinkifyRefs_NilURLFor(t *testing.T) {
+	input := "See TS 23.501 clause 5.1."
+	if got := LinkifyRefs(input, LinkifyRefsOpts{}); got != input {
+		t.Errorf("expected no change with nil URLFor, got %q", got)
+	}
+}

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -190,7 +190,7 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 		{
 			name:  "with 3GPP prefix",
 			input: "clauses 8.2 and 16.11 of 3GPP TS 23.402",
-			want:  "clauses [8.2](/specs/TS 23.402/sections/8.2) and [16.11](/specs/TS 23.402/sections/16.11) of [TS 23.402](/specs/TS 23.402)",
+			want:  "clauses [8.2](/specs/TS 23.402/sections/8.2) and [16.11](/specs/TS 23.402/sections/16.11) of 3GPP [TS 23.402](/specs/TS 23.402)",
 		},
 		{
 			name:  "spec-first multi-section",
@@ -543,9 +543,9 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See [TS 23.402](/specs/TS 23.402): Clause 5.1.",
 		},
 		{
-			name:  "mixed singular plural list of TS not linked bare",
+			name:  "mixed singular plural list links every element to the named spec",
 			input: "See clause 4.2 and clauses 5.1, 5.15.2 of TS 23.402.",
-			want:  "See clause 4.2 and clauses 5.1, 5.15.2 of [TS 23.402](/specs/TS 23.402).",
+			want:  "See clause [4.2](/specs/TS 23.402/sections/4.2) and clauses [5.1](/specs/TS 23.402/sections/5.1), [5.15.2](/specs/TS 23.402/sections/5.15.2) of [TS 23.402](/specs/TS 23.402).",
 		},
 		{
 			name:  "oxford comma list of TS not linked bare",
@@ -687,12 +687,12 @@ func TestLinkifyRefs_TargetValidation(t *testing.T) {
 		{
 			name:  "missing target links to spec top with tooltip",
 			input: "See TS 23.502 clause 4.12.2a.",
-			want:  `See [TS 23.502 clause 4.12.2a](/specs/TS 23.502 "` + missing502 + `").`,
+			want:  `See <a class="ref-unresolved" href="/specs/TS 23.502" title="` + missing502 + `">TS 23.502 clause 4.12.2a</a>.`,
 		},
 		{
 			name:  "missing target in prefix form",
 			input: "as described in clause 4.12.2a of TS 23.502.",
-			want:  `as described in [clause 4.12.2a of TS 23.502](/specs/TS 23.502 "` + missing502 + `").`,
+			want:  `as described in <a class="ref-unresolved" href="/specs/TS 23.502" title="` + missing502 + `">clause 4.12.2a of TS 23.502</a>.`,
 		},
 		{
 			name:  "unvalidatable spec links as-is",
@@ -703,18 +703,18 @@ func TestLinkifyRefs_TargetValidation(t *testing.T) {
 			name:  "multi list validates each element",
 			input: "TS 23.502 clauses 4.12.2 and 9.9",
 			want: "[TS 23.502](/specs/TS 23.502) clauses [4.12.2](/specs/TS 23.502/sections/4.12.2) and " +
-				`[9.9](/specs/TS 23.502 "Section 9.9 does not exist in TS 23.502 v20.2.0 — the text may reference a different version of TS 23.502; linked to the specification instead")`,
+				`<a class="ref-unresolved" href="/specs/TS 23.502" title="Section 9.9 does not exist in TS 23.502 v20.2.0 — the text may reference a different version of TS 23.502; linked to the specification instead">9.9</a>`,
 		},
 		{
 			name:  "coordinated list validates each element",
 			input: "in clause 4.12.2 and in clause 4.12.2a of TS 23.502.",
 			want: "in clause [4.12.2](/specs/TS 23.502/sections/4.12.2) and in " +
-				`clause [4.12.2a](/specs/TS 23.502 "` + missing502 + `") of [TS 23.502](/specs/TS 23.502).`,
+				"clause " + `<a class="ref-unresolved" href="/specs/TS 23.502" title="` + missing502 + `">4.12.2a</a>` + " of [TS 23.502](/specs/TS 23.502).",
 		},
 		{
 			name:  "missing target in table gets anchor title",
 			input: "<table><tr><td>TS 23.502 clause 4.12.2a</td></tr></table>",
-			want:  `<table><tr><td><a href="/specs/TS 23.502" title="` + missing502 + `">TS 23.502 clause 4.12.2a</a></td></tr></table>`,
+			want:  `<table><tr><td><a class="ref-unresolved" href="/specs/TS 23.502" title="` + missing502 + `">TS 23.502 clause 4.12.2a</a></td></tr></table>`,
 		},
 		{
 			name:  "RFC references are never validated",
@@ -735,7 +735,7 @@ func TestLinkifyRefs_TargetValidation(t *testing.T) {
 func TestLinkifyRefs_TargetValidationBracket(t *testing.T) {
 	bracketMap := map[string]string{"19": "TS 33.203"}
 	input := "See [19] clause 7 for details."
-	want := `See [[19] clause 7](/specs/TS 33.203 "Section 7 does not exist in TS 33.203 v18.0.0 — the text may reference a different version of TS 33.203; linked to the specification instead") for details.`
+	want := `See <a class="ref-unresolved" href="/specs/TS 33.203" title="Section 7 does not exist in TS 33.203 v18.0.0 — the text may reference a different version of TS 33.203; linked to the specification instead">[19] clause 7</a> for details.`
 	got := LinkifyRefs(input, LinkifyRefsOpts{BracketMap: bracketMap, URLFor: urlFor, TargetInfo: stubTargetInfo})
 	if got != want {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
@@ -762,6 +762,18 @@ func TestLinkifyRefs_BareUnresolvedInTable(t *testing.T) {
 	input := "<table><tr><td>see clause 9.9</td></tr></table>"
 	want := `<table><tr><td>see <span class="ref-unresolved" title="Section 9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">clause 9.9</span></td></tr></table>`
 	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
+// Coordinated lists may use plural keywords per element; the element
+// extractor must share the pattern's keyword classes.
+func TestLinkifyRefs_CoordPluralKeyword(t *testing.T) {
+	input := "See clause 8.2 and in clauses 8.3 and 8.4 of TS 23.402."
+	want := "See clause [8.2](/specs/TS 23.402/sections/8.2) and in clauses [8.3](/specs/TS 23.402/sections/8.3) and " +
+		"[8.4](/specs/TS 23.402/sections/8.4) of [TS 23.402](/specs/TS 23.402)."
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
 	if got != want {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
 	}

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -73,7 +73,7 @@ func TestLinkifyRefs_TS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -105,7 +105,7 @@ func TestLinkifyRefs_RFC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -148,7 +148,7 @@ func TestLinkifyRefs_Bracket(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, bracketMap, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{BracketMap: bracketMap, URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -210,7 +210,7 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -221,7 +221,7 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 func TestLinkifyRefs_NilBracketMap(t *testing.T) {
 	// Bracket refs should NOT be replaced when bracketMap is nil.
 	input := "See [19] clause 6 for details."
-	got := LinkifyRefs(input, nil, urlFor, nil)
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
 	if got != input {
 		t.Errorf("expected no change with nil bracketMap, got %q", got)
 	}
@@ -230,7 +230,7 @@ func TestLinkifyRefs_NilBracketMap(t *testing.T) {
 func TestLinkifyRefs_ExistingLink(t *testing.T) {
 	// References inside existing Markdown links should not be double-replaced.
 	input := "See [TS 23.501 clause 5](/specs/TS%2023.501/sections/5) for details."
-	got := LinkifyRefs(input, nil, urlFor, nil)
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
 	if got != input {
 		t.Errorf("existing link was modified:\n got:  %q\n want: %q", got, input)
 	}
@@ -238,7 +238,7 @@ func TestLinkifyRefs_ExistingLink(t *testing.T) {
 
 func TestLinkifyRefs_NoRef(t *testing.T) {
 	input := "This text has no spec references."
-	got := LinkifyRefs(input, nil, urlFor, nil)
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
 	if got != input {
 		t.Errorf("expected no change, got %q", got)
 	}
@@ -246,7 +246,7 @@ func TestLinkifyRefs_NoRef(t *testing.T) {
 
 func TestLinkifyRefs_MultipleRefs(t *testing.T) {
 	input := "See TS 23.501 and RFC 3748 for details."
-	got := LinkifyRefs(input, nil, urlFor, nil)
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
 	want := "See [TS 23.501](/specs/TS 23.501) and [RFC 3748](https://www.rfc-editor.org/rfc/rfc3748) for details."
 	if got != want {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
@@ -338,7 +338,7 @@ func TestLinkifyRefs_CodeRegions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -377,7 +377,7 @@ func TestLinkifyRefs_InsideTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, urlFor, nil)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -458,9 +458,9 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See [Annex B.1](/specs/TS 23.501/sections/B.1) for details.",
 		},
 		{
-			name:  "nonexistent section stays plain",
+			name:  "nonexistent section gets unresolved marker",
 			input: "See clause 9.9.9 for details.",
-			want:  "See clause 9.9.9 for details.",
+			want:  `See <span class="ref-unresolved" title="Section 9.9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">clause 9.9.9</span> for details.`,
 		},
 		{
 			name:  "keyword inside a longer word stays plain",
@@ -513,9 +513,14 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "as specified in [clause 4.2](/specs/TS 23.501/sections/4.2) of the present specification.",
 		},
 		{
-			name:  "coordinated list of TS not linked bare",
+			name:  "coordinated list links every element to the named spec",
 			input: "See clause 4.2 and clause 5.1 of TS 23.402.",
-			want:  "See clause 4.2 and [clause 5.1 of TS 23.402](/specs/TS 23.402/sections/5.1).",
+			want:  "See clause [4.2](/specs/TS 23.402/sections/4.2) and clause [5.1](/specs/TS 23.402/sections/5.1) of [TS 23.402](/specs/TS 23.402).",
+		},
+		{
+			name:  "coordinated list with preposition links every element to the named spec",
+			input: "described in clause 4.12.2 and in clause 4.12.2a of TS 23.502 [3], respectively.",
+			want:  "described in clause [4.12.2](/specs/TS 23.502/sections/4.12.2) and in clause [4.12.2a](/specs/TS 23.502/sections/4.12.2a) of [TS 23.502](/specs/TS 23.502) [3], respectively.",
 		},
 		{
 			name:  "coordinated bare numbers of TS keep qualified links",
@@ -578,14 +583,9 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See clauses [4.2](/specs/TS 23.501/sections/4.2), [5.15.2](/specs/TS 23.501/sections/5.15.2) and [5.15.3](/specs/TS 23.501/sections/5.15.3).",
 		},
 		{
-			name:  "bare plural links only existing sections",
+			name:  "bare plural links existing and marks missing sections",
 			input: "See clauses 5.15.2 and 9.9.",
-			want:  "See clauses [5.15.2](/specs/TS 23.501/sections/5.15.2) and 9.9.",
-		},
-		{
-			name:  "bare plural with no existing section stays plain",
-			input: "See clauses 9.8 and 9.9.",
-			want:  "See clauses 9.8 and 9.9.",
+			want:  `See clauses [5.15.2](/specs/TS 23.501/sections/5.15.2) and <span class="ref-unresolved" title="Section 9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">9.9</span>.`,
 		},
 		{
 			name:  "plural of-TS form keeps qualified links",
@@ -610,7 +610,7 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, nil, bareURLFor, bareSectionSet)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -643,7 +643,7 @@ func TestLinkifyRefs_BareRefsWithBracketMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LinkifyRefs(tt.input, bracketMap, bareURLFor, bareSectionSet)
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{BracketMap: bracketMap, URLFor: bareURLFor, SectionExists: bareSectionSet})
 			if got != tt.want {
 				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
 			}
@@ -654,8 +654,115 @@ func TestLinkifyRefs_BareRefsWithBracketMap(t *testing.T) {
 // A nil sectionExists must disable bare linkification entirely.
 func TestLinkifyRefs_BareRefsNilGate(t *testing.T) {
 	input := "as described in clause 4.2 with details."
-	got := LinkifyRefs(input, nil, bareURLFor, nil)
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor})
 	if got != input {
 		t.Errorf("expected no change with nil sectionExists, got %q", got)
+	}
+}
+
+// stubTargetInfo validates cross-spec references: TS 23.502 has only 4.12.2,
+// TS 33.203 has only 6; other specs cannot be validated.
+func stubTargetInfo(spec, section string) (bool, string, bool) {
+	switch spec {
+	case "TS 23.502":
+		return section == "4.12.2", "20.2.0", true
+	case "TS 33.203":
+		return section == "6", "18.0.0", true
+	}
+	return false, "", false
+}
+
+func TestLinkifyRefs_TargetValidation(t *testing.T) {
+	missing502 := `Section 4.12.2a does not exist in TS 23.502 v20.2.0 — the text may reference a different version of TS 23.502; linked to the specification instead`
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "existing target keeps section link",
+			input: "See TS 23.502 clause 4.12.2.",
+			want:  "See [TS 23.502 clause 4.12.2](/specs/TS 23.502/sections/4.12.2).",
+		},
+		{
+			name:  "missing target links to spec top with tooltip",
+			input: "See TS 23.502 clause 4.12.2a.",
+			want:  `See [TS 23.502 clause 4.12.2a](/specs/TS 23.502 "` + missing502 + `").`,
+		},
+		{
+			name:  "missing target in prefix form",
+			input: "as described in clause 4.12.2a of TS 23.502.",
+			want:  `as described in [clause 4.12.2a of TS 23.502](/specs/TS 23.502 "` + missing502 + `").`,
+		},
+		{
+			name:  "unvalidatable spec links as-is",
+			input: "See TS 29.500 clause 5.1.",
+			want:  "See [TS 29.500 clause 5.1](/specs/TS 29.500/sections/5.1).",
+		},
+		{
+			name:  "multi list validates each element",
+			input: "TS 23.502 clauses 4.12.2 and 9.9",
+			want: "[TS 23.502](/specs/TS 23.502) clauses [4.12.2](/specs/TS 23.502/sections/4.12.2) and " +
+				`[9.9](/specs/TS 23.502 "Section 9.9 does not exist in TS 23.502 v20.2.0 — the text may reference a different version of TS 23.502; linked to the specification instead")`,
+		},
+		{
+			name:  "coordinated list validates each element",
+			input: "in clause 4.12.2 and in clause 4.12.2a of TS 23.502.",
+			want: "in clause [4.12.2](/specs/TS 23.502/sections/4.12.2) and in " +
+				`clause [4.12.2a](/specs/TS 23.502 "` + missing502 + `") of [TS 23.502](/specs/TS 23.502).`,
+		},
+		{
+			name:  "missing target in table gets anchor title",
+			input: "<table><tr><td>TS 23.502 clause 4.12.2a</td></tr></table>",
+			want:  `<table><tr><td><a href="/specs/TS 23.502" title="` + missing502 + `">TS 23.502 clause 4.12.2a</a></td></tr></table>`,
+		},
+		{
+			name:  "RFC references are never validated",
+			input: "See RFC 3748 section 99.9.",
+			want:  "See [RFC 3748 section 99.9](https://www.rfc-editor.org/rfc/rfc3748#section-99.9).",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: urlFor, TargetInfo: stubTargetInfo})
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinkifyRefs_TargetValidationBracket(t *testing.T) {
+	bracketMap := map[string]string{"19": "TS 33.203"}
+	input := "See [19] clause 7 for details."
+	want := `See [[19] clause 7](/specs/TS 33.203 "Section 7 does not exist in TS 33.203 v18.0.0 — the text may reference a different version of TS 33.203; linked to the specification instead") for details.`
+	got := LinkifyRefs(input, LinkifyRefsOpts{BracketMap: bracketMap, URLFor: urlFor, TargetInfo: stubTargetInfo})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
+// CurrentLabel names the document in bare unresolved-reference tooltips.
+func TestLinkifyRefs_BareUnresolvedLabel(t *testing.T) {
+	input := "See clause 9.9 for details."
+	want := `See <span class="ref-unresolved" title="Section 9.9 does not exist in TS 23.501 v20.2.0 — possibly a stale or incorrect reference in the source text">clause 9.9</span> for details.`
+	got := LinkifyRefs(input, LinkifyRefsOpts{
+		URLFor:        bareURLFor,
+		SectionExists: bareSectionSet,
+		CurrentLabel:  "TS 23.501 v20.2.0",
+	})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
+// A bare reference in a table cell whose section is missing must be marked
+// with the same span — raw HTML is valid in both contexts.
+func TestLinkifyRefs_BareUnresolvedInTable(t *testing.T) {
+	input := "<table><tr><td>see clause 9.9</td></tr></table>"
+	want := `<table><tr><td>see <span class="ref-unresolved" title="Section 9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">clause 9.9</span></td></tr></table>`
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
 	}
 }

--- a/web/asn1lexer_test.go
+++ b/web/asn1lexer_test.go
@@ -119,7 +119,7 @@ func TestASN1LexerHyphenatedIdentifierNotSplit(t *testing.T) {
 
 func TestRenderMarkdownHighlightsASN1(t *testing.T) {
 	content := "```asn1\nRRCSetup ::= SEQUENCE {}\n```"
-	got := renderMarkdown(content, "TS 38.331", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 38.331"})
 	if !strings.Contains(got, "chroma") {
 		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
 	}

--- a/web/diameterlexer_test.go
+++ b/web/diameterlexer_test.go
@@ -88,7 +88,7 @@ func TestDiameterLexerDigitLeadingNameNotSplit(t *testing.T) {
 
 func TestRenderMarkdownHighlightsDiameter(t *testing.T) {
 	content := "```diameter\n< Session-Id >\n{ Origin-Host }\n```"
-	got := renderMarkdown(content, "TS 29.272", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 29.272"})
 	if !strings.Contains(got, "chroma") {
 		t.Errorf("renderMarkdown() = %q, want chroma-highlighted output", got)
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -601,11 +601,12 @@ func renderSections(sections []db.Section, o renderOpts) []sectionRendered {
 }
 
 // targetInfo returns a per-request validator of cross-spec section references
-// against the database's version of each target spec, with the TOCs fetched
-// lazily and cached for the request. References to the spec being viewed are
-// validated against the viewed version's own TOC instead, so archived pages
-// do not judge their self-references by the database version. A spec that is
-// not in the database reports ok=false and is not validated.
+// against the database's version of each target spec, with the section-number
+// sets fetched lazily and cached for the request. References to the spec
+// being viewed are validated against the viewed version's own TOC instead, so
+// archived pages do not judge their self-references by the database version.
+// A spec that is not in the database — or whose lookup fails, which is logged
+// — reports ok=false and is not validated.
 func (h *handler) targetInfo(ctx context.Context, specID, version string, secNums map[string]bool) func(spec, section string) (bool, string, bool) {
 	type entry struct {
 		set     map[string]bool
@@ -618,13 +619,12 @@ func (h *handler) targetInfo(ctx context.Context, specID, version string, secNum
 		}
 		e, ok := cache[spec]
 		if !ok {
-			toc, err := h.db.GetTOC(ctx, spec, "")
-			if err == nil && len(toc) > 0 {
-				e.set = make(map[string]bool, len(toc))
-				for _, s := range toc {
-					e.set[s.Number] = true
-				}
-				e.version = toc[0].Version
+			set, ver, err := h.db.SectionNumbers(ctx, spec)
+			if err != nil {
+				log.Printf("cross-reference validation for %s: %v", spec, err)
+			} else if len(set) > 0 {
+				e.set = set
+				e.version = ver
 			}
 			cache[spec] = e
 		}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	htmlpkg "html"
@@ -350,8 +351,13 @@ func (h *handler) renderSpecPage(w http.ResponseWriter, r *http.Request, specID,
 	for _, s := range toc {
 		secNums[s.Number] = true
 	}
-	rendered := renderSections(sections, specID, urlVersion, bracketMap, func(number string) bool {
-		return secNums[number]
+	rendered := renderSections(sections, renderOpts{
+		specID:        specID,
+		version:       urlVersion,
+		display:       toc[0].Version,
+		bracketMap:    bracketMap,
+		sectionExists: func(number string) bool { return secNums[number] },
+		targetInfo:    h.targetInfo(r.Context(), specID, toc[0].Version, secNums),
 	})
 	prev, next := adjacentSections(toc, number)
 
@@ -581,17 +587,52 @@ func (h *handler) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 // Helper functions
 
-func renderSections(sections []db.Section, specID, version string, bracketMap map[string]string, sectionExists func(string) bool) []sectionRendered {
+func renderSections(sections []db.Section, o renderOpts) []sectionRendered {
 	rendered := make([]sectionRendered, len(sections))
 	for i, s := range sections {
 		rendered[i] = sectionRendered{
 			Number:  s.Number,
 			Title:   s.Title,
 			Level:   s.Level,
-			Content: template.HTML(renderMarkdown(s.Content, specID, version, bracketMap, sectionExists)), //nolint:gosec
+			Content: template.HTML(renderMarkdown(s.Content, o)), //nolint:gosec
 		}
 	}
 	return rendered
+}
+
+// targetInfo returns a per-request validator of cross-spec section references
+// against the database's version of each target spec, with the TOCs fetched
+// lazily and cached for the request. References to the spec being viewed are
+// validated against the viewed version's own TOC instead, so archived pages
+// do not judge their self-references by the database version. A spec that is
+// not in the database reports ok=false and is not validated.
+func (h *handler) targetInfo(ctx context.Context, specID, version string, secNums map[string]bool) func(spec, section string) (bool, string, bool) {
+	type entry struct {
+		set     map[string]bool
+		version string
+	}
+	cache := map[string]entry{}
+	return func(spec, section string) (bool, string, bool) {
+		if spec == specID {
+			return secNums[section], version, true
+		}
+		e, ok := cache[spec]
+		if !ok {
+			toc, err := h.db.GetTOC(ctx, spec, "")
+			if err == nil && len(toc) > 0 {
+				e.set = make(map[string]bool, len(toc))
+				for _, s := range toc {
+					e.set[s.Number] = true
+				}
+				e.version = toc[0].Version
+			}
+			cache[spec] = e
+		}
+		if e.set == nil {
+			return false, "", false
+		}
+		return e.set[section], e.version, true
+	}
 }
 
 func refURL(ref db.Reference) string {

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -174,10 +174,12 @@ func renderMarkdown(content string, o renderOpts) string {
 	return sanitizeHTML(out)
 }
 
-// tableOpenRE matches the start of a converter-emitted table region. The
-// boundary character keeps prose like "<tables" or "<tabletop" from opening
-// a region.
-var tableOpenRE = regexp.MustCompile(`<table[\s>]`)
+// tableOpenRE matches the start of a converter-emitted table region: the
+// converter emits each table as its own block, so a real opener sits at the
+// start of a line. The anchor and boundary character keep prose mentioning
+// "<table>" mid-sentence — or words like "<tabletop" — from opening a region
+// and letting the text up to a real table's closer bypass escaping.
+var tableOpenRE = regexp.MustCompile(`(?m)^<table[\s>]`)
 
 // escapeOutsideTables applies escapeUnknownHTML to text outside
 // <table>...</table> regions and passes table regions through verbatim.

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -174,31 +174,38 @@ func renderMarkdown(content string, o renderOpts) string {
 	return sanitizeHTML(out)
 }
 
+// tableOpenRE matches the start of a converter-emitted table region. The
+// boundary character keeps prose like "<tables" or "<tabletop" from opening
+// a region.
+var tableOpenRE = regexp.MustCompile(`<table[\s>]`)
+
 // escapeOutsideTables applies escapeUnknownHTML to text outside
 // <table>...</table> regions and passes table regions through verbatim.
 // Table markup is pipeline-generated — the DOCX converter's tags with cell
 // text already entity-escaped at build time, plus db.LinkifyRefs's raw
 // anchors — so escaping there would turn the anchors into visible text
-// (and did, before this function existed). sanitizeHTML still attribute-
-// sanitizes everything afterwards.
+// (and did, before this function existed). An opener with no closer is not
+// treated as a region: the rest is escaped normally, which keeps document
+// prose mentioning "<table>" from disabling escaping. sanitizeHTML still
+// attribute-sanitizes everything afterwards.
 func escapeOutsideTables(text string) string {
 	var b strings.Builder
 	for {
-		open := strings.Index(text, "<table")
-		if open < 0 {
+		loc := tableOpenRE.FindStringIndex(text)
+		if loc == nil {
 			if b.Len() == 0 {
 				return escapeUnknownHTML(text)
 			}
 			b.WriteString(escapeUnknownHTML(text))
 			return b.String()
 		}
-		b.WriteString(escapeUnknownHTML(text[:open]))
-		rest := text[open:]
+		rest := text[loc[0]:]
 		end := strings.Index(rest, "</table>")
 		if end < 0 {
-			b.WriteString(rest)
+			b.WriteString(escapeUnknownHTML(text))
 			return b.String()
 		}
+		b.WriteString(escapeUnknownHTML(text[:loc[0]]))
 		end += len("</table>")
 		b.WriteString(rest[:end])
 		text = rest[end:]

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -159,7 +159,7 @@ func renderMarkdown(content string, o renderOpts) string {
 			continue
 		}
 		text := protectMath(seg.text, token, &mathSpans)
-		sb.WriteString(escapeUnknownHTML(text))
+		sb.WriteString(escapeOutsideTables(text))
 	}
 	content = sb.String()
 
@@ -172,6 +172,37 @@ func renderMarkdown(content string, o renderOpts) string {
 		out = strings.Replace(out, mathPlaceholder(token, i), span, 1)
 	}
 	return sanitizeHTML(out)
+}
+
+// escapeOutsideTables applies escapeUnknownHTML to text outside
+// <table>...</table> regions and passes table regions through verbatim.
+// Table markup is pipeline-generated — the DOCX converter's tags with cell
+// text already entity-escaped at build time, plus db.LinkifyRefs's raw
+// anchors — so escaping there would turn the anchors into visible text
+// (and did, before this function existed). sanitizeHTML still attribute-
+// sanitizes everything afterwards.
+func escapeOutsideTables(text string) string {
+	var b strings.Builder
+	for {
+		open := strings.Index(text, "<table")
+		if open < 0 {
+			if b.Len() == 0 {
+				return escapeUnknownHTML(text)
+			}
+			b.WriteString(escapeUnknownHTML(text))
+			return b.String()
+		}
+		b.WriteString(escapeUnknownHTML(text[:open]))
+		rest := text[open:]
+		end := strings.Index(rest, "</table>")
+		if end < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		end += len("</table>")
+		b.WriteString(rest[:end])
+		text = rest[end:]
+	}
 }
 
 // randRead is cryptorand.Read, injectable so tests can exercise the

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -61,33 +61,57 @@ func init() {
 	)
 }
 
+// renderOpts configures renderMarkdown.
+type renderOpts struct {
+	specID  string
+	version string // version carried on same-spec URLs; empty on database-version pages
+	display string // displayed version of the current document, for unresolved-reference tooltips
+	// bracketMap maps bracket numbers to spec IDs; nil skips bracket refs.
+	bracketMap map[string]string
+	// sectionExists gates bare same-document references ("clause 4.2");
+	// nil skips them.
+	sectionExists func(string) bool
+	// targetInfo validates cross-spec section references; nil skips validation.
+	targetInfo func(spec, section string) (exists bool, version string, ok bool)
+}
+
 // renderMarkdown converts Markdown content to HTML, rewriting image:// URLs
-// and linkifying inline spec/RFC references. A non-empty version is carried
+// and linkifying inline spec/RFC references. A non-empty o.version is carried
 // on every image URL and every same-spec section link so an archived version
-// serves its own images and stays within itself when followed. sectionExists
-// gates bare same-document references ("clause 4.2"); pass nil to skip them.
-func renderMarkdown(content, specID, version string, bracketMap map[string]string, sectionExists func(string) bool) string {
+// serves its own images and stays within itself when followed.
+func renderMarkdown(content string, o renderOpts) string {
+	specID, version := o.specID, o.version
+	currentLabel := specID
+	if o.display != "" {
+		currentLabel += " v" + o.display
+	}
 	// Linkify spec references before image/figure rewrites to avoid processing HTML attributes.
-	content = db.LinkifyRefs(content, bracketMap, func(spec, section string) string {
-		if strings.HasPrefix(spec, "RFC ") {
-			u := "https://www.rfc-editor.org/rfc/rfc" + strings.TrimPrefix(spec, "RFC ")
+	content = db.LinkifyRefs(content, db.LinkifyRefsOpts{
+		BracketMap: o.bracketMap,
+		URLFor: func(spec, section string) string {
+			if strings.HasPrefix(spec, "RFC ") {
+				u := "https://www.rfc-editor.org/rfc/rfc" + strings.TrimPrefix(spec, "RFC ")
+				if section != "" {
+					u += "#section-" + section
+				}
+				return u
+			}
+			if spec == "" { // bare reference: the current spec
+				spec = specID
+			}
+			u := "/specs/" + url.PathEscape(spec)
 			if section != "" {
-				u += "#section-" + section
+				u += "/sections/" + section
+			}
+			if version != "" && spec == specID {
+				u += "?version=" + url.QueryEscape(version)
 			}
 			return u
-		}
-		if spec == "" { // bare reference: the current spec
-			spec = specID
-		}
-		u := "/specs/" + url.PathEscape(spec)
-		if section != "" {
-			u += "/sections/" + section
-		}
-		if version != "" && spec == specID {
-			u += "?version=" + url.QueryEscape(version)
-		}
-		return u
-	}, sectionExists)
+		},
+		SectionExists: o.sectionExists,
+		CurrentLabel:  currentLabel,
+		TargetInfo:    o.targetInfo,
+	})
 	escapedSpec := url.PathEscape(specID)
 	imageURL := func(name string) string {
 		src := "/specs/" + escapedSpec + "/images/" + url.PathEscape(name)

--- a/web/sanitize.go
+++ b/web/sanitize.go
@@ -47,6 +47,12 @@ func escapeUnknownHTML(text string) string {
 			return b.String()
 		}
 		b.WriteString(text[:i])
+		// LinkifyRefs markers never span lines, so marker state resets at
+		// every newline: a marker-shaped fragment in document prose cannot
+		// keep admitting stray closers for the rest of the document.
+		if strings.IndexByte(text[:i], '\n') >= 0 {
+			clear(open)
+		}
 		text = text[i:]
 		if m := markerOpenRE.FindStringSubmatch(text); m != nil {
 			open[m[1]]++

--- a/web/sanitize.go
+++ b/web/sanitize.go
@@ -9,14 +9,16 @@ import (
 
 // allowedTagRE matches an HTML tag the rendering pipeline legitimately
 // produces before goldmark runs: the DOCX converter's table markup and list
-// tags inside cells (converter/docx/table.go), <sub>/<sup> in body text, and
-// the image:// rewrite's <img>. db.LinkifyRefs emits Markdown links, not raw
-// anchors, so <a> is document text here. Any other angle bracket in body
-// text is document text too — 3GPP prose is full of placeholders like
-// <SUPI> — and must be escaped so it stays visible instead of being parsed
-// as markup.
+// tags inside cells (converter/docx/table.go), <sub>/<sup> in body text, the
+// image:// rewrite's <img>, and db.LinkifyRefs's unresolved-reference
+// markers — only the exact <span class="ref-unresolved" ...> form, so a
+// literal <span> in document prose still escapes to visible text.
+// db.LinkifyRefs emits Markdown links, not raw anchors, so <a> is document
+// text here. Any other angle bracket in body text is document text too —
+// 3GPP prose is full of placeholders like <SUPI> — and must be escaped so it
+// stays visible instead of being parsed as markup.
 var allowedTagRE = regexp.MustCompile(
-	`(?i)^</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>`)
+	`(?i)^(?:</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>|<span class="ref-unresolved"[^<>]*>|</span>)`)
 
 // escapeUnknownHTML escapes every '<' in text that does not start a tag the
 // pipeline itself emits, so third-party document content cannot inject raw
@@ -69,6 +71,9 @@ func newSanitizePolicy() *bluemonday.Policy {
 	// KaTeX math targets.
 	p.AllowElements("strong", "em", "del", "sub", "sup", "span", "pre", "code")
 	p.AllowAttrs("class").Matching(regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)).OnElements("span", "pre", "code")
+	// Unresolved-reference markers (db.LinkifyRefs) carry their explanation
+	// in a title tooltip.
+	p.AllowAttrs("title").OnElements("span")
 	// Links: the pipeline only produces site-relative anchors
 	// (db.LinkifyRefs spec links) and https://www.rfc-editor.org RFC links.
 	// The pattern rejects protocol-relative //host and every other absolute

--- a/web/sanitize.go
+++ b/web/sanitize.go
@@ -9,16 +9,25 @@ import (
 
 // allowedTagRE matches an HTML tag the rendering pipeline legitimately
 // produces before goldmark runs: the DOCX converter's table markup and list
-// tags inside cells (converter/docx/table.go), <sub>/<sup> in body text, the
-// image:// rewrite's <img>, and db.LinkifyRefs's unresolved-reference
-// markers — only the exact <span class="ref-unresolved" ...> form, so a
-// literal <span> in document prose still escapes to visible text.
-// db.LinkifyRefs emits Markdown links, not raw anchors, so <a> is document
-// text here. Any other angle bracket in body text is document text too —
-// 3GPP prose is full of placeholders like <SUPI> — and must be escaped so it
-// stays visible instead of being parsed as markup.
+// tags inside cells (converter/docx/table.go), <sub>/<sup> in body text, and
+// the image:// rewrite's <img>. db.LinkifyRefs emits Markdown links in body
+// text; its raw markup — table anchors and unresolved-reference markers —
+// is handled separately (markerOpenRE/markerCloseRE and the table-region
+// skip in renderMarkdown). Any other angle bracket in body text is document
+// text — 3GPP prose is full of placeholders like <SUPI> — and must be
+// escaped so it stays visible instead of being parsed as markup.
 var allowedTagRE = regexp.MustCompile(
-	`(?i)^(?:</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>|<span class="ref-unresolved"[^<>]*>|</span>)`)
+	`(?i)^</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>`)
+
+// markerOpenRE and markerCloseRE match db.LinkifyRefs's unresolved-reference
+// markers in body text — only the exact class="ref-unresolved" form, so a
+// literal <span> or <a> in document prose still escapes to visible text.
+// Closers are only admitted while a marker is open (see escapeUnknownHTML),
+// so a stray literal </span> in prose stays visible too.
+var (
+	markerOpenRE  = regexp.MustCompile(`^<(span|a) class="ref-unresolved"[^<>]*>`)
+	markerCloseRE = regexp.MustCompile(`^</(span|a)>`)
+)
 
 // escapeUnknownHTML escapes every '<' in text that does not start a tag the
 // pipeline itself emits, so third-party document content cannot inject raw
@@ -27,6 +36,7 @@ var allowedTagRE = regexp.MustCompile(
 // sanitizeHTML.
 func escapeUnknownHTML(text string) string {
 	var b strings.Builder
+	open := map[string]int{}
 	for {
 		i := strings.IndexByte(text, '<')
 		if i < 0 {
@@ -38,6 +48,18 @@ func escapeUnknownHTML(text string) string {
 		}
 		b.WriteString(text[:i])
 		text = text[i:]
+		if m := markerOpenRE.FindStringSubmatch(text); m != nil {
+			open[m[1]]++
+			b.WriteString(m[0])
+			text = text[len(m[0]):]
+			continue
+		}
+		if m := markerCloseRE.FindStringSubmatch(text); m != nil && open[m[1]] > 0 {
+			open[m[1]]--
+			b.WriteString(m[0])
+			text = text[len(m[0]):]
+			continue
+		}
 		if loc := allowedTagRE.FindStringIndex(text); loc != nil {
 			b.WriteString(text[:loc[1]])
 			text = text[loc[1]:]
@@ -83,6 +105,8 @@ func newSanitizePolicy() *bluemonday.Policy {
 		`^(?:#.*|/(?:[^/\\].*)?|https://www\.rfc-editor\.org/.*)$`)).OnElements("a")
 	p.AllowAttrs("rel").Matching(regexp.MustCompile(`^[a-z ]+$`)).OnElements("a")
 	p.AllowAttrs("title").OnElements("a")
+	// Unresolved-reference anchors (db.LinkifyRefs) carry the marker class.
+	p.AllowAttrs("class").Matching(regexp.MustCompile(`^ref-unresolved$`)).OnElements("a")
 	// Images: only the site-relative URLs the image:// rewrite produces
 	// (reject protocol-relative //host and any absolute URL).
 	p.AllowAttrs("src").Matching(regexp.MustCompile(`^/[^/\\]`)).OnElements("img")

--- a/web/siplexer_test.go
+++ b/web/siplexer_test.go
@@ -113,7 +113,7 @@ func TestRenderMarkdownHighlightsSIPAndSDP(t *testing.T) {
 		{"```sip\nINVITE sip:bob@example.net SIP/2.0\nVia: SIP/2.0/UDP pc33.example.com\n```", ">INVITE</span>"},
 		{"```sdp\nv=0\no=- 4567 1234 IN IP4 1.1.1.1\n```", ">v</span>"},
 	} {
-		got := renderMarkdown(tt.content, "TS 24.228", "", nil, nil)
+		got := renderMarkdown(tt.content, renderOpts{specID: "TS 24.228"})
 		if !strings.Contains(got, "chroma") {
 			t.Errorf("renderMarkdown(%q) = %q, want chroma-highlighted output", tt.content, got)
 		}

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1681,14 +1681,10 @@ body:has(dialog.lightbox[open]) {
 /* === Unresolved references === */
 /* Reference text whose target section does not exist in the stored version:
    bare same-document refs get a marker span, cross-spec refs keep a link to
-   the spec top and carry an explanatory title tooltip. */
+   the spec top. Both carry an explanatory title tooltip and share this
+   class. */
 .ref-unresolved {
     text-decoration: underline dashed var(--danger);
     text-underline-offset: 3px;
     cursor: help;
-}
-
-.section-body a[title] {
-    text-decoration: underline dashed;
-    text-underline-offset: 3px;
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1677,3 +1677,18 @@ body:has(dialog.lightbox[open]) {
     cursor: pointer;
     white-space: nowrap;
 }
+
+/* === Unresolved references === */
+/* Reference text whose target section does not exist in the stored version:
+   bare same-document refs get a marker span, cross-spec refs keep a link to
+   the spec top and carry an explanatory title tooltip. */
+.ref-unresolved {
+    text-decoration: underline dashed var(--danger);
+    text-underline-offset: 3px;
+    cursor: help;
+}
+
+.section-body a[title] {
+    text-decoration: underline dashed;
+    text-underline-offset: 3px;
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -2128,3 +2128,31 @@ func TestRenderMarkdown_LiteralSpanCloserEscaped(t *testing.T) {
 		t.Errorf("stray </span> in prose must stay visible text, got:\n%s", got)
 	}
 }
+
+// TestEscapeOutsideTables pins the table-region boundary conditions: a
+// word-prefix lookalike or an unclosed opener must not disable escaping.
+func TestEscapeOutsideTables(t *testing.T) {
+	t.Run("prose word starting with table does not open a region", func(t *testing.T) {
+		got := renderMarkdown("a <tablet> device and a <SUPI> placeholder", renderOpts{specID: "TS 23.501"})
+		if !strings.Contains(got, "&lt;tablet&gt;") || !strings.Contains(got, "&lt;SUPI&gt;") {
+			t.Errorf("placeholders must stay visible text, got:\n%s", got)
+		}
+	})
+
+	t.Run("unclosed table opener does not disable escaping", func(t *testing.T) {
+		got := renderMarkdown("mentioning <table> without closing it, then <SUPI>", renderOpts{specID: "TS 23.501"})
+		if !strings.Contains(got, "&lt;SUPI&gt;") {
+			t.Errorf("placeholder after unclosed <table> must stay visible text, got:\n%s", got)
+		}
+	})
+}
+
+// A marker-shaped fragment in document prose must not admit stray closers on
+// later lines: marker state resets at newlines.
+func TestEscapeUnknownHTML_MarkerStateResetsAtNewline(t *testing.T) {
+	in := "forged <span class=\"ref-unresolved\" title=\"x\">text\nnext line literal </span> here"
+	got := escapeUnknownHTML(in)
+	if !strings.Contains(got, "&lt;/span>") {
+		t.Errorf("stray closer on a later line must be escaped, got:\n%s", got)
+	}
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -74,7 +74,7 @@ func TestRenderMarkdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderMarkdown(tt.content, tt.specID, "", nil, nil)
+			result := renderMarkdown(tt.content, renderOpts{specID: tt.specID})
 			if !strings.Contains(result, tt.want) {
 				t.Errorf("renderMarkdown() = %q, want to contain %q", result, tt.want)
 			}
@@ -88,7 +88,7 @@ func TestRenderMarkdown(t *testing.T) {
 func TestRenderMarkdown_MathProtected(t *testing.T) {
 	t.Run("paragraph matrix keeps backslashes", func(t *testing.T) {
 		content := `$\begin{matrix} 1 & j \\ -1 & j \end{matrix}$`
-		got := renderMarkdown(content, "TS 38.211", "", nil, nil)
+		got := renderMarkdown(content, renderOpts{specID: "TS 38.211"})
 		want := `<span class="math-inline">\begin{matrix} 1 &amp; j \\ -1 &amp; j \end{matrix}</span>`
 		if !strings.Contains(got, want) {
 			t.Errorf("math not protected, got:\n%s", got)
@@ -98,7 +98,7 @@ func TestRenderMarkdown_MathProtected(t *testing.T) {
 	t.Run("pre-escaped table-cell math normalizes ampersand", func(t *testing.T) {
 		// Table HTML from the docx converter has already HTML-escaped & → &amp;.
 		content := `<table><tbody><tr><td>$1 &amp; 2$</td></tr></tbody></table>`
-		got := renderMarkdown(content, "TS 38.211", "", nil, nil)
+		got := renderMarkdown(content, renderOpts{specID: "TS 38.211"})
 		// The span's inner HTML must be single-escaped so textContent is "1 & 2".
 		want := `<span class="math-inline">1 &amp; 2</span>`
 		if !strings.Contains(got, want) {
@@ -116,7 +116,7 @@ func TestRenderMarkdown_MathProtected(t *testing.T) {
 func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 	t.Run("fenced block keeps dollars", func(t *testing.T) {
 		content := "```asn1\nprice ::= $100 and $200\n```\n"
-		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+		got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 		// Chroma may tokenize around the dollars, so assert on the characters
 		// rather than the contiguous string.
 		if strings.Count(got, "$") != 2 {
@@ -133,7 +133,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 
 	t.Run("inline code keeps dollars, surrounding math still works", func(t *testing.T) {
 		content := "Set `$PATH` and `$HOME` first; the value $x^2$ is math."
-		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+		got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 		if !strings.Contains(got, "<code>$PATH</code>") || !strings.Contains(got, "<code>$HOME</code>") {
 			t.Errorf("inline code must keep its dollars, got:\n%s", got)
 		}
@@ -144,7 +144,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 
 	t.Run("angle brackets in code stay code", func(t *testing.T) {
 		content := "```\na <SUPI> in code\n```\n\nand `<NSSAI>` inline."
-		got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+		got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 		if !strings.Contains(got, "&lt;SUPI&gt;") {
 			t.Errorf("code block angle brackets must be goldmark-escaped, got:\n%s", got)
 		}
@@ -163,7 +163,7 @@ func TestRenderMarkdown_MathSkipsCode(t *testing.T) {
 // substituted.
 func TestRenderMarkdown_PlaceholderLiteralUntouched(t *testing.T) {
 	content := "Literal token xxkatexmathxx0xxkatexmathxx in prose.\n\nAnd math $a+b$ after it."
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, "xxkatexmathxx0xxkatexmathxx") {
 		t.Errorf("literal placeholder-lookalike text must survive verbatim, got:\n%s", got)
 	}
@@ -864,7 +864,7 @@ func TestIsExternalRef(t *testing.T) {
 // text flows through htmlpkg.EscapeString before reaching the template.
 func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
 	content := `![alt"onload=x("y")](image://fig.png?w=600&h=400)`
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if strings.Contains(got, `alt"onload`) {
 		t.Errorf("alt text should be HTML-escaped, got:\n%s", got)
 	}
@@ -879,7 +879,7 @@ func TestRenderMarkdown_ImageAltEscaped(t *testing.T) {
 // must reach the browser as visible text, never as markup.
 func TestRenderMarkdown_RawHTMLEscaped(t *testing.T) {
 	content := "Inline <b>bold</b> and <script>alert(1)</script> here."
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if strings.Contains(got, "<script>") {
 		t.Errorf("raw <script> must not pass through, got:\n%s", got)
 	}
@@ -899,7 +899,7 @@ func TestRenderMarkdown_RawHTMLEscaped(t *testing.T) {
 // must stay visible as text.
 func TestRenderMarkdown_AngleBracketPlaceholderVisible(t *testing.T) {
 	content := "The identifier <SUPI> is used here."
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, "&lt;SUPI&gt;") {
 		t.Errorf("expected <SUPI> to survive as escaped text, got:\n%s", got)
 	}
@@ -913,7 +913,7 @@ func TestRenderMarkdown_AngleBracketPlaceholderVisible(t *testing.T) {
 // through attributes or a non-relative src.
 func TestRenderMarkdown_EventHandlerStripped(t *testing.T) {
 	content := `Before <img src=x onerror=alert(1)> after, and <a href="javascript:alert(2)">link</a>.`
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if strings.Contains(got, "onerror") {
 		t.Errorf("event handler attribute must be stripped, got:\n%s", got)
 	}
@@ -934,7 +934,7 @@ func TestRenderMarkdown_ExternalHrefStripped(t *testing.T) {
 	content := `<a href="https://evil.example/p">x</a> <a href="//evil.example/p">y</a> ` +
 		`<a href="http://evil.example/p">z</a> ` +
 		"See RFC 3748 and TS 23.501 for details."
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if strings.Contains(got, `href="https://evil`) || strings.Contains(got, `href="//`) ||
 		strings.Contains(got, `href="http://`) {
 		t.Errorf("no anchor may carry an external href, got:\n%s", got)
@@ -1060,7 +1060,7 @@ func TestNewMathToken_RandFailure(t *testing.T) {
 	if a == b {
 		t.Errorf("fallback tokens must be unique, got %q twice", a)
 	}
-	got := renderMarkdown("Inline $x_1$ math.", "TS 23.501", "", nil, nil)
+	got := renderMarkdown("Inline $x_1$ math.", renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, "katex-math") && !strings.Contains(got, "math") {
 		t.Errorf("math must still render under the fallback token, got:\n%s", got)
 	}
@@ -1071,7 +1071,7 @@ func TestNewMathToken_RandFailure(t *testing.T) {
 
 // TestRenderMarkdown_UnknownLanguageFence pins the chroma fallback lexer path.
 func TestRenderMarkdown_UnknownLanguageFence(t *testing.T) {
-	got := renderMarkdown("```zzznotalanguage\nplain <text>\n```\n", "TS 23.501", "", nil, nil)
+	got := renderMarkdown("```zzznotalanguage\nplain <text>\n```\n", renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, "plain") {
 		t.Errorf("unknown-language fence must still render its content, got:\n%s", got)
 	}
@@ -1086,7 +1086,7 @@ func TestRenderMarkdown_UnknownLanguageFence(t *testing.T) {
 func TestRenderMarkdown_TableMarkupSurvivesSanitizer(t *testing.T) {
 	content := `<table><thead><tr><th colspan="2">Head</th></tr></thead>` +
 		`<tbody><tr><td rowspan="2">A</td><td><img src="image://fig.png?w=200&h=100" alt="diag" width="200" height="100"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, `colspan="2"`) {
 		t.Errorf("expected colspan to survive, got:\n%s", got)
 	}
@@ -1104,7 +1104,7 @@ func TestRenderMarkdown_TableMarkupSurvivesSanitizer(t *testing.T) {
 // correctly in the web viewer.
 func TestRenderMarkdown_SubSupPassthrough(t *testing.T) {
 	content := "n_78<sup>1</sup> and H<sub>2</sub>O"
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, "<sup>1</sup>") {
 		t.Errorf("expected <sup> to pass through, got:\n%s", got)
 	}
@@ -1118,7 +1118,7 @@ func TestRenderMarkdown_SubSupPassthrough(t *testing.T) {
 // converter) are rewritten to a real /specs/<id>/images/<name> URL.
 func TestRenderMarkdown_HTMLImageRewrite(t *testing.T) {
 	content := `<table><tbody><tr><td><img src="image://fig.png?w=200&h=100" alt="diag" width="200" height="100"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 	if !strings.Contains(got, `src="/specs/TS%2023.501/images/fig.png"`) {
 		t.Errorf("expected image:// to be rewritten to spec-relative URL, got:\n%s", got)
 	}
@@ -1137,7 +1137,7 @@ func TestRenderMarkdown_HTMLImageRewrite(t *testing.T) {
 // the served attribute has to round-trip back to the stored basename.
 func TestRenderMarkdown_HTMLImageRewriteSpecialChars(t *testing.T) {
 	content := `<table><tbody><tr><td><img src="image://Figure A&B's diagram.png?w=200&h=100" alt="diag"></td></tr></tbody></table>`
-	got := renderMarkdown(content, "TS 23.501", "", nil, nil)
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
 
 	const want = "Figure A&B's diagram.png"
 	prefix := `src="/specs/TS%2023.501/images/`
@@ -2002,44 +2002,105 @@ func TestRenderMarkdown_BareClauseRefs(t *testing.T) {
 	exists := func(section string) bool { return section == "4.2" }
 
 	t.Run("bare clause links within the current spec", func(t *testing.T) {
-		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "", nil, exists)
+		got := renderMarkdown("See clause 4.2 for details.", renderOpts{specID: "TS 23.501", sectionExists: exists})
 		if want := `<a href="/specs/TS%2023.501/sections/4.2">clause 4.2</a>`; !strings.Contains(got, want) {
 			t.Errorf("expected %s, got:\n%s", want, got)
 		}
 	})
 
 	t.Run("bare clause carries the version on archived pages", func(t *testing.T) {
-		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "18.5.0", nil, exists)
+		got := renderMarkdown("See clause 4.2 for details.", renderOpts{specID: "TS 23.501", version: "18.5.0", sectionExists: exists})
 		if want := `<a href="/specs/TS%2023.501/sections/4.2?version=18.5.0">clause 4.2</a>`; !strings.Contains(got, want) {
 			t.Errorf("expected %s, got:\n%s", want, got)
 		}
 	})
 
 	t.Run("qualified same-spec ref carries the version too", func(t *testing.T) {
-		got := renderMarkdown("See TS 23.501 clause 5.1 for details.", "TS 23.501", "18.5.0", nil, exists)
+		got := renderMarkdown("See TS 23.501 clause 5.1 for details.", renderOpts{specID: "TS 23.501", version: "18.5.0", sectionExists: exists})
 		if want := `<a href="/specs/TS%2023.501/sections/5.1?version=18.5.0">TS 23.501 clause 5.1</a>`; !strings.Contains(got, want) {
 			t.Errorf("expected %s, got:\n%s", want, got)
 		}
 	})
 
 	t.Run("qualified other-spec ref stays canonical", func(t *testing.T) {
-		got := renderMarkdown("See TS 23.502 clause 4.3 for details.", "TS 23.501", "18.5.0", nil, exists)
+		got := renderMarkdown("See TS 23.502 clause 4.3 for details.", renderOpts{specID: "TS 23.501", version: "18.5.0", sectionExists: exists})
 		if want := `<a href="/specs/TS%2023.502/sections/4.3">TS 23.502 clause 4.3</a>`; !strings.Contains(got, want) {
 			t.Errorf("expected %s, got:\n%s", want, got)
 		}
 	})
 
 	t.Run("nonexistent section stays plain", func(t *testing.T) {
-		got := renderMarkdown("See clause 9.9 for details.", "TS 23.501", "", nil, exists)
+		got := renderMarkdown("See clause 9.9 for details.", renderOpts{specID: "TS 23.501", sectionExists: exists})
 		if strings.Contains(got, `href="/specs/TS%2023.501/sections/9.9"`) {
 			t.Errorf("nonexistent section must not link, got:\n%s", got)
 		}
 	})
 
 	t.Run("nil sectionExists disables bare linking", func(t *testing.T) {
-		got := renderMarkdown("See clause 4.2 for details.", "TS 23.501", "", nil, nil)
+		got := renderMarkdown("See clause 4.2 for details.", renderOpts{specID: "TS 23.501"})
 		if strings.Contains(got, `href="/specs/TS%2023.501/sections/4.2"`) {
 			t.Errorf("bare ref must not link with nil sectionExists, got:\n%s", got)
+		}
+	})
+}
+
+// TestRenderMarkdown_UnresolvedRefs verifies unresolved-reference markers and
+// tooltips survive the full pipeline: escapeUnknownHTML keeps the marker
+// span, goldmark passes it through, and the sanitizer keeps class and title.
+func TestRenderMarkdown_UnresolvedRefs(t *testing.T) {
+	exists := func(section string) bool { return section == "4.2" }
+	targetInfo := func(spec, section string) (bool, string, bool) {
+		if spec == "TS 23.502" {
+			return section == "4.12.2", "20.2.0", true
+		}
+		return false, "", false
+	}
+
+	t.Run("bare unresolved ref renders marker span", func(t *testing.T) {
+		got := renderMarkdown("See clause 9.9 for details.", renderOpts{specID: "TS 23.501", display: "20.2.0", sectionExists: exists})
+		want := `<span class="ref-unresolved" title="Section 9.9 does not exist in TS 23.501 v20.2.0 — possibly a stale or incorrect reference in the source text">clause 9.9</span>`
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("bare unresolved ref in table renders marker span", func(t *testing.T) {
+		got := renderMarkdown("<table><tr><td>see clause 9.9</td></tr></table>", renderOpts{specID: "TS 23.501", sectionExists: exists})
+		want := `<span class="ref-unresolved" title="Section 9.9 does not exist in TS 23.501 — possibly a stale or incorrect reference in the source text">clause 9.9</span>`
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("cross-spec unresolved ref links to spec top with tooltip", func(t *testing.T) {
+		got := renderMarkdown("See TS 23.502 clause 4.12.2a.", renderOpts{specID: "TS 23.501", targetInfo: targetInfo})
+		if !strings.Contains(got, `href="/specs/TS%2023.502"`) {
+			t.Errorf("expected spec-top link, got:\n%s", got)
+		}
+		if !strings.Contains(got, `title="Section 4.12.2a does not exist in TS 23.502 v20.2.0`) {
+			t.Errorf("expected explanatory title, got:\n%s", got)
+		}
+		if strings.Contains(got, "/sections/4.12.2a") {
+			t.Errorf("must not link to the missing section, got:\n%s", got)
+		}
+	})
+
+	t.Run("cross-spec resolved ref keeps section link", func(t *testing.T) {
+		got := renderMarkdown("See TS 23.502 clause 4.12.2.", renderOpts{specID: "TS 23.501", targetInfo: targetInfo})
+		want := `<a href="/specs/TS%2023.502/sections/4.12.2">TS 23.502 clause 4.12.2</a>`
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s, got:\n%s", want, got)
+		}
+	})
+
+	t.Run("literal span in document text is escaped", func(t *testing.T) {
+		got := renderMarkdown("a literal <span> placeholder", renderOpts{specID: "TS 23.501"})
+		if !strings.Contains(got, "&lt;span&gt;") {
+			t.Errorf("bare <span> in prose must stay visible text, got:\n%s", got)
+		}
+		got = renderMarkdown(`a <span class="x"> placeholder`, renderOpts{specID: "TS 23.501"})
+		if !strings.Contains(got, "&lt;span") {
+			t.Errorf("non-marker <span class> in prose must stay visible text, got:\n%s", got)
 		}
 	})
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -2104,3 +2104,27 @@ func TestRenderMarkdown_UnresolvedRefs(t *testing.T) {
 		}
 	})
 }
+
+// TestRenderMarkdown_TableAnchors pins the fix for table-cell reference
+// links: escapeUnknownHTML must not escape db.LinkifyRefs's raw anchors
+// inside <table> regions (they previously rendered as literal
+// "&lt;a href=...&gt;" text).
+func TestRenderMarkdown_TableAnchors(t *testing.T) {
+	got := renderMarkdown("<table><tr><td>TS 23.501 clause 5.1</td></tr></table>", renderOpts{specID: "TS 23.502"})
+	want := `<a href="/specs/TS%2023.501/sections/5.1">TS 23.501 clause 5.1</a>`
+	if !strings.Contains(got, want) {
+		t.Errorf("expected %s, got:\n%s", want, got)
+	}
+	if strings.Contains(got, "&lt;a href") {
+		t.Errorf("table anchor must not be escaped to text, got:\n%s", got)
+	}
+}
+
+// A literal closing </span> in prose, with no marker open, must stay
+// visible text rather than vanishing as a stray closing tag.
+func TestRenderMarkdown_LiteralSpanCloserEscaped(t *testing.T) {
+	got := renderMarkdown("a literal </span> closer", renderOpts{specID: "TS 23.501"})
+	if !strings.Contains(got, "&lt;/span&gt;") {
+		t.Errorf("stray </span> in prose must stay visible text, got:\n%s", got)
+	}
+}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -2156,3 +2156,16 @@ func TestEscapeUnknownHTML_MarkerStateResetsAtNewline(t *testing.T) {
 		t.Errorf("stray closer on a later line must be escaped, got:\n%s", got)
 	}
 }
+
+// Prose mentioning a literal <table> before a real table must not open a
+// region early: everything up to the real table stays escaped.
+func TestEscapeOutsideTables_ProseMentionBeforeRealTable(t *testing.T) {
+	content := "prose mentions <table> and <SUPI> here\n\n<table><tr><td>TS 23.501 clause 5.1</td></tr></table>"
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.502"})
+	if !strings.Contains(got, "&lt;SUPI&gt;") {
+		t.Errorf("prose before the real table must stay escaped, got:\n%s", got)
+	}
+	if want := `<a href="/specs/TS%2023.501/sections/5.1">TS 23.501 clause 5.1</a>`; !strings.Contains(got, want) {
+		t.Errorf("the real table must keep its anchor, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

References whose target section does not exist in the stored version are now visibly marked instead of silently unlinked or dead-linked, so readers can tell a viewer limitation from an error or version skew in the source text.

- **Bare same-document refs** (e.g. TS 23.501 §4.2.8.0's "clause 4.2.8.2.4", which does not exist in v20.2.0): rendered as `<span class="ref-unresolved">` with a dashed underline and a tooltip ("Section … does not exist in TS 23.501 v20.2.0 — possibly a stale or incorrect reference in the source text").
- **Cross-spec refs** are now validated against the database's version of the target spec (light `SectionNumbers` query, cached per request). A missing section (e.g. "clause 4.12.2a of TS 23.502", renumbered to 4.12a.2 between v20.0.0 and v20.2.0) links to the spec's top page as `<a class="ref-unresolved">` with a tooltip noting the likely version mismatch — no more dead 404 links. Specs not in the database are not validated; RFC refs are never validated. On archived pages, self-references validate against the viewed version's own TOC.
- **Coordinated lists with repeated keywords** ("clause 4.12.2 and in clause 4.12.2a of TS 23.502") are now recognized as qualified references: every element links to the named spec, each validated individually. Plural keywords, prepositions and bare-number continuations are supported; a preposition requires a following keyword so "in 2024" is never read as a section.

## Bug fix

Table-cell reference links were rendering as literal `&lt;a href=…&gt;` text (visible on production, e.g. TS 23.501 §5.7.4): `escapeUnknownHTML` escaped the raw anchors `db.LinkifyRefs` emits inside tables. Escaping is now skipped inside `<table>` regions — cell text is already entity-escaped by the converter at build time, and `sanitizeHTML` still attribute-sanitizes everything.

## Safety

- Only the exact `<span|a class="ref-unresolved" …>` marker form passes `escapeUnknownHTML`; literal `<span>`, `<SUPI>` etc. in prose still escape to visible text. Marker closers are admitted statefully (per line), and markers fold matched newlines so they never span lines.
- Table regions require a line-anchored opener and a matching closer; prose mentioning `<table>` cannot open an unescaped window.
- `LinkifyRefs` now takes an options struct; nil `SectionExists`/`TargetInfo` reproduce the previous behavior (MCP tool output unchanged), nil `URLFor` is a no-op.
- No DB schema change or rebuild; `ExtractReferences`/`spec_references` untouched.

## Testing

- New table-driven db tests: unresolved markers (bare/plural/table/label), cross-spec validation (existing/missing/unvalidatable/bracket/multi/coordinated/RFC), preposition-keyword rule, newline folding, nil-option guards.
- New web tests: marker and tooltip survival through goldmark + sanitizer, table anchors unescaped (regression), literal `<span>`/`</span>`/`<tablet>`/unclosed `<table>` all staying visible text, `?version=` behavior unchanged.
- `go test -short ./...`, `gofmt`, `go vet` pass. Reviewed with open-code-review (3 rounds); all confirmed findings fixed with regression tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeQzirA3Kr2xxULRBbioAo)_