### PR TITLE
fix(docx): OMML to LaTeX conversion fixes

### DIFF
--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -211,12 +211,95 @@ func renderFraction(n *ommlNode) string {
 	if typ, ok := mVal(child(n, "fPr"), "type"); ok {
 		switch typ {
 		case "lin":
-			return num + "/" + den
+			return linOperand(num) + "/" + linOperand(den)
 		case "noBar":
 			return "{" + num + " \\atop " + den + "}"
 		}
 	}
 	return "\\frac{" + num + "}{" + den + "}"
+}
+
+// linOperand fences a linear-fraction operand that would otherwise lose its
+// grouping. m:num and m:den are separate operands, but "/" is a plain character
+// in LaTeX, so splicing them together turns "(a+b)/(c+d)" into "a+b/c+d", which
+// reads as a+(b/c)+d — a silent change of meaning (issue #141).
+func linOperand(s string) string {
+	s = trimMathSpace(s)
+	if !needsLinGroup(s) {
+		return s
+	}
+	return "\\left(" + s + "\\right)"
+}
+
+// looseMathCmds are the binary operators and relations escapeMathText emits as
+// LaTeX commands. They bind no more tightly than "/", so needsLinGroup has to
+// spot them just like a literal "+": "a±b" reaches it as "a\pm b", with the
+// operator hidden inside a control word.
+var looseMathCmds = map[string]bool{
+	// Additive-level operators.
+	"pm": true, "mp": true, "cup": true, "cap": true,
+	"oplus": true, "otimes": true,
+	// Multiplicative operators. They re-associate in a denominator —
+	// "a/(b×c)" flattened to "a/b\times c" reads as (a/b)×c.
+	"times": true, "div": true, "cdot": true, "circ": true,
+	// Relations.
+	"leq": true, "geq": true, "neq": true, "approx": true, "equiv": true,
+	"in": true, "notin": true, "subset": true, "subseteq": true,
+	"propto": true, "rightarrow": true, "leftarrow": true,
+	"leftrightarrow": true, "Rightarrow": true, "Leftrightarrow": true,
+}
+
+// needsLinGroup reports whether s binds loosely enough that "/" would steal
+// part of it. A top-level operator or relation makes it so; everything inside
+// braces or a \left...\right pair is already grouped, and a leading sign is
+// unary. Juxtaposition stays unfenced: "2n" is indistinguishable from a single
+// atom here, so "a/2n" keeps the source's own ambiguity.
+func needsLinGroup(s string) bool {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		case '\\':
+			name := latexCmdName(s[i+1:])
+			switch {
+			case name == "left":
+				depth++
+			case name == "right":
+				if depth > 0 {
+					depth--
+				}
+			case depth == 0 && i > 0 && looseMathCmds[name]:
+				return true
+			}
+			// Step over the control word, or over the single escaped
+			// character of a control symbol such as "\-", so neither the
+			// command spelling nor the escaped character is read as an
+			// operator.
+			i += max(len(name), 1)
+		case '+', '-', '/', '=', '<', '>':
+			if depth == 0 && i > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// latexCmdName returns the control word starting at the beginning of s (the
+// letters that follow a backslash), or "" when the backslash introduces a
+// control symbol such as "\{".
+func latexCmdName(s string) string {
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+			return s[:i]
+		}
+	}
+	return s
 }
 
 func renderDelimiter(n *ommlNode) string {

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -50,7 +50,7 @@ const maxOMMLDepth = 100
 // without surrounding "$" delimiters.
 func ommlToLaTeX(d *xml.Decoder, start xml.StartElement) string {
 	root := parseOMMLNode(d, start, 0)
-	return strings.TrimSpace(renderOMML(root))
+	return trimMathSpace(renderOMML(root))
 }
 
 // parseOMMLNode builds the subtree rooted at start, reading tokens from d until
@@ -249,7 +249,7 @@ func renderRadical(n *ommlNode) string {
 	e := renderOMML(child(n, "e"))
 	degHide, present := mVal(child(n, "radPr"), "degHide")
 	deg := renderOMML(child(n, "deg"))
-	if isTrue(degHide, present) || strings.TrimSpace(deg) == "" {
+	if isTrue(degHide, present) || trimMathSpace(deg) == "" {
 		return "\\sqrt{" + e + "}"
 	}
 	return "\\sqrt[" + deg + "]{" + e + "}"
@@ -315,7 +315,7 @@ func renderMatrix(n *ommlNode) string {
 }
 
 func renderFunc(n *ommlNode) string {
-	name := strings.TrimSpace(renderOMML(child(n, "fName")))
+	name := trimMathSpace(renderOMML(child(n, "fName")))
 	arg := renderOMML(child(n, "e"))
 	var op string
 	switch name {
@@ -461,6 +461,27 @@ var mathSymbols = map[rune]string{
 	'−': "-", // U+2212 minus sign → ASCII hyphen
 }
 
+// mathSpace is the protected form of a literal space inside m:t. Math mode
+// discards ordinary spaces ("n mod 2" would render as "nmod2"), so a space has
+// to be re-emitted as a text-mode group to survive rendering (issue #140).
+// \text{ } is used rather than "\ " because it also survives whitespace
+// trimming: TrimSpace would strip the space off "\ " and leave a stray
+// backslash behind.
+const mathSpace = "\\text{ }"
+
+// trimMathSpace trims whitespace and protected spaces from both ends of
+// rendered math. Math that is nothing but spacing therefore still compares
+// equal to "", and a padded function name still matches the operator table.
+func trimMathSpace(s string) string {
+	for prev := ""; s != prev; {
+		prev = s
+		s = strings.TrimSpace(s)
+		s = strings.TrimPrefix(s, mathSpace)
+		s = strings.TrimSuffix(s, mathSpace)
+	}
+	return s
+}
+
 // escapeMathText escapes LaTeX-special literals in ordinary math text and maps
 // common Unicode symbols to LaTeX commands.
 func escapeMathText(s string) string {
@@ -494,6 +515,8 @@ func escapeMathText(s string) string {
 			b.WriteString("\\text{\\textasciitilde}")
 		case '^':
 			b.WriteString("\\text{\\textasciicircum}")
+		case ' ':
+			b.WriteString(mathSpace)
 		default:
 			b.WriteRune(r)
 		}

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -281,7 +281,9 @@ func needsLinGroup(s string) bool {
 			// command spelling nor the escaped character is read as an
 			// operator.
 			i += max(len(name), 1)
-		case '+', '-', '/', '=', '<', '>':
+		// "*" covers both the ASCII character and U+2217, which mathSymbols
+		// maps to it; like \times it re-associates in a denominator.
+		case '+', '-', '*', '/', '=', '<', '>':
 			if depth == 0 && i > 0 {
 				return true
 			}

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -140,6 +140,16 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "a/\\left(b\\times c\\right)",
 		},
 		{
+			// U+2217 is mapped to a literal "*", so the multiplication is
+			// invisible to a command-based check: "a/b*c" would read as
+			// (a/b)*c.
+			name: "linear fraction fences a denominator multiplied with an asterisk",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a") + `</m:num><m:den>` + mrun("b∗c") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "a/\\left(b*c\\right)",
+		},
+		{
 			name: "linear fraction fences an operand holding a relation",
 			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
 				`<m:num>` + mrun("a=b") + `</m:num><m:den>` + mrun("c") + `</m:den>` +
@@ -371,6 +381,7 @@ func TestEscapeMathText(t *testing.T) {
 		{"n mod 2", "n\\text{ }mod\\text{ }2"},
 		{"a  b", "a\\text{ }\\text{ }b"},
 		{"a×b", "a\\times b"},
+		{"a∗b", "a*b"}, // U+2217 asterisk operator → ASCII "*"
 	}
 	for _, tt := range tests {
 		if got := escapeMathText(tt.in); got != tt.want {

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -228,6 +228,33 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "\\begin{gathered} a=1 \\\\ b=2 \\\\ c=3 \\end{gathered}",
 		},
 		{
+			// Math mode drops ordinary spaces, so "n mod 2" would otherwise
+			// render as "nmod2" (issue #140).
+			name: "spaces inside a run survive math mode",
+			xml:  `<m:oMath ` + mXMLNS + `>` + mrun("n mod 2") + `</m:oMath>`,
+			want: "n\\text{ }mod\\text{ }2",
+		},
+		{
+			name: "padding around a formula is trimmed, not protected",
+			xml:  `<m:oMath ` + mXMLNS + `>` + mrun(" x+1 ") + `</m:oMath>`,
+			want: "x+1",
+		},
+		{
+			// A padded function name still has to match the operator table.
+			name: "function name with surrounding spaces",
+			xml: `<m:oMath ` + mXMLNS + `><m:func>` +
+				`<m:fName>` + mrun(" cos ") + `</m:fName>` +
+				`<m:e>` + mrun("x") + `</m:e></m:func></m:oMath>`,
+			want: "\\cos x",
+		},
+		{
+			name: "radical with blank degree hides the degree",
+			xml: `<m:oMath ` + mXMLNS + `><m:rad>` +
+				`<m:deg>` + mrun(" ") + `</m:deg><m:e>` + mrun("x") + `</m:e>` +
+				`</m:rad></m:oMath>`,
+			want: "\\sqrt{x}",
+		},
+		{
 			name: "greek and relation symbols",
 			xml:  `<m:oMath ` + mXMLNS + `>` + mrun("α≤β") + `</m:oMath>`,
 			want: "\\alpha \\leq \\beta",
@@ -262,6 +289,10 @@ func TestEscapeMathText(t *testing.T) {
 		{"a^b", "a\\text{\\textasciicircum}b"},
 		{"$x", "\\$x"},
 		{"β≥γ", "\\beta \\geq \\gamma "},
+		// Spaces need the same treatment: math mode would collapse them and
+		// turn "n mod 2" into "nmod2".
+		{"n mod 2", "n\\text{ }mod\\text{ }2"},
+		{"a  b", "a\\text{ }\\text{ }b"},
 		{"a×b", "a\\times b"},
 	}
 	for _, tt := range tests {

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -79,6 +79,83 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "a/b",
 		},
 		{
+			// "/" is a plain character in LaTeX, so an ungrouped "a+b/c+d"
+			// would read as a+(b/c)+d (issue #141).
+			name: "linear fraction fences compound operands",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a+b") + `</m:num><m:den>` + mrun("c+d") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "\\left(a+b\\right)/\\left(c+d\\right)",
+		},
+		{
+			name: "linear fraction keeps a leading sign unfenced",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("-1") + `</m:num><m:den>` + mrun("2") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "-1/2",
+		},
+		{
+			name: "linear fraction does not re-fence a delimited operand",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num><m:d><m:e>` + mrun("a+b") + `</m:e></m:d></m:num>` +
+				`<m:den>` + mrun("c") + `</m:den></m:f></m:oMath>`,
+			want: "\\left(a+b\\right)/c",
+		},
+		{
+			// A nested division in the denominator is the other way "/" can
+			// re-associate: "a/b/c" would read as (a/b)/c.
+			name: "linear fraction fences a nested linear fraction",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a") + `</m:num><m:den>` +
+				`<m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("b") + `</m:num><m:den>` + mrun("c") + `</m:den></m:f>` +
+				`</m:den></m:f></m:oMath>`,
+			want: "a/\\left(b/c\\right)",
+		},
+		{
+			// "\leftarrow" must not be mistaken for a "\left" group opener,
+			// which would hide the top-level "+" from the scanner.
+			name: "linear fraction fences an operand holding an arrow command",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a←b+c") + `</m:num><m:den>` + mrun("d") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "\\left(a\\leftarrow b+c\\right)/d",
+		},
+		{
+			// The operator reaches needsLinGroup as the command "\pm", not as
+			// a literal character.
+			name: "linear fraction fences an operand joined by a symbol command",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a±b") + `</m:num><m:den>` + mrun("c") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "\\left(a\\pm b\\right)/c",
+		},
+		{
+			// Multiplication re-associates in a denominator: "a/b×c" reads as
+			// (a/b)×c, not a/(b×c).
+			name: "linear fraction fences a multiplied denominator",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a") + `</m:num><m:den>` + mrun("b×c") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "a/\\left(b\\times c\\right)",
+		},
+		{
+			name: "linear fraction fences an operand holding a relation",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("a=b") + `</m:num><m:den>` + mrun("c") + `</m:den>` +
+				`</m:f></m:oMath>`,
+			want: "\\left(a=b\\right)/c",
+		},
+		{
+			// Braces already group, and the \frac itself is a single atom.
+			name: "linear fraction with a bar fraction operand needs no fence",
+			xml: `<m:oMath ` + mXMLNS + `><m:f><m:fPr><m:type m:val="lin"/></m:fPr>` +
+				`<m:num>` + mrun("x") + `</m:num><m:den><m:f>` +
+				`<m:num>` + mrun("a+b") + `</m:num><m:den>` + mrun("2") + `</m:den>` +
+				`</m:f></m:den></m:f></m:oMath>`,
+			want: "x/\\frac{a+b}{2}",
+		},
+		{
 			name: "matrix",
 			xml: `<m:oMath ` + mXMLNS + `><m:m>` +
 				`<m:mr><m:e>` + mrun("1") + `</m:e><m:e>` + mrun("j") + `</m:e></m:mr>` +


### PR DESCRIPTION
Two fixes to the OMML → LaTeX converter, both producing KaTeX-compatible output.

- **Spaces in math text.** Math mode discards ordinary spaces, so `n mod 2` rendered as `nmod2`. Spaces in `m:t` are now emitted as `\text{ }`, matching the existing protection of `~` and `^`. `\text{ }` is used instead of `\ ` because it also survives whitespace trimming, which would otherwise leave a stray backslash. Trailing/leading padding is still trimmed, so function names and blank radical degrees keep behaving as before.
- **Linear fraction grouping.** `m:num` and `m:den` were concatenated around a bare `/`, so `(a+b)/(c+d)` collapsed to `a+b/c+d`, which reads as `a+(b/c)+d`. An operand that carries a top-level operator or relation is now fenced with `\left(...\right)`. Operands that are already grouped (a `m:d` delimiter, `\frac`, a brace group) and single atoms with a leading sign are left untouched, so `a/b` and `-1/2` are unchanged.

Fixes #140
Fixes #141

Verification: `gofmt -l .` clean, `go vet ./...`, `go test -short ./...` all pass. Regression tests added for space preservation, padded function names, compound/nested/delimited linear-fraction operands, and operators that arrive as commands (`\pm`, `\times`) rather than literal characters. `golangci-lint` could not run locally (the installed binary is built with go1.25 while the module targets 1.26) — CI covers it.

Note: cache schema bump is handled centrally in the docx block-parsing PR.