### PR TITLE
fix(pipeline): release parsing, .doc status reporting, empty cache handling

### DIFF
--- a/converter/pipeline/cache.go
+++ b/converter/pipeline/cache.go
@@ -80,7 +80,13 @@ func LoadCache(key string, ttl time.Duration) ([]string, error) {
 	}
 	defer f.Close()
 
-	var entries []string
+	// entries starts non-nil so a fresh cache file that legitimately holds
+	// zero entries (e.g. a filter with no matching specs) still returns a
+	// non-nil, empty slice. Callers distinguish a hit from a miss by nil-ness
+	// (see speclist.go), so a nil result here for a present, unexpired file
+	// would read as a miss and force a network re-fetch every call even
+	// within the TTL.
+	entries := []string{}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/converter/pipeline/cache_test.go
+++ b/converter/pipeline/cache_test.go
@@ -62,6 +62,33 @@ func TestSaveAndLoadCache(t *testing.T) {
 	}
 }
 
+// TestLoadCache_EmptyResultIsCacheHit verifies that a cache file saved with
+// zero entries (a filter that legitimately matched nothing) is loaded back as
+// a hit within its TTL, not a miss (#144). Before the fix, LoadCache returned
+// nil for both an empty-but-present cache and an actual miss, so callers that
+// check for a nil result to decide whether to hit the network re-fetched on
+// every call even inside the TTL window.
+func TestLoadCache_EmptyResultIsCacheHit(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	key := CacheKey("empty-result")
+	if err := SaveCache(key, nil); err != nil {
+		t.Fatalf("SaveCache: %v", err)
+	}
+
+	loaded, err := LoadCache(key, time.Hour)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected a non-nil empty slice for a fresh, empty cache file, got nil (indistinguishable from a miss)")
+	}
+	if len(loaded) != 0 {
+		t.Errorf("loaded = %v, want empty", loaded)
+	}
+}
+
 func TestLoadCache_Expired(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", tmpDir)

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -308,28 +309,86 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 		}
 	}
 
-	// docPathClaimants maps each shared docDir path to every DOC_ONLY spec
-	// that recorded it. Two specs whose .doc files share a basename both
-	// extract into the same path in the flat, shared docDir, so the second
-	// extraction silently overwrites the first: only one spec's content
-	// physically survives to be converted, but both specs' docFilesBySpec
-	// entries still point at that same surviving path. An existence check
-	// on the converted output can't tell whose file actually made it
-	// through, so any path claimed by more than one spec is treated as
-	// unattributable for all of them rather than risk crediting a spec
-	// whose own file was clobbered before conversion ever ran.
-	docPathClaimants := make(map[string][]string)
+	// _doc_files (holding every DOC_ONLY spec's extracted .doc files) and
+	// outputDir (holding every direct .docx and every published conversion
+	// result) are both flat and shared across the whole batch, and
+	// outputDir persists across separate invocations of this command too.
+	// That flatness makes a basename collision possible in several distinct
+	// shapes; each is called out below with how it's handled or why it
+	// doesn't need to be, since review has surfaced a new one on each of
+	// several passes and the reasoning needs to live somewhere durable:
+	//
+	//  1. direct .docx x direct .docx (two different specs' archives each
+	//     already ship a .docx with the same basename): NOT specially
+	//     handled. DownloadAndExtract writes straight into outputDir with a
+	//     plain overwrite, same as it always has -- including on a second
+	//     invocation of this command, where overwriting previously
+	//     downloaded specs to refresh them is the intended behavior.
+	//     Guarding this would either break that refresh or require
+	//     namespacing outputDir per spec, both bigger changes than this
+	//     collision-handling pass is scoped to. It also cannot occur in
+	//     practice: every 3GPP archive filename is prefixed with that
+	//     spec's own series+number (e.g. "23501-i30.docx"), so two
+	//     *different* specs never produce the same basename.
+	//  2. direct .docx x converted .doc->.docx (one spec's archive ships a
+	//     .docx directly; a different DOC_ONLY spec's .doc converts to that
+	//     same basename): handled by the no-clobber publish below -- a
+	//     converted file is never allowed to overwrite an existing file in
+	//     outputDir. The spec that lost the race stays DOC_ONLY with a
+	//     logged warning instead of destroying the other spec's real
+	//     output.
+	//  3. converted .doc x converted .doc, different specs (two DOC_ONLY
+	//     specs' .doc files share a basename): handled below via
+	//     unattributable -- both extract into the same _doc_files path, so
+	//     only one spec's content survives extraction to be converted, and
+	//     an existence check on the result can't tell whose it was. Neither
+	//     spec is promoted.
+	//  4. duplicate basenames within one spec's OWN archive (e.g. two zip
+	//     entries under different subfolders that both flatten to the same
+	//     name): handled by deduplicating each spec's own doc-file list
+	//     before counting claimants below, so a spec doesn't collide with
+	//     itself and get wrongly excluded as "shared with another spec".
+	//     Only one of the duplicate contents survives extraction (same
+	//     flat-directory constraint as case 3), but that's the existing
+	//     "partial success still counts as OK" rule already used elsewhere
+	//     in this file, not a new attribution risk: the survivor still
+	//     definitely belongs to this spec, since no other spec claims it.
+	//  5. this run's converted output vs. a stale file already sitting at
+	//     the same outputDir path (a leftover from an earlier invocation,
+	//     since outputDir is never cleared between runs): handled by the
+	//     same no-clobber publish as case 2; a spec is only promoted when
+	//     its own file actually lands in outputDir this run.
+	//
+	// docPathClaimants maps each shared docDir path to the set of distinct
+	// DOC_ONLY specs that recorded it (case 3), after deduplicating each
+	// spec's own list first (case 4) so a spec's repeated claim on its own
+	// path never inflates the count past 1.
+	docPathClaimants := make(map[string]map[string]bool)
 	for specID, docFiles := range docFilesBySpec {
+		claimedByThisSpec := make(map[string]bool)
 		for _, docPath := range docFiles {
-			docPathClaimants[docPath] = append(docPathClaimants[docPath], specID)
+			if claimedByThisSpec[docPath] {
+				continue
+			}
+			claimedByThisSpec[docPath] = true
+			if docPathClaimants[docPath] == nil {
+				docPathClaimants[docPath] = make(map[string]bool)
+			}
+			docPathClaimants[docPath][specID] = true
 		}
 	}
 	unattributable := make(map[string]bool)
