### PR TITLE
fix(tools): prevent integer overflow in paginateText

### DIFF
--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -82,9 +82,14 @@ func paginateText(content string, offset, maxLines, maxChars int) *mcp.CallToolR
 		return textResult(fmt.Sprintf("[No content at offset %d. Total lines: %d]", offset, totalLines))
 	}
 
-	end := offset + maxLines
-	if end > totalLines {
-		end = totalLines
+	// offset+maxLines can overflow int when maxLines is attacker-controlled
+	// (e.g. math.MaxInt64), wrapping negative and panicking on lines[i]
+	// below. offset < totalLines is already established above, so
+	// totalLines-offset cannot overflow; compare against it instead of
+	// adding offset+maxLines directly.
+	end := totalLines
+	if maxLines < totalLines-offset {
+		end = offset + maxLines
 	}
 
 	if maxChars > 0 {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -576,6 +577,26 @@ func TestPaginateText(t *testing.T) {
 		text := getTextContent(result)
 		if !strings.Contains(text, "[Lines 1-2 of 3]") {
 			t.Errorf("expected 2 lines within a 12-character budget, got: %s", text)
+		}
+	})
+
+	t.Run("does not panic on overflowing max_lines", func(t *testing.T) {
+		// offset+maxLines must not be computed directly: with
+		// maxLines=math.MaxInt64 the sum wraps negative and lines[i] below
+		// panics (issue #128). Any non-zero offset reproduces it.
+		result := paginateText(content, 1, math.MaxInt64, 0)
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 2-5 of 5]") {
+			t.Errorf("expected pagination header, got: %s", text)
+		}
+	})
+
+	t.Run("does not panic on overflowing max_lines with max_chars", func(t *testing.T) {
+		// Same overflow risk with the max_chars branch active.
+		result := paginateText(content, 1, math.MaxInt64, math.MaxInt64)
+		text := getTextContent(result)
+		if !strings.Contains(text, "[Lines 2-5 of 5]") {
+			t.Errorf("expected pagination header, got: %s", text)
 		}
 	})
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -582,9 +582,9 @@ func TestPaginateText(t *testing.T) {
 
 	t.Run("does not panic on overflowing max_lines", func(t *testing.T) {
 		// offset+maxLines must not be computed directly: with
-		// maxLines=math.MaxInt64 the sum wraps negative and lines[i] below
+		// maxLines=math.MaxInt the sum wraps negative and lines[i] below
 		// panics (issue #128). Any non-zero offset reproduces it.
-		result := paginateText(content, 1, math.MaxInt64, 0)
+		result := paginateText(content, 1, math.MaxInt, 0)
 		text := getTextContent(result)
 		if !strings.Contains(text, "[Lines 2-5 of 5]") {
 			t.Errorf("expected pagination header, got: %s", text)
@@ -593,7 +593,7 @@ func TestPaginateText(t *testing.T) {
 
 	t.Run("does not panic on overflowing max_lines with max_chars", func(t *testing.T) {
 		// Same overflow risk with the max_chars branch active.
-		result := paginateText(content, 1, math.MaxInt64, math.MaxInt64)
+		result := paginateText(content, 1, math.MaxInt, math.MaxInt)
 		text := getTextContent(result)
 		if !strings.Contains(text, "[Lines 2-5 of 5]") {
 			t.Errorf("expected pagination header, got: %s", text)


### PR DESCRIPTION
Fix an integer overflow in `paginateText` where `offset + maxLines` could wrap negative for large `max_lines` values, causing an index-out-of-range panic that crashes the MCP server. Reachable via `get_section`, `compare_versions`, and `get_openapi` with unvalidated input.

The end-of-window calculation now compares `maxLines` against `totalLines - offset` instead of adding `offset + maxLines` directly, avoiding the overflow.

Fixes #128

Verification:
- Added regression tests covering `offset=1, max_lines=math.MaxInt64` (with and without `max_chars` set), matching existing `paginateText` test conventions
- `gofmt -l .` clean, `go vet ./...` clean, `go test -short ./...` all pass
- `ocr review` (opencode-go/deepseek-v4-flash) against the diff: 0 findings, no warnings