### PR TITLE
fix(tools): error reporting fixes for list_versions, images, compare_versions

### DIFF
--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -60,7 +60,7 @@ func compareStructure(ctx context.Context, src *Source, input CompareVersionsInp
 		}
 		return r
 	}
-	if r := checkComparable(ctx, src, input.SpecID, oldSecs, newSecs, oldRes, newRes); r != nil {
+	if r := checkComparable(ctx, src, input.SpecID, "", oldSecs, newSecs, oldRes, newRes); r != nil {
 		return r
 	}
 
@@ -121,7 +121,7 @@ func compareSection(ctx context.Context, src *Source, input CompareVersionsInput
 		}
 		return r
 	}
-	if r := checkComparable(ctx, src, input.SpecID, oldSecs, newSecs, oldRes, newRes); r != nil {
+	if r := checkComparable(ctx, src, input.SpecID, input.SectionNumber, oldSecs, newSecs, oldRes, newRes); r != nil {
 		return r
 	}
 
@@ -188,10 +188,19 @@ func familyPartsHint(ctx context.Context, src *Source, specID string, oldErr, ne
 	return nil
 }
 
-func checkComparable(ctx context.Context, src *Source, specID string, oldSecs, newSecs []db.Section, oldRes, newRes Resolution) *mcp.CallToolResult {
+func checkComparable(ctx context.Context, src *Source, specID, sectionNumber string, oldSecs, newSecs []db.Section, oldRes, newRes Resolution) *mcp.CallToolResult {
 	if len(oldSecs) == 0 && len(newSecs) == 0 {
 		if parts, err := src.DB.FindSpecIDsByFamily(ctx, specID); err == nil && len(parts) > 0 {
 			return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", specID, strings.Join(parts, ", ")))
+		}
+		if sectionNumber != "" {
+			// Both sides came back empty because the requested section does
+			// not exist in either version, not because the spec itself
+			// failed to resolve — say so, rather than implying the whole
+			// specification is empty.
+			return errorResult(fmt.Sprintf(
+				"Section %s does not exist in %s in either version. Section numbers move between releases — run compare_versions without section_number, or get_toc, to locate it.",
+				sectionNumber, specID))
 		}
 		return errorResult(fmt.Sprintf("no sections found for %s in either version", specID))
 	}

--- a/tools/compare_versions_test.go
+++ b/tools/compare_versions_test.go
@@ -191,6 +191,36 @@ func TestCompareVersionsSectionMissingOnOneSide(t *testing.T) {
 	}
 }
 
+// TestCompareVersionsSectionMissingInBoth checks that comparing a section
+// number that does not exist in either version names the section, not the
+// whole specification — the earlier bug reported "no sections found for TS
+// 23.501 in either version" as if the whole spec were empty.
+func TestCompareVersionsSectionMissingInBoth(t *testing.T) {
+	d := setupTestDB(t)
+	seedOldVersion(t, d)
+	handler := HandleCompareVersions(NewSource(d))
+
+	result, _, err := handler(context.Background(), nil, CompareVersionsInput{
+		SpecID:        "TS 23.501",
+		OldVersion:    "17.9.0",
+		NewVersion:    "18.6.0",
+		SectionNumber: "99",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected an error result, got: %q", getTextContent(result))
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, "Section 99 does not exist in TS 23.501 in either version") {
+		t.Errorf("expected a section-specific message, got: %q", text)
+	}
+	if strings.Contains(text, "no sections found for TS 23.501 in either version") {
+		t.Errorf("message should not imply the whole spec is empty: %q", text)
+	}
+}
+
 func TestCompareVersionsSameVersion(t *testing.T) {
 	d := setupTestDB(t)
 	handler := HandleCompareVersions(NewSource(d))

--- a/tools/images_test.go
+++ b/tools/images_test.go
@@ -433,6 +433,60 @@ func TestGetImageArchivedFetchError(t *testing.T) {
 	}
 }
 
+// TestGetImageArchivedEvictedMidFetch checks that a version evicted from the
+// cache while its images were still downloading is reported as a transient,
+// retryable condition (FetchInProgressError) rather than a permanent
+// VersionUnavailableError: the version does exist, the fetch just lost a race
+// with a concurrent eviction, and the next call recovers it.
+func TestGetImageArchivedEvictedMidFetch(t *testing.T) {
+	d := setupTestDB(t)
+	proceed := make(chan struct{})
+	release := make(chan struct{})
+	src := sourceWithImageStore(t, d, func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+		close(proceed)
+		<-release
+		return []db.Image{{Name: "figure1.png", MIMEType: "image/png", Data: []byte("x"), LLMReadable: true}}, nil
+	})
+	// sourceWithImageStore leaves LimitBytes at its zero value, which keeps
+	// only the most recently fetched version, so fetching a second version
+	// below evicts the first.
+	src.Budget = 5 * time.Second
+	handler := HandleGetImage(src)
+
+	done := make(chan *mcp.CallToolResult, 1)
+	go func() {
+		result, _, err := handler(context.Background(), nil, GetImageInput{
+			SpecID:  "TS 23.501",
+			Name:    "figure1.png",
+			Version: "19.5.0",
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		done <- result
+	}()
+
+	<-proceed // the image fetch for 19.5.0 has started and is blocked on release
+
+	// Fetching a different version evicts 19.5.0's cache entry (sections and,
+	// with them, the row putImages needs to record 19.5.0's images against),
+	// racing the in-flight image fetch above.
+	if _, _, err := src.GetSection(context.Background(), "TS 23.501", "20.2.0", "5.1", false); err != nil {
+		t.Fatalf("evicting fetch: %v", err)
+	}
+
+	close(release) // let the blocked image fetch finish and try to commit
+
+	result := <-done
+	if result.IsError {
+		t.Fatalf("an evicted-mid-fetch image download must not be a permanent tool error: %s", getTextContent(result))
+	}
+	text := getTextContent(result)
+	if !strings.Contains(text, "Images for TS 23.501 v19.5.0 are being downloaded") || !strings.Contains(text, "Call the same tool again") {
+		t.Errorf("expected a retryable image fetch-in-progress message, got: %s", text)
+	}
+}
+
 // TestListImagesArchivedReResolveFails covers the cached fast path: the
 // version's sections are already cached (so resolve carries no archive entry)
 // and the archive listing has become unreachable, which must fail the image

--- a/tools/list_versions.go
+++ b/tools/list_versions.go
@@ -144,6 +144,27 @@ func HandleListVersions(src *Source) func(ctx context.Context, req *mcp.CallTool
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to marshal: %v", err)), nil, nil
 		}
+
+		// The archive listing may have failed while the cache and/or database
+		// still produced versions; the list returned is then incomplete, and
+		// silently returning it as if it were complete would hide that. The
+		// warning travels as its own content item so the JSON payload stays
+		// parseable.
+		if archiveErr != nil {
+			return listVersionsResult(string(data),
+				fmt.Sprintf("[Warning: failed to list archive versions for %s, so this list may be incomplete: %v]", input.SpecID, archiveErr)), nil, nil
+		}
 		return textResult(string(data)), nil, nil
 	}
+}
+
+// listVersionsResult builds a result whose first content item is the JSON
+// payload; a non-empty warning is appended as a separate item so it never
+// corrupts the JSON.
+func listVersionsResult(payload, warning string) *mcp.CallToolResult {
+	res := textResult(payload)
+	if warning != "" {
+		res.Content = append(res.Content, &mcp.TextContent{Text: warning})
+	}
+	return res
 }

--- a/tools/source.go
+++ b/tools/source.go
@@ -369,7 +369,11 @@ func (s *Source) ensureImages(ctx context.Context, specID string, res Resolution
 	switch err := s.Store.EnsureImages(ctx, specID, res.Version, sv, s.Budget); {
 	case err == nil:
 		return nil
-	case errors.Is(err, versionstore.ErrInProgress):
+	case errors.Is(err, versionstore.ErrInProgress), errors.Is(err, versionstore.ErrImagesEvicted):
+		// Both are transient: the fetch is either still running or was
+		// dropped by a concurrent eviction mid-flight, and in either case
+		// the next call recovers it. Reporting it as VersionUnavailableError
+		// would tell the caller to give up on a version that does exist.
 		return &FetchInProgressError{SpecID: specID, Version: res.Version, Images: true}
 	default:
 		return &VersionUnavailableError{

--- a/tools/source_test.go
+++ b/tools/source_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/higebu/3gpp-mcp/versionstore"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // redirectTransport rewrites all request URLs to point at the test server,
@@ -462,6 +463,44 @@ func TestHandleListVersions(t *testing.T) {
 		if out.Versions[i] != w {
 			t.Errorf("versions[%d] = %+v, want %+v", i, out.Versions[i], w)
 		}
+	}
+}
+
+// TestHandleListVersionsSurfacesArchiveFailure checks that a failed archive
+// listing is reported alongside a partial version list — versions found via
+// the database or cache must not be presented as if they were the complete
+// set when the archive listing itself failed.
+func TestHandleListVersionsSurfacesArchiveFailure(t *testing.T) {
+	d := setupTestDB(t)
+	src := NewSource(d)
+	src.Client = unreachableArchiveClient(t)
+	src.UseCache = false
+	handler := HandleListVersions(src)
+
+	result, _, err := handler(context.Background(), nil, ListVersionsInput{SpecID: "TS 23.501"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("a partial list with a warning should not be a tool error: %s", getTextContent(result))
+	}
+
+	// The JSON payload must still parse and hold the versions that were
+	// found (from the database here), not be corrupted by the warning.
+	var out ListVersionsOutput
+	if err := json.Unmarshal([]byte(getTextContent(result)), &out); err != nil {
+		t.Fatalf("payload is not valid JSON: %v; got %q", err, getTextContent(result))
+	}
+	if len(out.Versions) != 1 || out.Versions[0].Version != "18.6.0" {
+		t.Fatalf("expected the one database version, got %+v", out.Versions)
+	}
+
+	if len(result.Content) != 2 {
+		t.Fatalf("expected the archive-failure warning as a second content item, got %d items", len(result.Content))
+	}
+	warning := result.Content[1].(*mcp.TextContent).Text
+	if !strings.Contains(warning, "failed to list archive versions") || !strings.Contains(warning, "TS 23.501") {
+		t.Errorf("expected a warning naming the archive failure, got: %q", warning)
 	}
 }
 

--- a/versionstore/images_test.go
+++ b/versionstore/images_test.go
@@ -408,6 +408,12 @@ func TestPutImagesAfterEviction(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "evicted") {
 		t.Fatalf("EnsureImages = %v, want an eviction error", err)
 	}
+	// The error must be recognizable as transient (errors.Is), not just by
+	// message text, so callers can classify it as retryable rather than a
+	// permanent failure.
+	if !errors.Is(err, ErrImagesEvicted) {
+		t.Errorf("EnsureImages = %v, want it to wrap ErrImagesEvicted", err)
+	}
 	if img, err := s.GetImage("TS 23.501", "18.6.0", "image1.png"); err != nil || img != nil {
 		t.Errorf("orphaned image survived: %+v, %v", img, err)
 	}

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -33,6 +33,12 @@ import (
 // returns the content.
 var ErrInProgress = errors.New("version fetch still in progress")
 
+// ErrImagesEvicted reports that a version was evicted from the cache while its
+// images were downloading, so the newly fetched images could not be recorded.
+// This is transient, not a permanent failure: the caller's next call re-fetches
+// the version's sections first and then its images.
+var ErrImagesEvicted = errors.New("version was evicted while its images downloaded")
+
 // DefaultLimitBytes is the default cache size limit.
 const DefaultLimitBytes int64 = 1024 << 20 // 1 GiB
 
@@ -773,7 +779,7 @@ func (s *Store) putImages(specID, version string, images []db.Image) error {
 		// orphan the blobs and break the invariant that a cache entry always
 		// accompanies cached rows, so give up; the next call re-fetches the
 		// sections first.
-		return fmt.Errorf("%s v%s was evicted while its images downloaded; call the tool again", specID, version)
+		return fmt.Errorf("%w: %s v%s; call the tool again", ErrImagesEvicted, specID, version)
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Summary

- `list_versions` no longer silently drops a failed archive listing when the database/cache still produced versions; a warning now travels as a second content item alongside the (still valid) JSON payload.
- An image-cache eviction that races an in-flight image download is now classified as a transient, retryable `FetchInProgressError` instead of a permanent `VersionUnavailableError` — added `versionstore.ErrImagesEvicted` so the source layer can tell the two apart.
- `compare_versions` now reports "Section X does not exist ... in either version" when a requested section is genuinely missing from both sides, instead of the misleading whole-spec "no sections found" message.

Fixes #145
Fixes #146
Fixes #147

## Test plan
- [x] `gofmt -l .` — no output
- [x] `go vet ./...` — clean
- [x] `go test -short ./...` — all packages pass, including `tools`, `versionstore`, and `web`
- [x] `golangci-lint run` — could not run in this environment (golangci-lint's Go build version is older than the module's go 1.26.1 toolchain); reproduced the same failure on unmodified `origin/main`, confirming it's a pre-existing environment issue, not caused by this change
- [x] `ocr review --from origin/main --to HEAD` — status complete, 0 findings
- [x] Added regression tests for each fix (`tools/source_test.go`, `tools/images_test.go`, `tools/compare_versions_test.go`, `versionstore/images_test.go`), following existing test conventions (fakes/mocks, real concurrency for the eviction race)