### PR TITLE
fix(docx): EMF/WMF conversion fixes (name collision, malformed fallback, Windows URL)

### DIFF
--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -187,8 +187,10 @@ const (
 // stripEMFPlus removes EMF+ data embedded in EMR_COMMENT records from EMF
 // binary data. This forces LibreOffice to use the legacy EMR rendering path,
 // avoiding crashes on corrupted EMF+ records. The returned data contains only
-// legacy EMR records. If the input is not a valid EMF or contains no EMF+
-// data, it is returned unchanged.
+// legacy EMR records. If the input is not a valid EMF, contains no EMF+ data,
+// or contains a malformed record anywhere in the stream (including after
+// valid EMF+ data has already been found), it is returned unchanged rather
+// than truncated at the malformed point.
 //
 // Background: Some 3GPP spec documents contain EMF images with malformed EMF+
 // records. For example, TS 33.501 v19 (33501-j60.docx) Figure 16.4-1
@@ -233,7 +235,12 @@ func stripEMFPlus(data []byte) []byte {
 		recSize := binary.LittleEndian.Uint32(data[offset+4 : offset+8])
 		end, ok := emrRecordEnd(offset, recSize, len(data))
 		if !ok {
-			break
+			// A malformed record means the rest of the stream cannot be
+			// parsed reliably. Returning `out` here would silently drop
+			// every record after this point instead of honoring the "return
+			// unchanged on malformed input" contract, so hand back the
+			// original bytes untouched.
+			return data
 		}
 
 		isEMFPlus := false
@@ -253,6 +260,11 @@ func stripEMFPlus(data []byte) []byte {
 		offset = end
 	}
 
+	if offset != len(data) {
+		// Trailing bytes too short to form a record header (truncated
+		// file): the same "return unchanged" contract applies.
+		return data
+	}
 	if !hasEMFPlus {
 		return data
 	}

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -49,14 +49,46 @@ func ConvertImages(ctx context.Context, images map[string]*EmbeddedImage) int {
 		return 0
 	}
 
+	return assignConvertedImages(images, items)
+}
+
+// assignConvertedImages writes each successfully converted item's PNG data
+// back into images, keyed by the item's original map key. It is split out
+// from ConvertImages so the name-collision handling below can be unit
+// tested without invoking soffice. Returns the number of images assigned.
+func assignConvertedImages(images map[string]*EmbeddedImage, items []*batchItem) int {
+	// Two images that differ only by extension (e.g. image1.emf and
+	// image1.wmf, kept side by side per the batchItem doc comment above)
+	// would otherwise both convert to "image1.png" and collide: whichever
+	// is assigned last in the map below silently discards the other's image
+	// data. Count how many successfully converted items want each plain PNG
+	// name so colliding items can be given a name that keeps them distinct.
+	nameCount := make(map[string]int, len(items))
+	for _, item := range items {
+		if item.err != nil {
+			continue
+		}
+		nameCount[toPNGName(item.original.Name)]++
+	}
+
 	converted := 0
 	for _, item := range items {
 		if item.err != nil {
 			log.Printf("  image conversion failed for %s: %v", item.original.Name, item.err)
 			continue
 		}
+		finalName := toPNGName(item.original.Name)
+		if nameCount[finalName] > 1 {
+			// Keep the full original filename (including its extension) as
+			// the stem so siblings sharing a base name stay distinct after
+			// conversion. UpdateImagePlaceholders matches on this exact
+			// stem before falling back to base-name matching, so it still
+			// resolves image://image1.emf and image://image1.wmf to their
+			// own converted file instead of whichever converted last.
+			finalName = item.original.Name + ".png"
+		}
 		images[item.key] = &EmbeddedImage{
-			Name:        toPNGName(item.original.Name),
+			Name:        finalName,
 			MIMEType:    "image/png",
 			Data:        item.pngData,
 			LLMReadable: true,
@@ -98,14 +130,23 @@ var imageRefRE = regexp.MustCompile(`image://([^?"')\s]+)`)
 // UpdateImagePlaceholders rewrites image:// references in section content to
 // point at the converted PNG filenames after EMF/WMF conversion. Only the
 // filename is replaced; alt text and any ?w=&h= suffix are kept.
+//
+// The lookup map is keyed by the PNG name's stem (everything before the
+// final ".png"). For a plain conversion that stem is just the base name
+// ("image1"), which is enough to match the original reference's base name.
+// For a collision-disambiguated conversion (see ConvertImages) the stem is
+// the full original filename including its extension ("image1.wmf"), which
+// disambiguates it from a sibling like "image1.emf" that shares the same
+// base name — matching on base name alone would otherwise resolve both
+// references to whichever conversion happens to be in the map.
 func UpdateImagePlaceholders(result *ParseResult) {
-	converted := make(map[string]string) // base name (without ext) → new PNG name
+	converted := make(map[string]string) // PNG stem → new PNG name
 	for _, img := range result.Images {
 		if !img.LLMReadable {
 			continue
 		}
-		base := strings.TrimSuffix(img.Name, filepath.Ext(img.Name))
-		converted[base] = img.Name
+		stem := strings.TrimSuffix(img.Name, filepath.Ext(img.Name))
+		converted[stem] = img.Name
 	}
 	if len(converted) == 0 {
 		return
@@ -119,8 +160,14 @@ func UpdateImagePlaceholders(result *ParseResult) {
 					return match
 				}
 				filename := sub[1]
-				base := strings.TrimSuffix(filename, filepath.Ext(filename))
-				newName, ok := converted[base]
+				// Try the exact original filename first (disambiguated
+				// collision case), then fall back to the base name alone
+				// (plain conversion case).
+				newName, ok := converted[filename]
+				if !ok {
+					base := strings.TrimSuffix(filename, filepath.Ext(filename))
+					newName, ok = converted[base]
+				}
 				if !ok || newName == filename {
 					return match
 				}

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -373,6 +373,22 @@ func batchConvertToPNG(ctx context.Context, items []*batchItem) error {
 // which would otherwise block ConvertDir forever; see issue #60.
 const sofficeTimeout = 5 * time.Minute
 
+// fileURLForProfile builds the file:// URL LibreOffice's -env:UserInstallation
+// option expects from a filesystem path. Backslashes are converted to forward
+// slashes and a leading slash is added if missing, so a Windows path such as
+// `C:\Users\foo\AppData\Local\Temp\lo-profile-1` becomes
+// file:///C:/Users/foo/AppData/Local/Temp/lo-profile-1 instead of the invalid
+// file://C:\Users\... that plain string concatenation used to produce. A
+// POSIX path already starts with "/", so it keeps the standard
+// file:///abs/path form unchanged.
+func fileURLForProfile(path string) string {
+	p := strings.ReplaceAll(path, `\`, "/")
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return "file://" + p
+}
+
 // runSofficeBatch invokes `soffice --convert-to png` with the given inputs,
 // writing PNG outputs to outDir. Each invocation uses a fresh user profile
 // so that repeated calls do not contend for LibreOffice's per-profile lock.
@@ -392,7 +408,7 @@ func runSofficeBatch(ctx context.Context, outDir string, inputs []string) error 
 	args := []string{
 		"--headless",
 		"--norestore",
-		"-env:UserInstallation=file://" + profileDir,
+		"-env:UserInstallation=" + fileURLForProfile(profileDir),
 		"--convert-to", "png",
 		"--outdir", outDir,
 	}

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -380,13 +381,17 @@ const sofficeTimeout = 5 * time.Minute
 // file:///C:/Users/foo/AppData/Local/Temp/lo-profile-1 instead of the invalid
 // file://C:\Users\... that plain string concatenation used to produce. A
 // POSIX path already starts with "/", so it keeps the standard
-// file:///abs/path form unchanged.
+// file:///abs/path form unchanged. The path is then percent-encoded via
+// net/url: os.MkdirTemp resolves under the OS temp dir, which on Windows is
+// %TEMP% under the user's profile and commonly contains spaces (e.g.
+// `C:\Users\John Doe\AppData\...`) — an un-encoded space would make the
+// result an invalid URL per RFC 3986 that LibreOffice may reject or misparse.
 func fileURLForProfile(path string) string {
 	p := strings.ReplaceAll(path, `\`, "/")
 	if !strings.HasPrefix(p, "/") {
 		p = "/" + p
 	}
-	return "file://" + p
+	return (&url.URL{Scheme: "file", Path: p}).String()
 }
 
 // runSofficeBatch invokes `soffice --convert-to png` with the given inputs,

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -524,6 +524,43 @@ func TestRunSofficeBatch_Timeout(t *testing.T) {
 	}
 }
 
+// TestFileURLForProfile covers the file:// URL LibreOffice's
+// -env:UserInstallation option expects, including the Windows case that
+// plain "file://" + path concatenation gets wrong (issue #142): a backslash
+// path like `C:\Users\foo\AppData\Local\Temp\lo-profile-1` used to produce
+// the invalid file://C:\Users\... instead of the standard
+// file:///C:/Users/... form.
+func TestFileURLForProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "posix absolute path",
+			path: "/tmp/lo-profile-123",
+			want: "file:///tmp/lo-profile-123",
+		},
+		{
+			name: "windows absolute path with backslashes",
+			path: `C:\Users\foo\AppData\Local\Temp\lo-profile-123`,
+			want: "file:///C:/Users/foo/AppData/Local/Temp/lo-profile-123",
+		},
+		{
+			name: "windows path already using forward slashes",
+			path: "C:/Temp/lo-profile-123",
+			want: "file:///C:/Temp/lo-profile-123",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fileURLForProfile(tt.path); got != tt.want {
+				t.Errorf("fileURLForProfile(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEMRRecordEnd(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -380,6 +380,61 @@ func TestStripEMFPlus_ShortOutput(t *testing.T) {
 	}
 }
 
+// TestStripEMFPlus_MalformedRecordAfterValidEMFPlus verifies that a malformed
+// record following at least one already-stripped EMF+ record makes
+// stripEMFPlus return the entire input buffer byte-for-byte unchanged,
+// instead of the malformed-record contract violation reported in issue #138:
+// silently truncating the output to only the records seen before the
+// malformed one (reproduced there as a 124-byte input collapsing to an
+// 88-byte output). Also checks that a well-formed record placed after the
+// malformed one is not silently dropped, which only the "return unchanged"
+// fallback preserves.
+func TestStripEMFPlus_MalformedRecordAfterValidEMFPlus(t *testing.T) {
+	emfPlusPayload := make([]byte, 12)
+	binary.LittleEndian.PutUint32(emfPlusPayload[0:4], 8) // DataSize
+	binary.LittleEndian.PutUint32(emfPlusPayload[4:8], emfPlusSignature)
+
+	regularData := make([]byte, 4)
+	binary.LittleEndian.PutUint32(regularData[0:4], 1)
+
+	emf := buildTestEMF([]struct {
+		typ  uint32
+		data []byte
+	}{
+		{emrComment, emfPlusPayload}, // EMF+ comment — would normally be stripped
+		{0x12, regularData},          // valid record after the EMF+ comment
+	})
+
+	// Corrupt the second record's declared size in-place, simulating a
+	// truncated/corrupted record with valid data both before and after it
+	// in the original buffer. Offsets are computed structurally (rather
+	// than scanned) to avoid matching stray bytes elsewhere in the header:
+	// the 108-byte EMR_HEADER is followed by the 20-byte EMF+ comment
+	// record (recSize = 8 + 12 payload bytes, already 4-byte aligned), so
+	// the second record's Size field sits at offset 108+20+4 = 132.
+	const secondRecordSizeOffset = 108 + 20 + 4
+	if got := binary.LittleEndian.Uint32(emf[secondRecordSizeOffset-4 : secondRecordSizeOffset]); got != 0x12 {
+		t.Fatalf("test setup: expected the SETBKMODE record type (0x12) at offset %d, got %#x", secondRecordSizeOffset-4, got)
+	}
+	binary.LittleEndian.PutUint32(emf[secondRecordSizeOffset:secondRecordSizeOffset+4], 0xFFFFFFF0) // bogus oversized recSize
+	corrupted := make([]byte, len(emf))
+	copy(corrupted, emf) // snapshot of the malformed input as passed to stripEMFPlus
+
+	result := stripEMFPlus(emf)
+
+	// stripEMFPlus must hand back the malformed input exactly as given — not
+	// a "repaired" version and, per issue #138, not silently truncated to
+	// only the records seen before the malformed one.
+	if len(result) != len(corrupted) {
+		t.Fatalf("expected the %d-byte malformed input back unchanged, got %d bytes (truncated, per issue #138)", len(corrupted), len(result))
+	}
+	for i := range corrupted {
+		if result[i] != corrupted[i] {
+			t.Fatalf("result diverges from the input at byte %d: got %#x, want %#x", i, result[i], corrupted[i])
+		}
+	}
+}
+
 // sofficeCanConvertImages checks whether LibreOffice Draw is available by
 // attempting a trivial SVG-to-PNG conversion.
 func sofficeCanConvertImages(t *testing.T) bool {

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -130,6 +130,86 @@ func TestUpdateImagePlaceholders_WithDimensions(t *testing.T) {
 	}
 }
 
+// TestAssignConvertedImages_NameCollision verifies that image1.emf and
+// image1.wmf, which both convert to "image1.png" via toPNGName, are assigned
+// distinct final names so neither's PNG data is lost to the other via
+// map-key overwrite (issue #130). Does not invoke soffice: the batch items
+// are constructed with pngData already populated, as if conversion had
+// already succeeded.
+func TestAssignConvertedImages_NameCollision(t *testing.T) {
+	images := map[string]*EmbeddedImage{
+		"image1.emf": {Name: "image1.emf", MIMEType: "image/x-emf", Data: []byte("emf-src")},
+		"image1.wmf": {Name: "image1.wmf", MIMEType: "image/x-wmf", Data: []byte("wmf-src")},
+		"image2.emf": {Name: "image2.emf", MIMEType: "image/x-emf", Data: []byte("emf2-src")},
+	}
+	items := []*batchItem{
+		{key: "image1.emf", original: images["image1.emf"], pngData: []byte("emf-png")},
+		{key: "image1.wmf", original: images["image1.wmf"], pngData: []byte("wmf-png")},
+		{key: "image2.emf", original: images["image2.emf"], pngData: []byte("emf2-png")},
+	}
+
+	n := assignConvertedImages(images, items)
+	if n != 3 {
+		t.Fatalf("assignConvertedImages converted %d images, want 3", n)
+	}
+
+	emfResult := images["image1.emf"]
+	wmfResult := images["image1.wmf"]
+	if emfResult == nil || wmfResult == nil {
+		t.Fatalf("expected both image1.emf and image1.wmf entries to survive, got emf=%v wmf=%v", emfResult, wmfResult)
+	}
+	if emfResult.Name == wmfResult.Name {
+		t.Fatalf("colliding images were assigned the same name %q; one overwrote the other", emfResult.Name)
+	}
+	if string(emfResult.Data) != "emf-png" {
+		t.Errorf("image1.emf data = %q, want %q (must not be replaced by the wmf sibling's data)", emfResult.Data, "emf-png")
+	}
+	if string(wmfResult.Data) != "wmf-png" {
+		t.Errorf("image1.wmf data = %q, want %q (must not be replaced by the emf sibling's data)", wmfResult.Data, "wmf-png")
+	}
+	if !emfResult.LLMReadable || !wmfResult.LLMReadable {
+		t.Errorf("converted images should be marked LLMReadable")
+	}
+
+	// image2.emf has no colliding sibling, so it keeps the plain name.
+	if got, want := images["image2.emf"].Name, "image2.png"; got != want {
+		t.Errorf("non-colliding image name = %q, want %q", got, want)
+	}
+}
+
+// TestUpdateImagePlaceholders_NameCollision verifies that after a
+// collision-disambiguated conversion (image1.emf -> image1.emf.png,
+// image1.wmf -> image1.wmf.png), each original image:// reference is
+// rewritten to its own converted file rather than both resolving to
+// whichever conversion happens to be looked up first (issue #130).
+func TestUpdateImagePlaceholders_NameCollision(t *testing.T) {
+	result := &ParseResult{
+		Sections: []*Section{
+			{
+				Number: "7.2.1",
+				Content: []string{
+					"![Figure](image://image1.emf)",
+					"![Figure](image://image1.wmf)",
+				},
+			},
+		},
+		Images: []*EmbeddedImage{
+			{Name: "image1.emf.png", MIMEType: "image/png", LLMReadable: true},
+			{Name: "image1.wmf.png", MIMEType: "image/png", LLMReadable: true},
+		},
+	}
+
+	UpdateImagePlaceholders(result)
+
+	content := result.Sections[0].Content
+	if want := "![Figure](image://image1.emf.png)"; content[0] != want {
+		t.Errorf("emf reference = %q, want %q", content[0], want)
+	}
+	if want := "![Figure](image://image1.wmf.png)"; content[1] != want {
+		t.Errorf("wmf reference = %q, want %q", content[1], want)
+	}
+}
+
 // buildTestEMF constructs a minimal valid EMF binary with the given records.
 // Each record is a (type, data) pair. An EMR_HEADER and EMR_EOF are added
 // automatically.

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -529,7 +529,9 @@ func TestRunSofficeBatch_Timeout(t *testing.T) {
 // plain "file://" + path concatenation gets wrong (issue #142): a backslash
 // path like `C:\Users\foo\AppData\Local\Temp\lo-profile-1` used to produce
 // the invalid file://C:\Users\... instead of the standard
-// file:///C:/Users/... form.
+// file:///C:/Users/... form. Also covers a Windows username containing a
+// space (a real os.MkdirTemp/%TEMP% path shape), which must be
+// percent-encoded to stay a valid URL per RFC 3986.
 func TestFileURLForProfile(t *testing.T) {
 	tests := []struct {
 		name string
@@ -550,6 +552,11 @@ func TestFileURLForProfile(t *testing.T) {
 			name: "windows path already using forward slashes",
 			path: "C:/Temp/lo-profile-123",
 			want: "file:///C:/Temp/lo-profile-123",
+		},
+		{
+			name: "windows username with a space is percent-encoded",
+			path: `C:\Users\John Doe\AppData\Local\Temp\lo-profile-123`,
+			want: "file:///C:/Users/John%20Doe/AppData/Local/Temp/lo-profile-123",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/structdiff/imageref.go
+++ b/internal/structdiff/imageref.go
@@ -48,13 +48,21 @@ func NormalizeImageRefs(line string) string {
 
 // foldName drops the filename extension when it belongs to the EMF/WMF/PCZ →
 // PNG conversion the pipeline performs; any other extension is meaningful and
-// kept.
+// kept. The strip repeats so a collision-disambiguated conversion name like
+// "image1.wmf.png" (see docx.ConvertImages, used when image1.emf and
+// image1.wmf would otherwise both convert to "image1.png") still folds down
+// to "image1", matching the original "image1.wmf" reference in an archived,
+// unconverted version.
 func foldName(name string) string {
-	switch strings.ToLower(path.Ext(name)) {
-	case ".emf", ".wmf", ".pcz", ".png":
-		return strings.TrimSuffix(name, path.Ext(name))
+	for {
+		ext := strings.ToLower(path.Ext(name))
+		switch ext {
+		case ".emf", ".wmf", ".pcz", ".png":
+			name = strings.TrimSuffix(name, path.Ext(name))
+		default:
+			return name
+		}
 	}
-	return name
 }
 
 // foldAlt maps an alt text that adds no information beyond the filename to

--- a/internal/structdiff/imageref_test.go
+++ b/internal/structdiff/imageref_test.go
@@ -80,6 +80,17 @@ func TestNormalizeImageRefs(t *testing.T) {
 			b:    "new text ![Figure](image://image1.png)",
 			same: false,
 		},
+		{
+			// docx.ConvertImages disambiguates a name collision (e.g.
+			// image1.emf and image1.wmf both wanting "image1.png") by
+			// keeping the original extension: image1.wmf -> image1.wmf.png.
+			// The archived, unconverted version still references
+			// image://image1.wmf, so these must still fold equal.
+			name: "collision-disambiguated conversion name folds with its archived original",
+			a:    "![Figure](image://image1.wmf)",
+			b:    "![Figure](image://image1.wmf.png)",
+			same: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Three fixes to EMF/WMF image conversion in `converter/docx/emf.go`:

- Images sharing a base name but differing only by extension (e.g. `image1.emf` and `image1.wmf`) both converted to `image1.png` and collided via `INSERT OR REPLACE`, silently dropping one image's data. Colliding names now keep the original extension (`image1.wmf.png`); `structdiff.NormalizeImageRefs` was updated to still fold this back to the archived original for version diffing.
- `stripEMFPlus` broke out of its scan loop on the first malformed record and returned only the records collected so far, violating its documented "return unchanged on malformed input" contract. It now returns the original bytes unchanged as soon as a malformed record or truncated trailing data is seen.
- The LibreOffice profile dir's `file://` URL was built by string concatenation, producing an invalid URL on Windows (backslashes, no leading slash before the drive letter, and unescaped spaces in the username). It's now built via `net/url` with proper separator conversion and percent-encoding.

Fixes #130
Fixes #138
Fixes #142

## Verification

- `gofmt -l .`: no output
- `go vet ./...`: clean
- `golangci-lint run`: 0 issues
- `go test -short ./...`: all packages pass
- Added regression tests for all three fixes (name-collision assignment and placeholder rewriting, malformed-record-after-valid-EMF+ fallback, and `file://` URL construction including a Windows path with a space)
- `ocr review` (opencode-go/deepseek-v4-flash) against this branch found one real issue (missing percent-encoding in the Windows file URL), which is fixed and covered by a new test case in this PR

## Note

Cache schema bump is handled centrally in the docx block-parsing PR.