### PR TITLE
fix(db): sanitize unknown columns, phrase prefixes and NEAR groups in FTS5 queries

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -990,12 +990,16 @@ var fts5Operators = map[string]bool{
 // column-filter/NOT operator), a period (e.g. spec numbers like "38.101",
 // which FTS5 otherwise rejects with "syntax error near \".\""), a stray
 // double quote, a parenthesis riding along inside the token (an unquoted
-// "(38.331" or "SMF)" is a hard syntax error), or a star (valid only as a
+// "(38.331" or "SMF)" is a hard syntax error), a star (valid only as a
 // trailing prefix operator; quoteFTS5Term keeps that meaning and quotes
 // every other placement, so a bare "*" degrades to no results instead of
-// "unknown special query").
+// "unknown special query"), a comma (only valid as the NEAR distance
+// separator, so "AMF, SMF" is a syntax error), or a colon (valid only as
+// the separator of a column filter naming a real column, which
+// classifyToken checks before falling back here: "NOTE: mentions" would
+// otherwise fail the whole match with "no such column: NOTE").
 func needsFTS5Quoting(s string) bool {
-	return strings.ContainsAny(s, `-."()*`)
+	return strings.ContainsAny(s, `-."()*,:`)
 }
 
 // quoteFTS5String wraps s in double quotes, doubling any quote already
@@ -1018,12 +1022,17 @@ func quoteFTS5Term(s string) string {
 }
 
 // classifyToken quotes a bareword or "col:val" column-filter token if it
-// contains a character FTS5 cannot parse in an unquoted bareword.
+// contains a character FTS5 cannot parse in an unquoted bareword. Only a
+// prefix naming a real column of sections_fts is treated as a column filter
+// (FTS5 matches column names case-insensitively, so the lookup does too);
+// anything else before the colon is ordinary query text and is quoted along
+// with the rest of the token, because FTS5 answers an unknown column with a
+// hard "no such column" error that fails the entire search.
 func classifyToken(token string) string {
 	if colIdx := strings.IndexByte(token, ':'); colIdx > 0 {
 		col := token[:colIdx]
 		val := token[colIdx+1:]
-		if fts5Columns[col] {
+		if fts5Columns[strings.ToLower(col)] {
 			if val == "" {
 				// "content:" with no value is a syntax error; treat the
 				// whole token as a literal search term instead.
@@ -1048,6 +1057,96 @@ func classifyToken(token string) string {
 		return quoteFTS5Term(token)
 	}
 	return token
+}
+
+// splitFTS5Tokens splits s on whitespace, keeping a double-quoted phrase —
+// including the spaces inside it — in a single token.
+func splitFTS5Tokens(s string) []string {
+	var tokens []string
+	i, n := 0, len(s)
+	for i < n {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' {
+			i++
+			continue
+		}
+		j := i
+		for j < n && s[j] != ' ' && s[j] != '\t' && s[j] != '\n' {
+			if s[j] == '"' {
+				j++
+				for j < n && s[j] != '"' {
+					j++
+				}
+				if j < n {
+					j++
+				}
+				continue
+			}
+			j++
+		}
+		tokens = append(tokens, s[i:j])
+		i = j
+	}
+	return tokens
+}
+
+// isDecimal reports whether s is a non-empty run of ASCII digits.
+func isDecimal(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// quoteNEAROperand applies to one operand of a NEAR group the same quoting a
+// standalone term gets. An operand is a phrase or a bareword only: a column
+// filter belongs outside the group (content:NEAR(a b)) and AND/OR/NOT are
+// syntax errors inside it, so both are quoted as literal text.
+func quoteNEAROperand(token string) string {
+	if strings.HasPrefix(token, "\"") {
+		body, star := token, ""
+		if stem, ok := strings.CutSuffix(body, "*"); ok && len(stem) >= 2 && strings.HasSuffix(stem, "\"") {
+			body, star = stem, "*"
+		}
+		if len(body) < 2 || !strings.HasSuffix(body, "\"") {
+			// Unterminated phrase; supply the missing closing quote.
+			body += "\""
+		}
+		return body + star
+	}
+	if fts5Operators[token] || needsFTS5Quoting(token) {
+		return quoteFTS5Term(token)
+	}
+	return token
+}
+
+// sanitizeNEARGroup quotes the operands of a balanced NEAR(...) group. FTS5
+// parses a NEAR operand exactly as it parses a standalone term, so a dotted
+// or hyphenated bareword — NEAR(38.101 23.501), NEAR(IMS-AKA SMF) — is the
+// same hard syntax error there, and it rejects the whole MATCH. The group's
+// own syntax is preserved: the NEAR( ) wrapper and a trailing ", N" distance.
+func sanitizeNEARGroup(run string) string {
+	body := run[len("NEAR(") : len(run)-1]
+
+	// FTS5 allows one trailing ", N" distance and nothing else after it, so
+	// only a final all-digit tail is kept as the distance; any other comma is
+	// query text and is quoted along with its token.
+	distance := ""
+	if idx := strings.LastIndexByte(body, ','); idx >= 0 {
+		if tail := strings.TrimSpace(body[idx+1:]); isDecimal(tail) {
+			body, distance = body[:idx], ", "+tail
+		}
+	}
+
+	operands := splitFTS5Tokens(body)
+	for i, token := range operands {
+		operands[i] = quoteNEAROperand(token)
+	}
+	return "NEAR(" + strings.Join(operands, " ") + distance + ")"
 }
 
 // sanitizeFTS5Query wraps bare hyphenated or dotted tokens in double quotes
@@ -1082,6 +1181,13 @@ func sanitizeFTS5Query(query string) string {
 				// An unterminated phrase would reach FTS5 as a syntax
 				// error; supply the missing closing quote.
 				run += "\""
+			} else if j < n && query[j] == '*' {
+				// "38.101"* is a prefix phrase. Splitting the star off into
+				// its own token silently demoted it to an exact phrase
+				// match, so keep it attached. A second star is left behind
+				// as a separate token ("a"** is a syntax error).
+				run += "*"
+				j++
 			}
 			result = append(result, run)
 			i = j
@@ -1115,6 +1221,8 @@ func sanitizeFTS5Query(query string) string {
 				return r == '"' || unicode.IsLetter(r) || unicode.IsDigit(r)
 			}) {
 				run = quoteFTS5String(query[i:j])
+			} else {
+				run = sanitizeNEARGroup(run)
 			}
 			result = append(result, run)
 			i = j

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -424,6 +424,25 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"multi-word phrase column filter kept whole", `content:"core network"`, `content:"core network"`},
 		{"multi-word phrase column filter with trailing term", `title:"band requirements" AMF`, `title:"band requirements" AMF`},
 		{"unterminated multi-word phrase column filter repaired", `content:"core network`, `content:"core network"`},
+		{"unknown column quoted literally", "NOTE: mentions", `"NOTE:" mentions`},
+		{"unknown column with value quoted literally", "NOTE:mentions", `"NOTE:mentions"`},
+		{"leading colon quoted literally", ":foo", `":foo"`},
+		{"colon inside column filter value quoted", "content:a:b", `content:"a:b"`},
+		{"column name matched case-insensitively", "Content:band", "Content:band"},
+		{"bare comma quoted", "AMF, SMF", `"AMF," SMF`},
+		{"NEAR with dotted operands quoted", "NEAR(38.101 23.501)", `NEAR("38.101" "23.501")`},
+		{"NEAR with hyphenated operands quoted", "NEAR(IMS-AKA SMF)", `NEAR("IMS-AKA" SMF)`},
+		{"NEAR keeps distance while quoting operands", "NEAR(38.101 23.501, 10)", `NEAR("38.101" "23.501", 10)`},
+		{"unterminated NEAR quotes operands", "NEAR(38.101 23.501", `NEAR("38.101" "23.501")`},
+		{"NEAR phrase operand kept", `NEAR("core network" 38.101)`, `NEAR("core network" "38.101")`},
+		{"NEAR prefix phrase operand kept", `NEAR("core network"* AMF)`, `NEAR("core network"* AMF)`},
+		{"NEAR unterminated phrase operand repaired", `NEAR("core network 38.101)`, `NEAR("core network 38.101")`},
+		{"NEAR operator operand quoted", "NEAR(AND AMF)", `NEAR("AND" AMF)`},
+		{"NEAR extra comma quoted", "NEAR(a b, 5, 6)", `NEAR(a "b," 5, 6)`},
+		{"NEAR non-integer distance quoted", "NEAR(a b, x)", `NEAR(a "b," x)`},
+		{"phrase prefix kept attached", `"38.101"*`, `"38.101"*`},
+		{"phrase prefix kept with following term", `"38.101"* AND UE`, `"38.101"* AND UE`},
+		{"phrase with repeated stars keeps one", `"38.101"**`, `"38.101"* "*"`},
 	}
 
 	for _, tt := range tests {
@@ -473,6 +492,16 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 		`AMF"`, `content:"band`, `content:"core network"`, `content:"core network`,
 		"38.10*", "title:38.10*", "RRCSetup-IEs*", "38.10**", "AMF -38.10*",
 		`content:"core network"*`,
+		// Issue #132: unknown column names, NEAR operands and phrase
+		// prefixes all reached FTS5 unquoted and failed the whole MATCH.
+		"NOTE: mentions", "NOTE:mentions", ":foo", "content:a:b",
+		"Content:band", "AMF, SMF", "AMF -NOTE: mentions",
+		"NEAR(38.101 23.501)", "NEAR(IMS-AKA SMF)", "NEAR(38.101 23.501, 10)",
+		"NEAR(38.101 23.501", "NEAR(AND AMF)", "NEAR(a b, 5, 6)", "NEAR(a b, x)",
+		"NEAR(NEAR(a b) c)", "NEAR(a b)*", "NEAR(content:a b)",
+		`NEAR("core network" 38.101)`, `NEAR("core network"* AMF)`,
+		`NEAR("core network 38.101)`, `NEAR(38.101 23.501) AND band`,
+		`"38.101"*`, `"38.101"**`, `"38.101"* AND UE`, `title:"38.101"*`,
 		"*", "**", "handov*",
 		"AND", "OR", "NOT", "AND AMF", "AMF AND", "AMF AND AND SMF",
 		"NEAR(a b", "NEAR(AMF UE, 5", "NEAR(", "NEAR()",
@@ -568,6 +597,99 @@ func TestSanitizeFTS5Query_PrefixWildcard(t *testing.T) {
 		if n != tt.want {
 			t.Errorf("query %q sanitized to %q and matched %d rows, want %d", tt.query, sanitized, n, tt.want)
 		}
+	}
+}
+
+// TestSanitizeFTS5Query_Issue132 checks the three ways the sanitizer used to
+// hand FTS5 a query that either failed the whole MATCH or silently searched
+// for something else: a "col:" token naming a column that does not exist, an
+// unquoted operand inside a NEAR group, and a "*" after a quoted phrase that
+// was split off into its own term (turning a prefix phrase into an exact one).
+func TestSanitizeFTS5Query_Issue132(t *testing.T) {
+	dbConn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbConn.Close()
+	dbConn.SetMaxOpenConns(1)
+
+	if _, err := dbConn.Exec(`CREATE VIRTUAL TABLE t USING fts5(spec_id, number, title, content)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbConn.Exec(
+		`INSERT INTO t(spec_id, number, title, content) VALUES (?, ?, ?, ?)`,
+		"TS 38.101-1", "5.1", "Band requirements",
+		"NOTE: this clause mentions 38.101 and 23.501, IMS-AKA and the SMF",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"unknown column is a literal term", "NOTE: mentions", 1},
+		{"unknown column with no match", "NOTE: absent", 0},
+		{"colon inside a term", "content:a:b", 0},
+		{"known column still filters", "content:mentions", 1},
+		{"known column is case-insensitive", "Content:mentions", 1},
+		{"comma between terms", "mentions, SMF", 1},
+		{"NEAR with dotted operands", "NEAR(38.101 23.501)", 1},
+		{"NEAR with hyphenated operands", "NEAR(IMS-AKA SMF)", 1},
+		{"NEAR distance kept", "NEAR(38.101 SMF, 10)", 1},
+		{"NEAR distance is honoured", "NEAR(38.101 SMF, 1)", 0},
+		{"NEAR with phrase operand", `NEAR("this clause" 38.101)`, 1},
+		{"NEAR unterminated", "NEAR(38.101 23.501", 1},
+		{"phrase prefix matches longer term", `"38.10"*`, 1},
+		{"phrase prefix on full term", `"38.101"*`, 1},
+		{"phrase prefix that matches nothing", `"39.10"*`, 0},
+		{"phrase prefix combined with operator", `"38.10"* AND SMF`, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sanitized := sanitizeFTS5Query(tt.query)
+			var n int
+			if err := dbConn.QueryRow(`SELECT count(*) FROM t WHERE t MATCH ?`, sanitized).Scan(&n); err != nil {
+				t.Fatalf("query %q sanitized to %q, which FTS5 rejected: %v", tt.query, sanitized, err)
+			}
+			if n != tt.want {
+				t.Errorf("query %q sanitized to %q and matched %d rows, want %d", tt.query, sanitized, n, tt.want)
+			}
+		})
+	}
+}
+
+// TestSearch_QuerySyntax runs the same queries end to end through Search, so a
+// sanitizer change that FTS5 accepts but that loses hits still shows up.
+func TestSearch_QuerySyntax(t *testing.T) {
+	d := setupTestDB(t)
+
+	for _, tt := range []struct {
+		name    string
+		query   string
+		wantMin int
+	}{
+		{"unknown column term", "NOTE: registration", 0},
+		{"unknown column term that matches", "IMS: registration", 1},
+		{"known column filter", "title:Registration", 1},
+		{"NEAR over hyphenated and dotted terms", "NEAR(IMS-AKA 33.203, 10)", 1},
+		{"NEAR that matches nothing", "NEAR(IMS-AKA 38.101, 10)", 0},
+		{"phrase prefix", `"23.50"*`, 1},
+		{"phrase prefix with operator", `"23.50"* AND architecture`, 1},
+		{"comma separated terms", "IMS-AKA, registration", 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			page, err := d.Search(t.Context(), tt.query, nil, 10, 0)
+			if err != nil {
+				t.Fatalf("Search(%q) failed: %v", tt.query, err)
+			}
+			if len(page.Results) < tt.wantMin {
+				t.Errorf("Search(%q) returned %d results, want at least %d", tt.query, len(page.Results), tt.wantMin)
+			}
+			if tt.wantMin == 0 && len(page.Results) != 0 {
+				t.Errorf("Search(%q) returned %d results, want 0", tt.query, len(page.Results))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
`sanitizeFTS5Query` let three kinds of input reach FTS5 unfixed, so a natural
query either failed the whole `MATCH` or silently searched for something else.

- **Unknown column filters.** Only a prefix naming a real `sections_fts` column
  is treated as a column filter now (matched case-insensitively, as FTS5 does);
  anything else before a colon is quoted as ordinary text. `NOTE: mentions` used
  to fail with `no such column: NOTE`, which is common in 3GPP prose.
- **NEAR operands.** Operands inside `NEAR(...)` get the same quoting as
  standalone terms, keeping the `NEAR( )` wrapper and the optional `, N`
  distance. `NEAR(38.101 23.501)` and `NEAR(IMS-AKA SMF)` were hard syntax
  errors.
- **Phrase prefixes.** A `*` right after a closing quote stays attached, so
  `"38.101"*` remains a prefix phrase instead of being split into
  `"38.101" "*"` and degrading to an exact match.
- A bare comma (`AMF, SMF`) is now quoted too — the same syntax error class,
  and required for the NEAR operand handling.

Fixes #132

Verified with `gofmt -l .`, `go vet ./...`, `golangci-lint run` (0 issues) and
`go test -short ./...`. New regression tests run every reported query against a
real FTS5 index and through `Search`, asserting both that FTS5 accepts them and
that they return the expected hits.