### PR TITLE
fix(db): reference extraction and linkification fixes

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -543,6 +543,18 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 	}
 	defer refStmt.Close()
 
+	// Same-version re-import (e.g. after a reference-extraction fix) must not
+	// leave references that the new extraction no longer produces: INSERT OR
+	// REPLACE only overwrites rows whose (source, target) pair still matches,
+	// so a section's stale references need an explicit delete first.
+	delRefStmt, err := tx.Prepare(
+		"DELETE FROM spec_references WHERE source_spec_id = ? AND source_version = ? AND source_section = ?",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare ref delete: %w", err)
+	}
+	defer delRefStmt.Close()
+
 	// Build bracketed reference map from the References section.
 	var bracketMap map[string]string
 	for _, s := range sections {
@@ -608,6 +620,10 @@ func (d *DB) InsertSpecWithSectionsAndImages(spec Spec, sections []Section, imag
 		_, err = insStmt.Exec(s.SpecID, spec.Version, s.Number, s.Title, s.Level, s.ParentNumber, s.Content)
 		if err != nil {
 			return fmt.Errorf("insert section: %w", err)
+		}
+
+		if _, err = delRefStmt.Exec(s.SpecID, spec.Version, s.Number); err != nil {
+			return fmt.Errorf("delete stale references: %w", err)
 		}
 
 		refs := ExtractReferences(s.SpecID, s.Number, s.Content, bracketMap)

--- a/db/db.go
+++ b/db/db.go
@@ -1292,7 +1292,7 @@ const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp 
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
-	tsRefRE = regexp.MustCompile(`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)(?:` + sp + `*[,;]?` + sp + `*(?:clause|section|subclause|[Aa]nnex)` + sp + `+` + secNum + `)?`)
+	tsRefRE = regexp.MustCompile(`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)(?:` + sp + `*[,;]?` + sp + `*(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + sp + `+` + secNum + `)?`)
 	// "Annex H of 3GPP TS 33.203" or "subclause 5.1 of TS 23.228"
 	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + sp + `+` + secNum + sp + `+of` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
 	rfcRefRE      = regexp.MustCompile(`(?:IETF` + sp + `+)?RFC` + sp + `+(\d+)(?:` + sp + `*[,;]?` + sp + `*(?:section|clause)` + sp + `+(\d+(?:\.\d+)*))?`)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1256,6 +1256,58 @@ func TestInsertSpecWithSections_References(t *testing.T) {
 	}
 }
 
+func TestInsertSpecWithSections_ReimportDropsStaleReferences(t *testing.T) {
+	// Regression test for #134: re-importing the same (spec, version) must
+	// drop references the new content no longer produces. INSERT OR REPLACE
+	// only overwrites rows whose (source, target) pair still matches, so a
+	// reference extracted from the old content but absent from the new
+	// content would otherwise survive forever.
+	d := setupTestDB(t)
+
+	spec := Spec{ID: "TS 99.002", Version: "1.0.0", Title: "Test Spec", Series: "99"}
+	sections := []Section{
+		{
+			SpecID:  "TS 99.002",
+			Version: "1.0.0",
+			Number:  "1",
+			Title:   "Scope",
+			Level:   1,
+			Content: "# 1 Scope\nThis spec references TS 23.501 clause 5.1.",
+		},
+	}
+	if err := d.InsertSpecWithSections(spec, sections); err != nil {
+		t.Fatalf("initial import: %v", err)
+	}
+
+	refs, err := d.GetReferences(t.Context(), "TS 99.002", "1.0.0", "1", "outgoing", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 || refs[0].TargetSpec != "TS 23.501" || refs[0].TargetSection != "5.1" {
+		t.Fatalf("expected initial ref to TS 23.501 5.1, got %+v", refs)
+	}
+
+	// Re-import the same (spec, version, section) with content that no
+	// longer references TS 23.501.
+	sections[0].Content = "# 1 Scope\nThis spec references RFC 8259 instead."
+	if err := d.InsertSpecWithSections(spec, sections); err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+
+	refs, err = d.GetReferences(t.Context(), "TS 99.002", "1.0.0", "1", "outgoing", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 || refs[0].TargetSpec != "RFC 8259" {
+		t.Fatalf("expected only RFC 8259 ref after re-import, got %+v", refs)
+	}
+	for _, r := range refs {
+		if r.TargetSpec == "TS 23.501" {
+			t.Errorf("stale reference to TS 23.501 survived re-import: %+v", r)
+		}
+	}
+}
+
 func TestParseBracketedRefMap(t *testing.T) {
 	content := `## 2 References
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2134,6 +2134,53 @@ func TestQueryMethodsHonorContext(t *testing.T) {
 	}
 }
 
+func TestExtractReferences_PluralKeyword(t *testing.T) {
+	// Regression test for #133: tsRefRE's keyword alternation must accept
+	// plurals ("clauses"), or it falls through to matching just "TS 23.402"
+	// with an empty TargetSection alongside the correct multi-section refs
+	// produced by tsMultiRefRE.
+	content := "See TS 23.402 clauses 8.2 and 16.11 for details."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d: %+v", len(refs), refs)
+	}
+	for _, want := range []string{"8.2", "16.11"} {
+		found := false
+		for _, r := range refs {
+			if r.TargetSpec == "TS 23.402" && r.TargetSection == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected reference to TS 23.402 section %s, got refs: %+v", want, refs)
+		}
+	}
+	for _, r := range refs {
+		if r.TargetSpec == "TS 23.402" && r.TargetSection == "" {
+			t.Errorf("unexpected reference with empty TargetSection: %+v", r)
+		}
+	}
+}
+
+func TestExtractReferences_PluralKeywordSingleSection(t *testing.T) {
+	// Direct exercise of tsRefRE's keyword alternation with a plural keyword
+	// but only one section number (no "and" list, so tsMultiRefRE does not
+	// match): the section must still be captured, not dropped.
+	content := "The procedures are described in TS 23.501 sections 5.1."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 23.501" || refs[0].TargetSection != "5.1" {
+		t.Errorf("expected TS 23.501 section 5.1, got %+v", refs[0])
+	}
+}
+
 func TestExtractReferences_CoordinatedList(t *testing.T) {
 	// Coordinated keyword-per-element list: every element belongs to the
 	// named spec and must be indexed.

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1256,6 +1256,48 @@ func TestInsertSpecWithSections_References(t *testing.T) {
 	}
 }
 