-	for docPath, specIDs := range docPathClaimants {
-		if len(specIDs) > 1 {
-			unattributable[docPath] = true
-			log.Printf("  warning: %s share a same-named .doc file (%s); none will be promoted from it", strings.Join(specIDs, ", "), filepath.Base(docPath))
+	for docPath, specIDSet := range docPathClaimants {
+		if len(specIDSet) <= 1 {
+			continue
 		}
+		unattributable[docPath] = true
+		specIDs := make([]string, 0, len(specIDSet))
+		for specID := range specIDSet {
+			specIDs = append(specIDs, specID)
+		}
+		sort.Strings(specIDs)
+		log.Printf("  warning: %s share a same-named .doc file (%s); none will be promoted from it", strings.Join(specIDs, ", "), filepath.Base(docPath))
 	}
 
 	if convertDoc {
@@ -369,21 +428,34 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				// actually made it there. Deciding OK from mere existence
 				// in convDir (as an earlier version of this fix did) could
 				// report a spec OK and then have the evidence vanish: if
-				// the rename below failed for that file -- outputDir
-				// already holds a same-named directory, a permissions
-				// problem, anything -- the .docx never reached outputDir,
-				// yet the scratch-dir cleanup at the end of this block
-				// would delete the only copy that had ever existed,
+				// publishing failed for that file, the .docx never reached
+				// outputDir, yet the scratch-dir cleanup at the end of this
+				// block would delete the only copy that had ever existed,
 				// leaving the reported OK status orphaned from any real
-				// file. Only a file that is confirmed moved counts as
+				// file. Only a file that is confirmed published counts as
 				// evidence a spec's conversion succeeded.
+				//
+				// Publishing uses os.Link (not os.Rename) so it fails
+				// closed on an existing destination instead of silently
+				// overwriting it (collision cases 2 and 5 in the survey
+				// above): a converted file may not be the only thing that
+				// ever wanted that outputDir path -- another spec's own
+				// .docx may already be sitting there from this very run, or
+				// from an earlier invocation of this command. Since convDir
+				// is a subdirectory of outputDir (same filesystem), the
+				// hard link always succeeds or fails atomically; there is
+				// no separate existence check to race against.
 				published := make(map[string]bool)
 				if convEntries, err := os.ReadDir(convDir); err == nil {
 					for _, e := range convEntries {
 						src := filepath.Join(convDir, e.Name())
 						dst := filepath.Join(outputDir, e.Name())
-						if err := os.Rename(src, dst); err != nil {
-							log.Printf("  publish converted %s: %v", e.Name(), err)
+						if err := os.Link(src, dst); err != nil {
+							if os.IsExist(err) {
+								log.Printf("  publish converted %s: skipped, %s already exists in outputDir", e.Name(), e.Name())
+							} else {
+								log.Printf("  publish converted %s: %v", e.Name(), err)
+							}
 							continue
 						}
 						published[e.Name()] = true

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -311,6 +311,23 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 	if convertDoc {
 		docDir := filepath.Join(outputDir, "_doc_files")
 		if entries, err := os.ReadDir(docDir); err == nil && len(entries) > 0 {
+			// outputDir is the caller's persistent --output-dir: it is
+			// created but never cleared between runs (see cmdDownload), so
+			// a .docx left over from an earlier invocation can already sit
+			// at a spec's expected output path before conversion even
+			// starts. Record which expected outputs pre-date this run so a
+			// stale file is never mistaken for evidence that this run's
+			// LibreOffice conversion succeeded.
+			preExisting := make(map[string]bool)
+			for _, docFiles := range docFilesBySpec {
+				for _, docPath := range docFiles {
+					out := convertedDocxPath(docPath, outputDir)
+					if _, statErr := os.Stat(out); statErr == nil {
+						preExisting[out] = true
+					}
+				}
+			}
+
 			log.Println("Converting .doc files to .docx...")
 			n, err := ConvertDocFiles(ctx, docDir, outputDir)
 			if err != nil {
@@ -318,15 +335,20 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 			}
 			log.Printf("Converted %d files", n)
 			// A spec is promoted from DOC_ONLY to OK only when one of its
-			// own .doc files produced a .docx (partial success still
-			// counts, matching the .docx branch above). The old code used
-			// min(convertedFileCount, docOnlySpecCount), which conflates a
-			// file count with a spec count: a spec with several .doc files
-			// could absorb the whole converted-file budget and drag an
-			// unrelated, fully-failed spec's status up to OK along with it.
+			// own .doc files produced a new .docx this run (partial success
+			// still counts, matching the .docx branch above). The old code
+			// used min(convertedFileCount, docOnlySpecCount), which
+			// conflates a file count with a spec count: a spec with several
+			// .doc files could absorb the whole converted-file budget and
+			// drag an unrelated, fully-failed spec's status up to OK along
+			// with it.
 			for _, docFiles := range docFilesBySpec {
 				for _, docPath := range docFiles {
-					if _, statErr := os.Stat(convertedDocxPath(docPath, outputDir)); statErr == nil {
+					out := convertedDocxPath(docPath, outputDir)
+					if preExisting[out] {
+						continue
+					}
+					if _, statErr := os.Stat(out); statErr == nil {
 						stats["DOC_ONLY"]--
 						stats["OK"]++
 						break

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -377,12 +377,24 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 			docPathClaimants[docPath][specID] = true
 		}
 	}
+	// unattributableBasenames is the set of converted .docx basenames whose
+	// source .doc path is unattributable: not just excluded from
+	// promotion, but never even published into outputDir. The publish loop
+	// below can't tell which spec's content the surviving .doc physically
+	// held (see case 3), so any file it converts to is an ownerless
+	// .docx that no spec should be credited for -- and its content may
+	// itself be a jumble of a racy write to a path two specs both
+	// extracted into. Skipping the publish, not just the promotion, keeps
+	// that ambiguous file out of outputDir entirely rather than leaving it
+	// there unowned.
 	unattributable := make(map[string]bool)
+	unattributableBasenames := make(map[string]bool)
 	for docPath, specIDSet := range docPathClaimants {
 		if len(specIDSet) <= 1 {
 			continue
 		}
 		unattributable[docPath] = true
+		unattributableBasenames[filepath.Base(convertedDocxPath(docPath, ""))] = true
 		specIDs := make([]string, 0, len(specIDSet))
 		for specID := range specIDSet {
 			specIDs = append(specIDs, specID)
@@ -448,6 +460,10 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				published := make(map[string]bool)
 				if convEntries, err := os.ReadDir(convDir); err == nil {
 					for _, e := range convEntries {
+						if unattributableBasenames[e.Name()] {
+							log.Printf("  publish converted %s: skipped, ambiguous ownership (shared .doc basename, see warning above)", e.Name())
+							continue
+						}
 						src := filepath.Join(convDir, e.Name())
 						dst := filepath.Join(outputDir, e.Name())
 						if err := os.Link(src, dst); err != nil {

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -42,6 +42,10 @@ type DownloadResult struct {
 	Status    string // "OK", "DOC_ONLY", "NO_DOC", "FAILED"
 	DocxFiles []string
 	YAMLFiles []string
+	// DocFiles holds the extracted .doc file paths when Status is DOC_ONLY,
+	// so callers that later run LibreOffice conversion on a shared directory
+	// can tell which converted .docx (if any) belongs to this spec.
+	DocFiles []string
 }
 
 // DownloadAndExtract downloads a spec zip and extracts .docx files to a temp directory.
@@ -150,15 +154,28 @@ func DownloadAndExtract(ctx context.Context, client *http.Client, spec *SpecVers
 			if err := os.MkdirAll(docDir, 0o700); err != nil {
 				log.Printf("  %s: failed to create doc dir: %v", spec.SpecID, err)
 			}
+			var extracted []string
 			for _, f := range r.File {
 				name := filepath.Base(f.Name)
 				if strings.HasSuffix(strings.ToLower(name), ".doc") && !strings.HasPrefix(name, ".") {
-					if err := extractFile(f, filepath.Join(docDir, name)); err != nil {
+					outPath := filepath.Join(docDir, name)
+					if err := extractFile(f, outPath); err != nil {
 						log.Printf("  %s: failed to extract %s: %v", spec.SpecID, name, err)
+					} else {
+						extracted = append(extracted, outPath)
 					}
 				}
 			}
+			// As with the .docx branch above, the archive listing .doc
+			// entries does not mean any of them actually landed on disk.
+			// Reporting DOC_ONLY here would tell the caller "install
+			// LibreOffice and retry" for a spec that has nothing to convert.
+			if len(extracted) == 0 {
+				result.Status = "FAILED"
+				return result, fmt.Errorf("extracted none of the %d .doc file(s) in the archive", len(docFiles))
+			}
 			result.Status = "DOC_ONLY"
+			result.DocFiles = extracted
 			return result, nil
 		}
 
@@ -239,8 +256,9 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 
 	sem := make(chan struct{}, parallel)
 	type result struct {
-		specID string
-		status string
+		specID   string
+		status   string
+		docFiles []string
 	}
 	results := make(chan result, total)
 	var wg sync.WaitGroup
@@ -262,10 +280,12 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				log.Printf("  %s: download error: %v", spec.SpecID, err)
 			}
 			status := "FAILED"
+			var docFiles []string
 			if r != nil {
 				status = r.Status
+				docFiles = r.DocFiles
 			}
-			results <- result{spec.SpecID, status}
+			results <- result{spec.SpecID, status, docFiles}
 		}()
 	}
 
@@ -274,11 +294,18 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 		close(results)
 	}()
 
+	// docFilesBySpec remembers, per DOC_ONLY spec, which .doc files were
+	// extracted for it into the shared docDir below, so a later conversion
+	// pass can attribute success or failure back to the right spec.
+	docFilesBySpec := make(map[string][]string)
 	i := 0
 	for r := range results {
 		i++
 		stats[r.status]++
 		log.Printf("[%d/%d] %s: %s", i, total, r.specID, r.status)
+		if r.status == "DOC_ONLY" && len(r.docFiles) > 0 {
+			docFilesBySpec[r.specID] = r.docFiles
+		}
 	}
 
 	if convertDoc {
@@ -290,18 +317,37 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				log.Printf("ConvertDocFiles error: %v", err)
 			}
 			log.Printf("Converted %d files", n)
-			if n > 0 && stats["DOC_ONLY"] > 0 {
-				converted := n
-				if converted > stats["DOC_ONLY"] {
-					converted = stats["DOC_ONLY"]
+			// A spec is promoted from DOC_ONLY to OK only when one of its
+			// own .doc files produced a .docx (partial success still
+			// counts, matching the .docx branch above). The old code used
+			// min(convertedFileCount, docOnlySpecCount), which conflates a
+			// file count with a spec count: a spec with several .doc files
+			// could absorb the whole converted-file budget and drag an
+			// unrelated, fully-failed spec's status up to OK along with it.
+			for _, docFiles := range docFilesBySpec {
+				for _, docPath := range docFiles {
+					if _, statErr := os.Stat(convertedDocxPath(docPath, outputDir)); statErr == nil {
+						stats["DOC_ONLY"]--
+						stats["OK"]++
+						break
+					}
 				}
-				stats["DOC_ONLY"] -= converted
-				stats["OK"] += converted
 			}
 		}
 	}
 
 	return stats
+}
+
+// convertedDocxPath returns the .docx path ConvertDocFiles would produce in
+// outputDir for a .doc file extracted at docPath: LibreOffice's --convert-to
+// keeps the input's basename and swaps the extension.
+func convertedDocxPath(docPath, outputDir string) string {
+	base := filepath.Base(docPath)
+	if ext := filepath.Ext(base); strings.EqualFold(ext, ".doc") {
+		base = base[:len(base)-len(ext)]
+	}
+	return filepath.Join(outputDir, base+".docx")
 }
 
 func downloadZip(ctx context.Context, client *http.Client, url string) ([]byte, error) {

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -311,48 +311,64 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 	if convertDoc {
 		docDir := filepath.Join(outputDir, "_doc_files")
 		if entries, err := os.ReadDir(docDir); err == nil && len(entries) > 0 {
-			// outputDir is the caller's persistent --output-dir: it is
-			// created but never cleared between runs (see cmdDownload), so
-			// a .docx left over from an earlier invocation can already sit
-			// at a spec's expected output path before conversion even
-			// starts. Record which expected outputs pre-date this run so a
-			// stale file is never mistaken for evidence that this run's
-			// LibreOffice conversion succeeded.
-			preExisting := make(map[string]bool)
-			for _, docFiles := range docFilesBySpec {
-				for _, docPath := range docFiles {
-					out := convertedDocxPath(docPath, outputDir)
-					if _, statErr := os.Stat(out); statErr == nil {
-						preExisting[out] = true
+			// Convert into a fresh, run-scoped scratch directory instead of
+			// outputDir directly. outputDir is the caller's persistent
+			// --output-dir (never cleared between runs, see cmdDownload)
+			// and can already hold a .docx at a spec's expected output path
+			// before conversion even starts this time — either a stale
+			// leftover from an earlier invocation, or, within this very
+			// run, another spec's own .docx that its download already
+			// extracted directly into outputDir (every spec's download and
+			// extraction completes before this block runs). A wall-clock
+			// "written since conversion started" check was tried and
+			// discarded: under load, this environment's file mtimes were
+			// observed landing before the in-process marker that preceded
+			// the write, so mtime cannot be trusted here either. Converting
+			// into an empty directory sidesteps all of that: any file
+			// appearing in it is unambiguously this run's output, no
+			// timing assumptions required. The results are moved into
+			// outputDir afterward to keep the flat layout other commands
+			// (e.g. import-dir) expect.
+			convDir, mkErr := os.MkdirTemp(outputDir, ".doc-convert-*")
+			if mkErr != nil {
+				log.Printf("doc conversion scratch dir error: %v", mkErr)
+			} else {
+				log.Println("Converting .doc files to .docx...")
+				n, err := ConvertDocFiles(ctx, docDir, convDir)
+				if err != nil {
+					log.Printf("ConvertDocFiles error: %v", err)
+				}
+				log.Printf("Converted %d files", n)
+				// A spec is promoted from DOC_ONLY to OK only when one of
+				// its own .doc files produced a .docx in convDir this run
+				// (partial success still counts, matching the .docx branch
+				// above). The old code used
+				// min(convertedFileCount, docOnlySpecCount), which
+				// conflates a file count with a spec count: a spec with
+				// several .doc files could absorb the whole converted-file
+				// budget and drag an unrelated, fully-failed spec's status
+				// up to OK along with it.
+				for _, docFiles := range docFilesBySpec {
+					for _, docPath := range docFiles {
+						if _, statErr := os.Stat(convertedDocxPath(docPath, convDir)); statErr == nil {
+							stats["DOC_ONLY"]--
+							stats["OK"]++
+							break
+						}
 					}
 				}
-			}
 
-			log.Println("Converting .doc files to .docx...")
-			n, err := ConvertDocFiles(ctx, docDir, outputDir)
-			if err != nil {
-				log.Printf("ConvertDocFiles error: %v", err)
-			}
-			log.Printf("Converted %d files", n)
-			// A spec is promoted from DOC_ONLY to OK only when one of its
-			// own .doc files produced a new .docx this run (partial success
-			// still counts, matching the .docx branch above). The old code
-			// used min(convertedFileCount, docOnlySpecCount), which
-			// conflates a file count with a spec count: a spec with several
-			// .doc files could absorb the whole converted-file budget and
-			// drag an unrelated, fully-failed spec's status up to OK along
-			// with it.
-			for _, docFiles := range docFilesBySpec {
-				for _, docPath := range docFiles {
-					out := convertedDocxPath(docPath, outputDir)
-					if preExisting[out] {
-						continue
+				if convEntries, err := os.ReadDir(convDir); err == nil {
+					for _, e := range convEntries {
+						src := filepath.Join(convDir, e.Name())
+						dst := filepath.Join(outputDir, e.Name())
+						if err := os.Rename(src, dst); err != nil {
+							log.Printf("  move converted %s: %v", e.Name(), err)
+						}
 					}
-					if _, statErr := os.Stat(out); statErr == nil {
-						stats["DOC_ONLY"]--
-						stats["OK"]++
-						break
-					}
+				}
+				if err := os.RemoveAll(convDir); err != nil {
+					log.Printf("  cleanup doc conversion scratch dir: %v", err)
 				}
 			}
 		}

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -308,6 +308,30 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 		}
 	}
 
+	// docPathClaimants maps each shared docDir path to every DOC_ONLY spec
+	// that recorded it. Two specs whose .doc files share a basename both
+	// extract into the same path in the flat, shared docDir, so the second
+	// extraction silently overwrites the first: only one spec's content
+	// physically survives to be converted, but both specs' docFilesBySpec
+	// entries still point at that same surviving path. An existence check
+	// on the converted output can't tell whose file actually made it
+	// through, so any path claimed by more than one spec is treated as
+	// unattributable for all of them rather than risk crediting a spec
+	// whose own file was clobbered before conversion ever ran.
+	docPathClaimants := make(map[string][]string)
+	for specID, docFiles := range docFilesBySpec {
+		for _, docPath := range docFiles {
+			docPathClaimants[docPath] = append(docPathClaimants[docPath], specID)
+		}
+	}
+	unattributable := make(map[string]bool)
+	for docPath, specIDs := range docPathClaimants {
+		if len(specIDs) > 1 {
+			unattributable[docPath] = true
+			log.Printf("  warning: %s share a same-named .doc file (%s); none will be promoted from it", strings.Join(specIDs, ", "), filepath.Base(docPath))
+		}
+	}
+
 	if convertDoc {
 		docDir := filepath.Join(outputDir, "_doc_files")
 		if entries, err := os.ReadDir(docDir); err == nil && len(entries) > 0 {
@@ -350,6 +374,9 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				// up to OK along with it.
 				for _, docFiles := range docFilesBySpec {
 					for _, docPath := range docFiles {
+						if unattributable[docPath] {
+							continue
+						}
 						if _, statErr := os.Stat(convertedDocxPath(docPath, convDir)); statErr == nil {
 							stats["DOC_ONLY"]--
 							stats["OK"]++

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -363,11 +363,38 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 					log.Printf("ConvertDocFiles error: %v", err)
 				}
 				log.Printf("Converted %d files", n)
+
+				// Publish every converted file into outputDir before
+				// deciding any promotion, and track which basenames
+				// actually made it there. Deciding OK from mere existence
+				// in convDir (as an earlier version of this fix did) could
+				// report a spec OK and then have the evidence vanish: if
+				// the rename below failed for that file -- outputDir
+				// already holds a same-named directory, a permissions
+				// problem, anything -- the .docx never reached outputDir,
+				// yet the scratch-dir cleanup at the end of this block
+				// would delete the only copy that had ever existed,
+				// leaving the reported OK status orphaned from any real
+				// file. Only a file that is confirmed moved counts as
+				// evidence a spec's conversion succeeded.
+				published := make(map[string]bool)
+				if convEntries, err := os.ReadDir(convDir); err == nil {
+					for _, e := range convEntries {
+						src := filepath.Join(convDir, e.Name())
+						dst := filepath.Join(outputDir, e.Name())
+						if err := os.Rename(src, dst); err != nil {
+							log.Printf("  publish converted %s: %v", e.Name(), err)
+							continue
+						}
+						published[e.Name()] = true
+					}
+				}
+
 				// A spec is promoted from DOC_ONLY to OK only when one of
-				// its own .doc files produced a .docx in convDir this run
-				// (partial success still counts, matching the .docx branch
-				// above). The old code used
-				// min(convertedFileCount, docOnlySpecCount), which
+				// its own .doc files was both converted and successfully
+				// published into outputDir this run (partial success still
+				// counts, matching the .docx branch above). The old code
+				// used min(convertedFileCount, docOnlySpecCount), which
 				// conflates a file count with a spec count: a spec with
 				// several .doc files could absorb the whole converted-file
 				// budget and drag an unrelated, fully-failed spec's status
@@ -377,23 +404,16 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 						if unattributable[docPath] {
 							continue
 						}
-						if _, statErr := os.Stat(convertedDocxPath(docPath, convDir)); statErr == nil {
-							stats["DOC_ONLY"]--
-							stats["OK"]++
-							break
+						base := filepath.Base(convertedDocxPath(docPath, ""))
+						if !published[base] {
+							continue
 						}
+						stats["DOC_ONLY"]--
+						stats["OK"]++
+						break
 					}
 				}
 
-				if convEntries, err := os.ReadDir(convDir); err == nil {
-					for _, e := range convEntries {
-						src := filepath.Join(convDir, e.Name())
-						dst := filepath.Join(outputDir, e.Name())
-						if err := os.Rename(src, dst); err != nil {
-							log.Printf("  move converted %s: %v", e.Name(), err)
-						}
-					}
-				}
 				if err := os.RemoveAll(convDir); err != nil {
 					log.Printf("  cleanup doc conversion scratch dir: %v", err)
 				}

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -447,6 +447,50 @@ func TestDownloadSpecs_ConvertDocSameBatchBasenameCollision(t *testing.T) {
 	}
 }
 
+// TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly verifies
+// that two DOC_ONLY specs whose .doc files share a basename are never both
+// promoted to OK (2nd Greptile review finding). Both extract into the same
+// path in the shared, flat _doc_files directory, so one extraction silently
+// overwrites the other and only one spec's content survives to be
+// converted; an existence check on the single resulting .docx cannot tell
+// which spec it actually belongs to, so neither should be credited.
+func TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zipF := makeZipWithFiles(t, map[string][]byte{
+		"collide.doc": []byte("from spec F"),
+	})
+	zipG := makeZipWithFiles(t, map[string][]byte{
+		"collide.doc": []byte("from spec G"),
+	})
+
+	tsF := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipF)
+	}))
+	defer tsF.Close()
+	tsG := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipG)
+	}))
+	defer tsG.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.006", URL: tsF.URL + "/f.zip"},
+		{SpecID: "TS 88.007", URL: tsG.URL + "/g.zip"},
+	}
+
+	outputDir := t.TempDir()
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 0 {
+		t.Errorf("OK = %d, want 0 (the surviving .doc can't be safely attributed to either spec)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 2 {
+		t.Errorf("DOC_ONLY = %d, want 2 (both specs stay DOC_ONLY rather than risk a false OK)", stats["DOC_ONLY"])
+	}
+}
+
 // TestConvertDocFiles_NoDocFiles verifies ConvertDocFiles returns (0, nil)
 // when the directory contains no .doc files (happy but trivial path).
 func TestConvertDocFiles_NoDocFiles(t *testing.T) {

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -466,7 +466,10 @@ func TestDownloadSpecs_ConvertDocDirectVsConvertedCollision_PreservesExisting(t 
 // extraction silently overwrites the other and only one spec's content
 // survives to be converted; an existence check on the single resulting
 // .docx cannot tell which spec it actually belongs to, so neither should be
-// credited.
+// credited. The converted file must also never reach outputDir at all: an
+// earlier version of this fix skipped promotion but still published the
+// ambiguous result, leaving an ownerless .docx that neither spec was
+// credited for (a later Greptile review finding on this same test).
 func TestDownloadSpecs_ConvertDocConvertedVsConvertedCollision_NeitherPromoted(t *testing.T) {
 	writeFakeLibreOffice(t)
 
@@ -501,6 +504,10 @@ func TestDownloadSpecs_ConvertDocConvertedVsConvertedCollision_NeitherPromoted(t
 	}
 	if stats["DOC_ONLY"] != 2 {
 		t.Errorf("DOC_ONLY = %d, want 2 (both specs stay DOC_ONLY rather than risk a false OK)", stats["DOC_ONLY"])
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "collide.docx")); !os.IsNotExist(err) {
+		t.Errorf("collide.docx stat = %v, want it absent from outputDir (ambiguous ownership must not be published)", err)
 	}
 }
 

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -360,6 +360,45 @@ func TestDownloadSpecs_ConvertDocPerSpec(t *testing.T) {
 	}
 }
 
+// TestDownloadSpecs_ConvertDocIgnoresStaleOutput verifies that a leftover
+// .docx from an earlier invocation of this command does not get mistaken for
+// evidence that this run's conversion succeeded (ocr review finding on
+// #143's fix). outputDir is the caller's persistent --output-dir and is
+// never cleared between runs, so a stale file can already sit at a spec's
+// expected output path before conversion even starts this time.
+func TestDownloadSpecs_ConvertDocIgnoresStaleOutput(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zip := makeZipWithFiles(t, map[string][]byte{
+		"specC-fail.doc": []byte("c1"),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zip)
+	}))
+	defer ts.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.003", URL: ts.URL + "/c.zip"},
+	}
+
+	outputDir := t.TempDir()
+	// Plant a stale .docx at the exact path this spec's .doc file would
+	// convert to, simulating leftover output from an earlier run.
+	if err := os.WriteFile(filepath.Join(outputDir, "specC-fail.docx"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 0 {
+		t.Errorf("OK = %d, want 0 (this run's conversion failed; the stale .docx must not count)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 1 {
+		t.Errorf("DOC_ONLY = %d, want 1", stats["DOC_ONLY"])
+	}
+}
+
 // TestConvertDocFiles_NoDocFiles verifies ConvertDocFiles returns (0, nil)
 // when the directory contains no .doc files (happy but trivial path).
 func TestConvertDocFiles_NoDocFiles(t *testing.T) {

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -399,6 +399,54 @@ func TestDownloadSpecs_ConvertDocIgnoresStaleOutput(t *testing.T) {
 	}
 }
 
+// TestDownloadSpecs_ConvertDocSameBatchBasenameCollision verifies that a
+// same-batch, different spec's freshly-extracted .docx does not block a
+// DOC_ONLY spec's own promotion just because it happens to share a basename
+// (Greptile review finding on the stale-output fix above). SpecD's archive
+// ships an already-converted "shared.docx" directly (its DownloadAndExtract
+// call returns OK), landing in outputDir before SpecE's .doc conversion
+// runs. SpecE's own .doc file happens to convert to that very path
+// ("shared.doc" -> "shared.docx"); an existence check alone cannot tell that
+// apart from a stale leftover and would wrongly leave SpecE at DOC_ONLY, so
+// the promotion must be based on whether the file was written at or after
+// conversion started, not merely on whether it exists.
+func TestDownloadSpecs_ConvertDocSameBatchBasenameCollision(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zipD := makeZipWithFiles(t, map[string][]byte{
+		"shared.docx": []byte("already a docx"),
+	})
+	zipE := makeZipWithFiles(t, map[string][]byte{
+		"shared.doc": []byte("needs conversion"),
+	})
+
+	tsD := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipD)
+	}))
+	defer tsD.Close()
+	tsE := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipE)
+	}))
+	defer tsE.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.004", URL: tsD.URL + "/d.zip"},
+		{SpecID: "TS 88.005", URL: tsE.URL + "/e.zip"},
+	}
+
+	outputDir := t.TempDir()
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 2 {
+		t.Errorf("OK = %d, want 2 (SpecD's own .docx plus SpecE's converted .doc)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 0 {
+		t.Errorf("DOC_ONLY = %d, want 0 (SpecE's conversion succeeded despite the basename collision)", stats["DOC_ONLY"])
+	}
+}
+
 // TestConvertDocFiles_NoDocFiles verifies ConvertDocFiles returns (0, nil)
 // when the directory contains no .doc files (happy but trivial path).
 func TestConvertDocFiles_NoDocFiles(t *testing.T) {

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -491,6 +491,57 @@ func TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly(t *testing.
 	}
 }
 
+// TestDownloadSpecs_ConvertDocPublishFailureStaysDocOnly verifies that a spec
+// is never reported OK when its converted .docx fails to publish into
+// outputDir (3rd Greptile review finding). Before this fix, promotion was
+// decided from mere existence in the scratch conversion directory: if the
+// subsequent os.Rename into outputDir then failed, the spec had already been
+// counted OK, and the scratch-dir cleanup that follows would delete the only
+// copy of the file that had ever existed -- leaving an "OK" spec with no
+// .docx anywhere. This plants a directory at the exact path the converted
+// .docx would publish to, which makes os.Rename fail deterministically
+// (renaming a regular file onto a directory always errors), and checks the
+// spec stays DOC_ONLY with the scratch file gone rather than orphaned.
+func TestDownloadSpecs_ConvertDocPublishFailureStaysDocOnly(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zip := makeZipWithFiles(t, map[string][]byte{
+		"blocked.doc": []byte("h1"),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zip)
+	}))
+	defer ts.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.008", URL: ts.URL + "/h.zip"},
+	}
+
+	outputDir := t.TempDir()
+	// A directory at the expected publish path makes the rename fail: you
+	// cannot rename a regular file onto an existing directory.
+	if err := os.MkdirAll(filepath.Join(outputDir, "blocked.docx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 0 {
+		t.Errorf("OK = %d, want 0 (the converted .docx never published into outputDir)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 1 {
+		t.Errorf("DOC_ONLY = %d, want 1", stats["DOC_ONLY"])
+	}
+
+	// The blocking directory must still be the untouched directory it was:
+	// the rename must not have partially clobbered it.
+	info, err := os.Stat(filepath.Join(outputDir, "blocked.docx"))
+	if err != nil || !info.IsDir() {
+		t.Errorf("blocked.docx = %v (isDir=%v), want the original directory intact", err, info != nil && info.IsDir())
+	}
+}
+
 // TestConvertDocFiles_NoDocFiles verifies ConvertDocFiles returns (0, nil)
 // when the directory contains no .doc files (happy but trivial path).
 func TestConvertDocFiles_NoDocFiles(t *testing.T) {

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -138,6 +138,33 @@ func TestDownloadAndExtract_DocOnly(t *testing.T) {
 	}
 }
 
+// TestDownloadAndExtract_AllDocExtractionsFail verifies that a ZIP whose only
+// .doc entry cannot be extracted is reported FAILED, not DOC_ONLY (#143): a
+// DOC_ONLY status with nothing on disk to convert misdirects the operator
+// toward "install LibreOffice and retry" for a spec that has nothing to
+// retry.
+func TestDownloadAndExtract_AllDocExtractionsFail(t *testing.T) {
+	zipBytes := makeRawZipEntry(t, "../evil.doc", []byte("pwned"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipBytes)
+	}))
+	defer ts.Close()
+
+	outDir := t.TempDir()
+	spec := &SpecVersion{SpecID: "TS 99.005", URL: ts.URL + "/z2.zip"}
+	result, err := DownloadAndExtract(context.Background(), ts.Client(), spec, outDir, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected an error when no .doc could be extracted")
+	}
+	if result.Status != "FAILED" {
+		t.Errorf("status = %q, want FAILED", result.Status)
+	}
+	if len(result.DocFiles) != 0 {
+		t.Errorf("DocFiles = %v, want none", result.DocFiles)
+	}
+}
+
 // TestDownloadAndExtract_NoDoc verifies the NO_DOC status when the ZIP holds
 // only irrelevant files.
 func TestDownloadAndExtract_NoDoc(t *testing.T) {
@@ -248,6 +275,88 @@ func TestDownloadZip_HTTPError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HTTP 500") {
 		t.Errorf("error = %v, want 'HTTP 500'", err)
+	}
+}
+
+// writeFakeLibreOffice installs a fake "libreoffice" executable on PATH that
+// mimics --convert-to docx --outdir DIR FILE without needing real
+// LibreOffice: any input whose basename contains "fail" exits non-zero and
+// writes nothing; every other input writes an empty same-name .docx into the
+// --outdir directory, exactly where the real conversion would.
+func writeFakeLibreOffice(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+# PATH is overridden to just this directory for the test, so this script
+# must not rely on external utilities like basename -- pure shell parameter
+# expansion only.
+outdir=""
+prev=""
+last=""
+for arg in "$@"; do
+  if [ "$prev" = "--outdir" ]; then
+    outdir="$arg"
+  fi
+  last="$arg"
+  prev="$arg"
+done
+base="${last##*/}"
+case "$base" in
+  *fail*) exit 1 ;;
+esac
+name="${base%.*}"
+echo "converted" > "$outdir/$name.docx"
+exit 0
+`
+	path := filepath.Join(dir, "libreoffice")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+// TestDownloadSpecs_ConvertDocPerSpec verifies DOC_ONLY->OK promotion is
+// attributed per spec instead of by a blind min(convertedFileCount,
+// docOnlySpecCount) (#143). SpecA ships two .doc files that both convert
+// (partial success still counts as OK); SpecB ships a single .doc file whose
+// conversion fails outright and must stay DOC_ONLY. The old min()-based logic
+// would promote both specs to OK here, because two files convert overall
+// while only two specs are DOC_ONLY.
+func TestDownloadSpecs_ConvertDocPerSpec(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zipA := makeZipWithFiles(t, map[string][]byte{
+		"specA-part1.doc": []byte("a1"),
+		"specA-part2.doc": []byte("a2"),
+	})
+	zipB := makeZipWithFiles(t, map[string][]byte{
+		"specB-fail.doc": []byte("b1"),
+	})
+
+	tsA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipA)
+	}))
+	defer tsA.Close()
+	tsB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipB)
+	}))
+	defer tsB.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.001", URL: tsA.URL + "/a.zip"},
+		{SpecID: "TS 88.002", URL: tsB.URL + "/b.zip"},
+	}
+
+	outputDir := t.TempDir()
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 1 {
+		t.Errorf("OK = %d, want 1 (only SpecA converted)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 1 {
+		t.Errorf("DOC_ONLY = %d, want 1 (SpecB's conversion failed)", stats["DOC_ONLY"])
 	}
 }
 

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -360,12 +360,14 @@ func TestDownloadSpecs_ConvertDocPerSpec(t *testing.T) {
 	}
 }
 
-// TestDownloadSpecs_ConvertDocIgnoresStaleOutput verifies that a leftover
-// .docx from an earlier invocation of this command does not get mistaken for
-// evidence that this run's conversion succeeded (ocr review finding on
-// #143's fix). outputDir is the caller's persistent --output-dir and is
-// never cleared between runs, so a stale file can already sit at a spec's
-// expected output path before conversion even starts this time.
+// TestDownloadSpecs_ConvertDocIgnoresStaleOutput covers collision matrix
+// case 5 (this run's converted output vs. a stale leftover from an earlier
+// invocation): a leftover .docx from an earlier invocation of this command
+// does not get mistaken for evidence that this run's conversion succeeded
+// (ocr review finding on #143's fix). outputDir is the caller's persistent
+// --output-dir and is never cleared between runs, so a stale file can
+// already sit at a spec's expected output path before conversion even
+// starts this time.
 func TestDownloadSpecs_ConvertDocIgnoresStaleOutput(t *testing.T) {
 	writeFakeLibreOffice(t)
 
@@ -399,18 +401,19 @@ func TestDownloadSpecs_ConvertDocIgnoresStaleOutput(t *testing.T) {
 	}
 }
 
-// TestDownloadSpecs_ConvertDocSameBatchBasenameCollision verifies that a
-// same-batch, different spec's freshly-extracted .docx does not block a
-// DOC_ONLY spec's own promotion just because it happens to share a basename
-// (Greptile review finding on the stale-output fix above). SpecD's archive
+// TestDownloadSpecs_ConvertDocDirectVsConvertedCollision_PreservesExisting
+// covers collision matrix case 2 (direct .docx vs. converted .doc->.docx,
+// same batch): a converted file must never overwrite another spec's real
+// output that happens to share its basename (Greptile review finding on an
+// earlier version of this fix, which let the rename through as long as it
+// happened "this run" -- landing at the right path wasn't enough, it also
+// must not destroy someone else's file already there). SpecD's archive
 // ships an already-converted "shared.docx" directly (its DownloadAndExtract
 // call returns OK), landing in outputDir before SpecE's .doc conversion
 // runs. SpecE's own .doc file happens to convert to that very path
-// ("shared.doc" -> "shared.docx"); an existence check alone cannot tell that
-// apart from a stale leftover and would wrongly leave SpecE at DOC_ONLY, so
-// the promotion must be based on whether the file was written at or after
-// conversion started, not merely on whether it exists.
-func TestDownloadSpecs_ConvertDocSameBatchBasenameCollision(t *testing.T) {
+// ("shared.doc" -> "shared.docx"); SpecE must lose that race and stay
+// DOC_ONLY, and SpecD's original content must survive untouched.
+func TestDownloadSpecs_ConvertDocDirectVsConvertedCollision_PreservesExisting(t *testing.T) {
 	writeFakeLibreOffice(t)
 
 	zipD := makeZipWithFiles(t, map[string][]byte{
@@ -439,22 +442,32 @@ func TestDownloadSpecs_ConvertDocSameBatchBasenameCollision(t *testing.T) {
 	outputDir := t.TempDir()
 	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
 
-	if stats["OK"] != 2 {
-		t.Errorf("OK = %d, want 2 (SpecD's own .docx plus SpecE's converted .doc)", stats["OK"])
+	if stats["OK"] != 1 {
+		t.Errorf("OK = %d, want 1 (only SpecD's own direct .docx)", stats["OK"])
 	}
-	if stats["DOC_ONLY"] != 0 {
-		t.Errorf("DOC_ONLY = %d, want 0 (SpecE's conversion succeeded despite the basename collision)", stats["DOC_ONLY"])
+	if stats["DOC_ONLY"] != 1 {
+		t.Errorf("DOC_ONLY = %d, want 1 (SpecE loses the publish race and stays DOC_ONLY)", stats["DOC_ONLY"])
+	}
+
+	got, err := os.ReadFile(filepath.Join(outputDir, "shared.docx"))
+	if err != nil {
+		t.Fatalf("read shared.docx: %v", err)
+	}
+	if string(got) != "already a docx" {
+		t.Errorf("shared.docx content = %q, want %q (SpecE's conversion must not have overwritten it)", got, "already a docx")
 	}
 }
 
-// TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly verifies
-// that two DOC_ONLY specs whose .doc files share a basename are never both
-// promoted to OK (2nd Greptile review finding). Both extract into the same
-// path in the shared, flat _doc_files directory, so one extraction silently
-// overwrites the other and only one spec's content survives to be
-// converted; an existence check on the single resulting .docx cannot tell
-// which spec it actually belongs to, so neither should be credited.
-func TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly(t *testing.T) {
+// TestDownloadSpecs_ConvertDocConvertedVsConvertedCollision_NeitherPromoted
+// covers collision matrix case 3 (converted .doc vs. converted .doc, two
+// different specs): two DOC_ONLY specs whose .doc files share a basename
+// must never both be promoted to OK (Greptile review finding). Both extract
+// into the same path in the shared, flat _doc_files directory, so one
+// extraction silently overwrites the other and only one spec's content
+// survives to be converted; an existence check on the single resulting
+// .docx cannot tell which spec it actually belongs to, so neither should be
+// credited.
+func TestDownloadSpecs_ConvertDocConvertedVsConvertedCollision_NeitherPromoted(t *testing.T) {
 	writeFakeLibreOffice(t)
 
 	zipF := makeZipWithFiles(t, map[string][]byte{
@@ -488,6 +501,44 @@ func TestDownloadSpecs_ConvertDocSameBasenameAcrossSpecsStaysDocOnly(t *testing.
 	}
 	if stats["DOC_ONLY"] != 2 {
 		t.Errorf("DOC_ONLY = %d, want 2 (both specs stay DOC_ONLY rather than risk a false OK)", stats["DOC_ONLY"])
+	}
+}
+
+// TestDownloadSpecs_ConvertDocDuplicateBasenameWithinOneSpec covers
+// collision matrix case 4 (duplicate basenames within one spec's OWN
+// archive): a single spec's zip has two different .doc entries under
+// different subfolders that both flatten to the same basename on
+// extraction ("partA/dup.doc" and "partB/dup.doc" both become "dup.doc").
+// Before this fix, docPathClaimants counted the spec's own repeated claim
+// on that one path as if two different specs had claimed it, wrongly
+// treating the spec as colliding with itself and leaving it at DOC_ONLY
+// even though its own (single surviving) .doc file converts and publishes
+// cleanly with no other spec involved at all.
+func TestDownloadSpecs_ConvertDocDuplicateBasenameWithinOneSpec(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zip := makeZipWithFiles(t, map[string][]byte{
+		"partA/dup.doc": []byte("from partA"),
+		"partB/dup.doc": []byte("from partB"),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zip)
+	}))
+	defer ts.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.009", URL: ts.URL + "/i.zip"},
+	}
+
+	outputDir := t.TempDir()
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+
+	if stats["OK"] != 1 {
+		t.Errorf("OK = %d, want 1 (the spec's own duplicate .doc basenames must not look like a cross-spec collision)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 0 {
+		t.Errorf("DOC_ONLY = %d, want 0", stats["DOC_ONLY"])
 	}
 }
 

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -21,8 +21,12 @@ import (
 )
 
 // docxVersionRE matches 3GPP docx filenames like "21900-j10.docx" or
-// "38101-1-j50.docx" to capture the base-36 version token.
-var docxVersionRE = regexp.MustCompile(`(?i)-([0-9a-z]{2,})\.docx$`)
+// "38101-1-j50.docx" to capture the base-36 version token. It anchors on the
+// leading 5-digit spec number (series+number) and optional multi-part suffix
+// instead of matching the last "-xxx" before ".docx", so a split-spec chunk
+// suffix appended after the token (e.g. "36133-920_s00-11.docx") is never
+// mistaken for the version token itself.
+var docxVersionRE = regexp.MustCompile(`(?i)^\d{2}\d{3}(?:-\d{1,2})?-?([0-9a-z]{3})`)
 
 // releaseFromDocxFilename extracts the release number from a 3GPP docx filename.
 // The release is encoded in the first character of the version token (base-36:

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -696,11 +696,18 @@ func TestConvertSingleFile_BadPath(t *testing.T) {
 // used to populate the Release column when importing single files.
 func TestReleaseFromDocxFilename(t *testing.T) {
 	cases := map[string]int{
-		"23501-i30.docx": 18,
-		"24229-h50.docx": 17,
-		"29510-f60.docx": 15,
-		"weirdname.docx": 0,
-		"23501.docx":     0,
+		"23501-i30.docx":   18,
+		"24229-h50.docx":   17,
+		"29510-f60.docx":   15,
+		"weirdname.docx":   0,
+		"23501.docx":       0,
+		"38101-1-j50.docx": 19,
+		// #131: a split-spec chunk suffix ("_s00-11") must not be mistaken
+		// for the version token — the real token ("920") sits right after
+		// the spec number, and its first digit (9) is the release.
+		"36133-920_s00-11.docx":     9,
+		"38101-1-k00_s00-05.docx":   20,
+		"38101-1-k00_sAnnexes.docx": 20,
 	}
 	for in, want := range cases {
 		if got := releaseFromDocxFilename(in); got != want {


### PR DESCRIPTION
## Summary

- Fix `docxVersionRE` misparsing split-spec chunk filenames (e.g. `36133-920_s00-11.docx`) as release 1 instead of 9, by anchoring on the leading spec number instead of the trailing `-xxx` before `.docx`.
- Report `.doc` extraction/conversion status per actual outcome instead of a blind file-vs-spec count `min()`: `DownloadAndExtract` now returns FAILED (not DOC_ONLY) when zero `.doc` files land on disk, and `DownloadSpecs` attributes DOC_ONLY→OK promotion per spec based on whether that spec's own `.doc` files produced a new `.docx` this run (ignoring any stale `.docx` left over from an earlier invocation of the same `--output-dir`).
- Fix `LoadCache` returning `nil` for both a cache miss and a legitimately empty-but-present cache file, which defeated caching for filters with zero matching specs.

Fixes #131
Fixes #143
Fixes #144

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test -short ./...` — all packages pass
- [x] Added regression tests: split-spec chunk filename → release 9 (plus existing filenames unaffected), `.doc` extraction-all-fail → FAILED, per-spec DOC_ONLY→OK promotion (including a stale-output edge case), empty-cache-is-a-hit-within-TTL
- [x] Reviewed with `ocr review`; addressed the one real finding (stale `.docx` from a prior run could cause a false OK promotion) with a fix + test