+func TestInsertSpecWithSections_DeleteStaleReferencesError(t *testing.T) {
+	// Covers the "delete stale references" error branch added for #134: a
+	// BEFORE DELETE trigger on spec_references forces the DELETE issued
+	// ahead of re-extraction to fail, so InsertSpecWithSections must
+	// propagate that error instead of silently continuing. The trigger only
+	// fires per matched row, so a pre-existing reference row for the same
+	// (spec, version, section) is seeded first.
+	d := setupTestDB(t)
+
+	if err := d.Exec(
+		"INSERT INTO spec_references (source_spec_id, source_version, source_section, target_spec, target_section, context) VALUES (?, ?, ?, ?, ?, ?)",
+		"TS 99.003", "1.0.0", "1", "TS 23.501", "5.1", "seed",
+	); err != nil {
+		t.Fatalf("seed reference: %v", err)
+	}
+	if err := d.Exec(
+		"CREATE TRIGGER block_ref_delete BEFORE DELETE ON spec_references BEGIN SELECT RAISE(ABORT, 'blocked for test'); END",
+	); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	spec := Spec{ID: "TS 99.003", Version: "1.0.0", Title: "Test Spec", Series: "99"}
+	sections := []Section{
+		{
+			SpecID:  "TS 99.003",
+			Version: "1.0.0",
+			Number:  "1",
+			Title:   "Scope",
+			Level:   1,
+			Content: "# 1 Scope\nNo references here.",
+		},
+	}
+
+	err := d.InsertSpecWithSections(spec, sections)
+	if err == nil {
+		t.Fatal("expected error from blocked spec_references delete")
+	}
+	if !strings.Contains(err.Error(), "delete stale references") {
+		t.Errorf("expected \"delete stale references\" error, got: %v", err)
+	}
+}
+
 func TestInsertSpecWithSections_ReimportDropsStaleReferences(t *testing.T) {
 	// Regression test for #134: re-importing the same (spec, version) must
 	// drop references the new content no longer produces. INSERT OR REPLACE

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -7,8 +7,14 @@ import (
 	"strings"
 )
 
-// existingLinkRE matches Markdown link syntax [text](url) to avoid double-linking.
-var existingLinkRE = regexp.MustCompile(`\[[^\]]*\]\([^)]*\)`)
+// existingLinkRE matches Markdown link syntax [text](url) to avoid
+// double-linking. Both character classes exclude newlines: real link/image
+// syntax is emitted on a single line, and without this an unclosed "["
+// earlier in the content (e.g. an interval "[0, 1)" or an unterminated
+// editor's note "[FFS ...") would greedily span paragraphs to the next
+// unrelated "](" — such as an image link — swallowing every reference in
+// between as "already linked" and silently dropping their linkification.
+var existingLinkRE = regexp.MustCompile(`\[[^\]\n]*\]\([^)\n]*\)`)
 
 // tableRegionOpenRE matches a converter-emitted table opener: each table is
 // its own block, so a real opener sits at the start of a line.

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -792,6 +792,24 @@ func TestLinkifyRefs_PrepositionNeedsKeyword(t *testing.T) {
 
 // URLFor is the one mandatory option; without it LinkifyRefs is a no-op
 // instead of a panic.
+// Regression test for #135: an unclosed "[" (e.g. an interval like "[0, 1)"
+// or an unterminated editor's note "[FFS ...") must not have existingLinkRE
+// treat everything up to a later, unrelated "](" — such as a real image
+// link several paragraphs down — as one giant existing link. That used to
+// swallow every reference in between, suppressing their linkification.
+func TestLinkifyRefs_UnclosedBracketDoesNotSuppressLaterRefs(t *testing.T) {
+	input := "The interval is [0, 1) as noted.\n\n" +
+		"See TS 23.501 for architecture details.\n\n" +
+		"![diagram](image://foo.png)"
+	want := "The interval is [0, 1) as noted.\n\n" +
+		"See [TS 23.501](/specs/TS 23.501) for architecture details.\n\n" +
+		"![diagram](image://foo.png)"
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: urlFor})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
 func TestLinkifyRefs_NilURLFor(t *testing.T) {
 	input := "See TS 23.501 clause 5.1."
 	if got := LinkifyRefs(input, LinkifyRefsOpts{}); got != input {


### PR DESCRIPTION
## Summary

- `tsRefRE`'s keyword alternation now accepts plurals (`clauses`, `sections`, `subclauses`, `annexes`), so "TS 23.402 clauses 8.2 and 16.11" no longer emits a spurious reference with an empty `TargetSection` alongside the two correct ones.
- `InsertSpecWithSectionsAndImages` now deletes a section's existing `spec_references` rows before re-inserting extracted references, so a same-version re-import (e.g. after a reference-extraction fix, via `make build-db`) drops references the new extraction no longer produces instead of leaving them stale forever.
- `existingLinkRE` no longer matches across newlines, so an unclosed `[` earlier in the content (an interval like `[0, 1)`, or an unterminated editor's note `[FFS ...`) can no longer greedily span multiple paragraphs to a later, unrelated `](` (e.g. an image link) and suppress linkification of every TS/TR reference in between.

Fixes #133
Fixes #134
Fixes #135

## Verification

- `gofmt -l .` — no output
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- `go test -short ./...` — all packages pass
- Each bug was reproduced against the pre-fix code and confirmed fixed, with a regression test added for each

Cache schema bump is handled centrally in the docx block-parsing PR.