### PR TITLE
fix(docx): block parsing fixes (XML fences, VML textbox, deep headings)

### DIFF
--- a/converter/docx/markdown.go
+++ b/converter/docx/markdown.go
@@ -4,9 +4,24 @@ import (
 	"strings"
 )
 
+// maxATXLevel is the deepest heading CommonMark accepts: seven or more "#"
+// characters are plain text, not a heading. Styles "Heading 7" to "Heading 9"
+// and deep annex numbering (dot count + 1) both produce deeper levels, so the
+// emitted prefix is clamped while Section.Level keeps the real depth for the
+// table of contents and nesting. No depth information is lost in the markdown
+// either: the heading text still carries the clause number (issue #139).
+const maxATXLevel = 6
+
 // SectionToMarkdown converts a single section's content to a markdown string.
 func SectionToMarkdown(section *Section) string {
-	headingPrefix := strings.Repeat("#", section.Level)
+	level := section.Level
+	if level > maxATXLevel {
+		level = maxATXLevel
+	}
+	if level < 1 {
+		level = 1
+	}
+	headingPrefix := strings.Repeat("#", level)
 	heading := section.Title
 	if section.Number != "" && section.Number != section.Title {
 		heading = section.Number + " " + section.Title

--- a/converter/docx/markdown_test.go
+++ b/converter/docx/markdown_test.go
@@ -27,6 +27,33 @@ func TestSectionsToMarkdown(t *testing.T) {
 	}
 }
 
+// CommonMark stops recognizing ATX headings at six "#", so deeper levels —
+// "Heading 7" to "Heading 9" styles, or deep annex numbering — are clamped
+// instead of emitted as plain text (issue #139).
+func TestSectionToMarkdown_ClampsDeepHeadings(t *testing.T) {
+	tests := []struct {
+		level      int
+		wantPrefix string
+	}{
+		{1, "# "},
+		{6, "###### "},
+		{7, "###### "},
+		{9, "###### "},
+		{0, "# "},
+	}
+	for _, tt := range tests {
+		section := &Section{Number: "A.1.2.3.4.5.6.7", Title: "Deep clause", Level: tt.level}
+		got := SectionToMarkdown(section)
+		want := tt.wantPrefix + "A.1.2.3.4.5.6.7 Deep clause"
+		if got != want {
+			t.Errorf("level %d: SectionToMarkdown = %q, want %q", tt.level, got, want)
+		}
+		if strings.HasPrefix(got, strings.Repeat("#", maxATXLevel+1)) {
+			t.Errorf("level %d: emitted more than %d hashes: %q", tt.level, maxATXLevel, got)
+		}
+	}
+}
+
 func TestSectionsToMarkdown_Empty(t *testing.T) {
 	if got := SectionsToMarkdown(nil); got != "" {
 		t.Errorf("expected empty string for nil sections, got: %q", got)

--- a/converter/docx/paragraph.go
+++ b/converter/docx/paragraph.go
@@ -159,6 +159,29 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 				}
 				continue
 			}
+			// A standalone VML text box (v:shape > v:textbox > w:txbxContent,
+			// common in compatibility-mode documents) is not a grouped diagram,
+			// so it is not intercepted above and its paragraphs would otherwise
+			// be parsed as part of this one: a nested w:pStyle overwrites
+			// info.StyleID and a nested monospace font marks the whole paragraph
+			// as code, producing fake headings and bogus code fences (issue
+			// #137). Parse the text box's paragraphs in isolation and fold only
+			// their content in, so the labels and images stay where they already
+			// were while the outer paragraph keeps its own properties.
+			if local == "txbxContent" {
+				depth--
+				if drawDepth >= maxDrawingDepth {
+					_ = d.Skip()
+					continue
+				}
+				flushRunText()
+				for _, p := range scanTextBoxParagraphs(d, drawDepth+1) {
+					info.Runs = append(info.Runs, p.Runs...)
+					info.Images = append(info.Images, p.Images...)
+					info.SkippedDiagramLabels = append(info.SkippedDiagramLabels, p.SkippedDiagramLabels...)
+				}
+				continue
+			}
 			switch local {
 			case "pPr":
 				inPPr = true
@@ -447,23 +470,46 @@ func scanDrawingSubtreeDepth(d *xml.Decoder, _ xml.StartElement, drawDepth int) 
 // text box keeps counting against maxDrawingDepth.
 func scanTextBoxLabels(d *xml.Decoder, drawDepth int) []string {
 	var labels []string
+	for _, p := range scanTextBoxParagraphs(d, drawDepth) {
+		if text := strings.TrimSpace(p.Text); text != "" {
+			labels = append(labels, text)
+		}
+	}
+	return labels
+}
+
+// scanTextBoxParagraphs consumes a w:txbxContent element (the start element has
+// already been consumed by the caller) and parses each paragraph inside it, in
+// document order. Parsing them separately is what keeps a text box's paragraph
+// properties out of the paragraph that encloses the text box (issue #137).
+//
+// Paragraphs nested in a container — the cells of a w:tbl, a w:sdt content
+// control — count too: skipping those containers would drop text that used to
+// reach the enclosing paragraph. The descent walks the element nesting with a
+// counter instead of recursing, so deeply nested markup cannot exhaust the
+// stack.
+func scanTextBoxParagraphs(d *xml.Decoder, drawDepth int) []paragraphInfo {
+	var paras []paragraphInfo
+	nesting := 0
 	for {
 		tok, err := d.Token()
 		if err != nil {
-			return labels
+			return paras
 		}
 		switch t := tok.(type) {
 		case xml.StartElement:
 			if t.Name.Local == "p" {
-				pInfo := parseParagraphFromDecoderDepth(d, t, drawDepth)
-				if text := strings.TrimSpace(pInfo.Text); text != "" {
-					labels = append(labels, text)
-				}
-			} else {
-				_ = d.Skip()
+				// Consumes through the matching end element, so the nesting
+				// counter stays balanced without seeing that element.
+				paras = append(paras, parseParagraphFromDecoderDepth(d, t, drawDepth))
+				continue
 			}
+			nesting++
 		case xml.EndElement:
-			return labels
+			if nesting == 0 {
+				return paras
+			}
+			nesting--
 		}
 	}
 }

--- a/converter/docx/paragraph_test.go
+++ b/converter/docx/paragraph_test.go
@@ -701,6 +701,64 @@ func TestParseParagraph_GroupShapeNoImage_SkipsLabels(t *testing.T) {
 	}
 }
 
+func TestParseParagraph_StandaloneTextBox_KeepsOuterParagraphProperties(t *testing.T) {
+	// A plain VML text box (no v:group around it) is parsed inline, so the
+	// paragraph inside it must not lend its w:pStyle or its monospace font to
+	// the paragraph that encloses the text box (issue #137).
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:pPr><w:pStyle w:val="Normal"/></w:pPr>` +
+		`<w:r><w:t>outer text</w:t></w:r>` +
+		`<w:r><w:pict><shape><textbox><txbxContent>` +
+		`<w:p><w:pPr><w:pStyle w:val="Heading1"/><w:rPr><w:rFonts w:ascii="Courier New"/></w:rPr></w:pPr>` +
+		`<w:r><w:t>label</w:t></w:r></w:p>` +
+		`</txbxContent></textbox></shape></w:pict></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.StyleID != "Normal" {
+		t.Errorf("StyleID = %q, want %q: the text box paragraph overwrote the outer style", info.StyleID, "Normal")
+	}
+	if info.IsCode {
+		t.Error("expected the outer paragraph not to be marked as code by the text box's font")
+	}
+	// The label text itself keeps its existing position in the paragraph's
+	// reading flow.
+	if info.Text != "outer textlabel" {
+		t.Errorf("Text = %q, want %q", info.Text, "outer textlabel")
+	}
+}
+
+func TestParseParagraph_StandaloneTextBox_KeepsNestedImage(t *testing.T) {
+	// Folding the text box's content in must not lose an image embedded in it.
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:pict><shape><textbox><txbxContent>` +
+		`<w:p><w:r><w:pict><shape><imagedata r:id="rId9"/></shape></w:pict></w:r><w:r><w:t>label</w:t></w:r></w:p>` +
+		`</txbxContent></textbox></shape></w:pict></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if len(info.Images) != 1 || info.Images[0].RID != "rId9" {
+		t.Fatalf("Images = %+v, want one rId9 entry", info.Images)
+	}
+	if info.Text != "label" {
+		t.Errorf("Text = %q, want %q", info.Text, "label")
+	}
+}
+
+func TestParseParagraph_StandaloneTextBox_KeepsNestedContainerText(t *testing.T) {
+	// A text box may hold a table or a content control rather than bare
+	// paragraphs; their text reached the enclosing paragraph before the text
+	// box was parsed separately and must keep doing so.
+	xml := `<w:p ` + wXMLNS + `>` +
+		`<w:r><w:pict><shape><textbox><txbxContent>` +
+		`<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell text</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+		`<w:sdt><w:sdtContent><w:p><w:r><w:t>; sdt text</w:t></w:r></w:p></w:sdtContent></w:sdt>` +
+		`</txbxContent></textbox></shape></w:pict></w:r>` +
+		`</w:p>`
+	info := parseParagraph([]byte(xml))
+	if info.Text != "cell text; sdt text" {
+		t.Errorf("Text = %q, want %q", info.Text, "cell text; sdt text")
+	}
+}
+
 func TestParseParagraph_GroupShapeWithImage_KeepsImageDropsLabels(t *testing.T) {
 	// A group that mixes a raster picture with textbox callouts should keep
 	// extracting the image (existing behavior), and should not classify the

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -356,21 +356,44 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 	var xmlPending *paragraphInfo
 	var xmlPendingStyle string
 	inXML := false
+	// Paragraphs absorbed only because an element is still open (they carry no
+	// markup of their own) are held here instead of going straight into the
+	// fence: element text content is confirmed by the markup that follows it,
+	// while a block whose closing tag never comes must not turn the rest of the
+	// clause into code (issue #136). Held paragraphs join the fence as soon as
+	// another markup line arrives, and are replayed as ordinary paragraphs when
+	// the block ends before that happens.
+	var xmlHeld []paragraphInfo
+	var xmlHeldStyles []string
+	holdXMLLine := func(info paragraphInfo, styleName string) {
+		xmlHeld = append(xmlHeld, info)
+		xmlHeldStyles = append(xmlHeldStyles, styleName)
+	}
+	commitXMLHeld := func() {
+		for _, info := range xmlHeld {
+			xmlBuffer = append(xmlBuffer, codeLineText(info))
+		}
+		xmlHeld, xmlHeldStyles = nil, nil
+	}
 	flushXML := func() {
 		inXML = false
 		xmlTracker = xmlLineTracker{}
-		if len(xmlBuffer) == 0 || currentSection == nil {
-			xmlBuffer = nil
-			return
-		}
-		for len(xmlBuffer) > 0 && strings.TrimSpace(xmlBuffer[len(xmlBuffer)-1]) == "" {
-			xmlBuffer = xmlBuffer[:len(xmlBuffer)-1]
-		}
-		if len(xmlBuffer) > 0 {
-			currentSection.Content = append(currentSection.Content,
-				"```xml\n"+strings.Join(xmlBuffer, "\n")+"\n```")
+		held, heldStyles := xmlHeld, xmlHeldStyles
+		xmlHeld, xmlHeldStyles = nil, nil
+		if len(xmlBuffer) > 0 && currentSection != nil {
+			for len(xmlBuffer) > 0 && strings.TrimSpace(xmlBuffer[len(xmlBuffer)-1]) == "" {
+				xmlBuffer = xmlBuffer[:len(xmlBuffer)-1]
+			}
+			if len(xmlBuffer) > 0 {
+				currentSection.Content = append(currentSection.Content,
+					"```xml\n"+strings.Join(xmlBuffer, "\n")+"\n```")
+			}
 		}
 		xmlBuffer = nil
+		// The unconfirmed lines belong after the fence, as the prose they are.
+		for i, info := range held {
+			emitParagraph(info, heldStyles[i])
+		}
 	}
 	abandonXMLPending := func() {
 		if xmlPending == nil {
@@ -569,12 +592,26 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 						// Preserve blank lines inside a pending block
 						// (whitespace-only paragraphs included, so indentation
 						// filler does not split the fence); trailing ones are
-						// trimmed at flush.
-						xmlBuffer = append(xmlBuffer, "")
+						// trimmed at flush. A blank line after unconfirmed
+						// content is held with it, so the two keep their order.
+						if len(xmlHeld) > 0 {
+							holdXMLLine(info, styleName)
+						} else {
+							xmlBuffer = append(xmlBuffer, "")
+						}
 						continue
 					case !isCodePara && len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
 						line := codeLineText(info)
-						xmlBuffer = append(xmlBuffer, line)
+						if matchXMLLine(info, &xmlTracker) {
+							// A line that looks like XML by itself confirms
+							// whatever content was held before it.
+							commitXMLHeld()
+							xmlBuffer = append(xmlBuffer, line)
+						} else {
+							// Absorbed only on the strength of an open element:
+							// hold it until markup confirms it belongs inside.
+							holdXMLLine(info, styleName)
+						}
 						xmlTracker.observe(line)
 						continue
 					default:

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -358,13 +358,14 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 	inXML := false
 	// Paragraphs absorbed only because an element is still open (they carry no
 	// markup of their own) are held here instead of going straight into the
-	// fence: element text content is confirmed by the markup that follows it,
-	// while a block whose closing tag never comes must not turn the rest of the
-	// clause into code (issue #136). Held paragraphs join the fence as soon as
-	// another markup line arrives, and are replayed as ordinary paragraphs when
-	// the block ends before that happens.
+	// fence: a block whose closing tag never comes must not turn the rest of
+	// the clause into code (issue #136). They join the fence only once the
+	// element that was open when holding started — recorded in xmlHeldDepth —
+	// is closed, which is what proves they were its content; if the block ends
+	// first they are replayed as the ordinary paragraphs they are.
 	var xmlHeld []paragraphInfo
 	var xmlHeldStyles []string
+	xmlHeldDepth := 0
 	holdXMLLine := func(info paragraphInfo, styleName string) {
 		xmlHeld = append(xmlHeld, info)
 		xmlHeldStyles = append(xmlHeldStyles, styleName)
@@ -602,17 +603,34 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 						continue
 					case !isCodePara && len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
 						line := codeLineText(info)
-						if matchXMLLine(info, &xmlTracker) {
-							// A line that looks like XML by itself confirms
-							// whatever content was held before it.
-							commitXMLHeld()
+						switch {
+						case len(xmlHeld) > 0:
+							// Only the close of the element that was open when
+							// holding started proves the held paragraphs were
+							// its content. Any other line — including a tag that
+							// merely opens something new — is held as well, so
+							// document order survives and unrelated markup later
+							// in the clause cannot fence the prose in between.
+							probe := xmlTracker
+							probe.observe(line)
+							if probe.depth < xmlHeldDepth {
+								commitXMLHeld()
+								xmlBuffer = append(xmlBuffer, line)
+							} else {
+								holdXMLLine(info, styleName)
+							}
+							xmlTracker = probe
+						case matchXMLLine(info, &xmlTracker):
+							// Markup in its own right: straight into the fence.
 							xmlBuffer = append(xmlBuffer, line)
-						} else {
-							// Absorbed only on the strength of an open element:
-							// hold it until markup confirms it belongs inside.
+							xmlTracker.observe(line)
+						default:
+							// Absorbed only on the strength of an open element,
+							// so hold it until that element closes.
+							xmlHeldDepth = xmlTracker.depth
 							holdXMLLine(info, styleName)
+							xmlTracker.observe(line)
 						}
-						xmlTracker.observe(line)
 						continue
 					default:
 						// First non-matching (or code-styled) paragraph ends

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -603,6 +603,14 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 						continue
 					case !isCodePara && len(info.Images) == 0 && matchXMLContinuation(info, &xmlTracker):
 						line := codeLineText(info)
+						// Observe on a copy first: whether this line closes an
+						// element decides where it and anything held belong, and
+						// that is only known after the line has been parsed.
+						// minDepth, not the depth left at the end of the line,
+						// is what answers it — "</a><b>" closes a and opens b.
+						probe := xmlTracker
+						probe.observe(line)
+						isMarkup := matchXMLLine(info, &xmlTracker)
 						switch {
 						case len(xmlHeld) > 0:
 							// Only the close of the element that was open when
@@ -611,26 +619,34 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 							// merely opens something new — is held as well, so
 							// document order survives and unrelated markup later
 							// in the clause cannot fence the prose in between.
-							probe := xmlTracker
-							probe.observe(line)
-							if probe.depth < xmlHeldDepth {
+							// Nesting opened and closed while holding never
+							// reaches below xmlHeldDepth, so it neither confirms
+							// nor disturbs the wait; comments, CDATA and
+							// self-closing tags leave the depth alone entirely.
+							if probe.minDepth < xmlHeldDepth {
 								commitXMLHeld()
 								xmlBuffer = append(xmlBuffer, line)
 							} else {
 								holdXMLLine(info, styleName)
 							}
-							xmlTracker = probe
-						case matchXMLLine(info, &xmlTracker):
+						case isMarkup:
 							// Markup in its own right: straight into the fence.
 							xmlBuffer = append(xmlBuffer, line)
-							xmlTracker.observe(line)
+						case probe.minDepth < xmlTracker.depth:
+							// Text absorbed by an open element that this very
+							// paragraph closes ("some text </a>"): already
+							// confirmed, so there is nothing to hold.
+							xmlBuffer = append(xmlBuffer, line)
 						default:
 							// Absorbed only on the strength of an open element,
-							// so hold it until that element closes.
+							// so hold it until that element closes. xmlHeldDepth
+							// is written whenever holding starts from empty and
+							// read only while xmlHeld is non-empty, so it can
+							// never be stale.
 							xmlHeldDepth = xmlTracker.depth
 							holdXMLLine(info, styleName)
-							xmlTracker.observe(line)
 						}
+						xmlTracker = probe
 						continue
 					default:
 						// First non-matching (or code-styled) paragraph ends

--- a/converter/docx/xmlblock.go
+++ b/converter/docx/xmlblock.go
@@ -119,10 +119,18 @@ type xmlLineTracker struct {
 	inComment bool
 	depth     int    // element nesting depth of the captured lines
 	pending   string // unterminated tag text carried over from the previous line
+	// minDepth is the lowest depth reached while observing the most recent
+	// line, which is not the same as the depth left at its end: a paragraph
+	// that closes an element and opens a sibling in one go ("</a><b>") ends at
+	// the depth it started from, yet it did close the element whose content
+	// preceded it. Callers deciding whether an element has closed must read
+	// this rather than depth (issue #136).
+	minDepth int
 }
 
 // observe updates the tracker after line has been captured into the block.
 func (t *xmlLineTracker) observe(line string) {
+	t.minDepth = t.depth
 	rest := line
 	if t.inComment {
 		loc := xmlCommentCloseRE.FindStringIndex(rest)
@@ -247,6 +255,9 @@ func (t *xmlLineTracker) observeTag(tag string) {
 	if inner[0] == '/' {
 		if t.depth > 0 {
 			t.depth--
+		}
+		if t.depth < t.minDepth {
+			t.minDepth = t.depth
 		}
 		return
 	}

--- a/converter/docx/xmlblock.go
+++ b/converter/docx/xmlblock.go
@@ -90,16 +90,29 @@ func matchXMLLine(info paragraphInfo, tr *xmlLineTracker) bool {
 	return tr.open || xmlLooseLineRE.MatchString(t)
 }
 
+// xmlMaxOpenElementPlainLines bounds how many consecutive markup-free
+// paragraphs an element left open (depth > 0) may absorb. Element content
+// spilling onto its own paragraph is a short run of lines (see
+// matchXMLContinuation), while a block whose closing tag is missing keeps
+// depth above zero forever and would otherwise swallow every following
+// paragraph up to the next heading or table (issue #136) — the same runaway
+// the comment and pending-tag states already give up on.
+const xmlMaxOpenElementPlainLines = 2
+
 // matchXMLContinuation reports whether the paragraph continues an open XML/DTD
 // block. On top of matchXMLLine, an element left open (depth > 0) absorbs
 // plain text lines: element content regularly spills onto its own paragraph
-// (e.g. the <xs:documentation> text of TS 24.423 clause 6.4).
+// (e.g. the <xs:documentation> text of TS 24.423 clause 6.4). Only a bounded
+// run of them, though: an unbalanced block must not absorb a section's prose.
 func matchXMLContinuation(info paragraphInfo, tr *xmlLineTracker) bool {
 	t := xmlTrimmedText(info)
 	if t == "" || strings.HasPrefix(t, "$") {
 		return false
 	}
-	return tr.open || tr.depth > 0 || xmlLooseLineRE.MatchString(t)
+	if tr.open || xmlLooseLineRE.MatchString(t) {
+		return true
+	}
+	return tr.depth > 0 && tr.plainRun < xmlMaxOpenElementPlainLines
 }
 
 // xmlLineTracker tracks parse state across the captured lines of a block:
@@ -113,10 +126,18 @@ type xmlLineTracker struct {
 	inComment bool
 	depth     int    // element nesting depth of the captured lines
 	pending   string // unterminated tag text carried over from the previous line
+	// plainRun counts the consecutive captured lines that carried no markup
+	// at all, bounding what an unbalanced element absorbs (issue #136).
+	plainRun int
 }
 
 // observe updates the tracker after line has been captured into the block.
 func (t *xmlLineTracker) observe(line string) {
+	if t.inComment || t.pending != "" || strings.ContainsRune(line, '<') {
+		t.plainRun = 0
+	} else {
+		t.plainRun++
+	}
 	rest := line
 	if t.inComment {
 		loc := xmlCommentCloseRE.FindStringIndex(rest)
@@ -131,7 +152,8 @@ func (t *xmlLineTracker) observe(line string) {
 		joined := t.pending + rest
 		t.pending = ""
 		i := xmlTagEnd(joined)
-		if i < 0 {
+		switch {
+		case i < 0:
 			// The tag did not close on this line either. Carrying the state
 			// further would absorb every following paragraph until a stray
 			// ">" turns up (issue #95), so give up on the tag instead — the
@@ -139,9 +161,17 @@ func (t *xmlLineTracker) observe(line string) {
 			// next line.
 			t.open = false
 			return
+		case xmlTagHasInnerLT(joined[:i+1]):
+			// The join only "closed" because this line opens a construct of
+			// its own: a tag body never contains an unquoted "<". Counting
+			// the join as a start element would inflate the depth and eat the
+			// very close tag that ends it, leaving depth stuck above zero and
+			// absorbing the following prose (issue #136). Drop the carried-over
+			// "<…" and read this line on its own terms instead.
+		default:
+			t.observeTag(joined[:i+1])
+			rest = joined[i+1:]
 		}
-		t.observeTag(joined[:i+1])
-		rest = joined[i+1:]
 	}
 	for {
 		i := strings.IndexByte(rest, '<')
@@ -194,6 +224,27 @@ func xmlTagEnd(s string) int {
 		}
 	}
 	return -1
+}
+
+// xmlTagHasInnerLT reports whether the "<…>" tag in s carries another unquoted
+// "<" after its opening one — the signature of a bogus join between an
+// unterminated "<…" and a line that starts markup of its own, since a
+// well-formed tag body cannot contain "<" (issue #136).
+func xmlTagHasInnerLT(s string) bool {
+	var quote byte
+	for i := 1; i < len(s); i++ {
+		switch c := s[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '<':
+			return true
+		}
+	}
+	return false
 }
 
 // observeTag adjusts the element depth for one complete "<…>" tag.

--- a/converter/docx/xmlblock.go
+++ b/converter/docx/xmlblock.go
@@ -90,29 +90,22 @@ func matchXMLLine(info paragraphInfo, tr *xmlLineTracker) bool {
 	return tr.open || xmlLooseLineRE.MatchString(t)
 }
 
-// xmlMaxOpenElementPlainLines bounds how many consecutive markup-free
-// paragraphs an element left open (depth > 0) may absorb. Element content
-// spilling onto its own paragraph is a short run of lines (see
-// matchXMLContinuation), while a block whose closing tag is missing keeps
-// depth above zero forever and would otherwise swallow every following
-// paragraph up to the next heading or table (issue #136) — the same runaway
-// the comment and pending-tag states already give up on.
-const xmlMaxOpenElementPlainLines = 2
-
 // matchXMLContinuation reports whether the paragraph continues an open XML/DTD
 // block. On top of matchXMLLine, an element left open (depth > 0) absorbs
 // plain text lines: element content regularly spills onto its own paragraph
-// (e.g. the <xs:documentation> text of TS 24.423 clause 6.4). Only a bounded
-// run of them, though: an unbalanced block must not absorb a section's prose.
+// (e.g. the <xs:documentation> text of TS 24.423 clause 6.4).
+//
+// Such a line is captured but not committed: the caller holds it until a line
+// that matchXMLLine accepts confirms it, because an element whose closing tag
+// never comes keeps the depth above zero for the rest of the clause (issue
+// #136). Confirming on markup rather than counting lines lets element content
+// run as long as it likes without a missing close tag turning prose into code.
 func matchXMLContinuation(info paragraphInfo, tr *xmlLineTracker) bool {
 	t := xmlTrimmedText(info)
 	if t == "" || strings.HasPrefix(t, "$") {
 		return false
 	}
-	if tr.open || xmlLooseLineRE.MatchString(t) {
-		return true
-	}
-	return tr.depth > 0 && tr.plainRun < xmlMaxOpenElementPlainLines
+	return tr.open || tr.depth > 0 || xmlLooseLineRE.MatchString(t)
 }
 
 // xmlLineTracker tracks parse state across the captured lines of a block:
@@ -126,18 +119,10 @@ type xmlLineTracker struct {
 	inComment bool
 	depth     int    // element nesting depth of the captured lines
 	pending   string // unterminated tag text carried over from the previous line
-	// plainRun counts the consecutive captured lines that carried no markup
-	// at all, bounding what an unbalanced element absorbs (issue #136).
-	plainRun int
 }
 
 // observe updates the tracker after line has been captured into the block.
 func (t *xmlLineTracker) observe(line string) {
-	if t.inComment || t.pending != "" || strings.ContainsRune(line, '<') {
-		t.plainRun = 0
-	} else {
-		t.plainRun++
-	}
 	rest := line
 	if t.inComment {
 		loc := xmlCommentCloseRE.FindStringIndex(rest)

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -417,6 +417,102 @@ func TestParseSections_XMLMixedContentStaysFenced(t *testing.T) {
 	}
 }
 
+// A paragraph that closes an element and opens a sibling in one go ends at the
+// depth it started from, but it did close the element whose content preceded
+// it: that content belongs in the fence, while text absorbed by the sibling
+// that never closes does not (issue #136).
+func TestParseSections_XMLCloseAndSiblingOpenConfirmsContent(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.8\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<a>`),
+		xmlTestPara("Legit text content of a."),
+		xmlTestPara(`</a><b>`),
+		xmlTestPara("Prose absorbed by the unclosed sibling."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "Legit text content of a.\n</a><b>\n```") {
+		t.Errorf("expected the content confirmed by the close inside the fence, got %q", content[0])
+	}
+	if content[1] != "Prose absorbed by the unclosed sibling." {
+		t.Errorf("expected the unconfirmed paragraph replayed as prose, got %q", content[1])
+	}
+
+	// The same holds several levels in: closing back past the depth where
+	// holding started confirms the content, even in one paragraph.
+	elements = []bodyElement{
+		xmlTestHeading("6.9\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<a><b><c>`),
+		xmlTestPara("Deeply nested text."),
+		xmlTestPara(`</c></b>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections = parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	content = sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "Deeply nested text.\n</c></b>\n```") {
+		t.Errorf("expected the nested content inside the fence, got %q", content[0])
+	}
+}
+
+// Text that closes the element it was absorbed under, in the very paragraph
+// that would otherwise be held, needs no confirmation from a later line and
+// must keep its place in the fence.
+func TestParseSections_XMLContentClosingItsOwnElement(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.10\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<a>`),
+		xmlTestPara("some text </a>"),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected fence + prose, got %v", content)
+	}
+	if !strings.Contains(content[0], "<a>\nsome text </a>\n```") {
+		t.Errorf("expected the self-closing content inside the fence, got %q", content[0])
+	}
+	if content[1] != "Trailing prose." {
+		t.Errorf("expected trailing prose outside the fence, got %q", content[1])
+	}
+}
+
+// Markup that leaves the element depth alone — a comment, a CDATA section, a
+// self-closing tag — proves nothing about the open element, so it must not
+// confirm the paragraphs held before it.
+func TestParseSections_XMLDepthNeutralMarkupDoesNotConfirm(t *testing.T) {
+	for _, neutral := range []string{`<!-- note -->`, `<![CDATA[x < y]]>`, `<br/>`} {
+		elements := []bodyElement{
+			xmlTestHeading("6.11\tXML body"),
+			xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+			xmlTestPara(`<a>`),
+			xmlTestPara("This clause text must stay prose."),
+			xmlTestPara(neutral),
+			xmlTestPara("Tail prose."),
+		}
+		sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+		content := sections[0].Content
+		if len(content) != 4 {
+			t.Fatalf("%s: expected fence + 3 replayed paragraphs, got %v", neutral, content)
+		}
+		if strings.Contains(content[0], "clause text") {
+			t.Errorf("%s: prose fenced by depth-neutral markup: %q", neutral, content[0])
+		}
+		if content[1] != "This clause text must stay prose." || content[2] != neutral {
+			t.Errorf("%s: expected the held paragraphs replayed in order, got %v", neutral, content[1:])
+		}
+	}
+}
+
 // Unconfirmed paragraphs must not be fenced by markup that merely turns up
 // later in the clause: an unrelated tag line does not close the element they
 // were absorbed under, so the clause text between the two stays prose.

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -1,6 +1,7 @@
 package docx
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -103,6 +104,87 @@ func TestXMLLineTrackerUnterminatedNotSticky(t *testing.T) {
 	}
 	if matchXMLContinuation(prose, &tr) {
 		t.Error("expected prose not to continue the block after the tag is abandoned")
+	}
+}
+
+// An element that is never closed keeps depth above zero, but it only absorbs
+// a bounded run of markup-free paragraphs instead of every following one
+// (issue #136).
+func TestXMLLineTrackerUnbalancedDepthBounded(t *testing.T) {
+	prose := paragraphInfo{
+		Text: "Ordinary prose paragraph.",
+		Runs: []runInfo{{Text: "Ordinary prose paragraph."}},
+	}
+
+	var tr xmlLineTracker
+	tr.observe(`<root>`)
+	tr.observe(`<child>`)
+	if tr.depth != 2 {
+		t.Fatalf("expected depth 2 after two unclosed elements, got %d", tr.depth)
+	}
+	for i := 0; i < xmlMaxOpenElementPlainLines; i++ {
+		if !matchXMLContinuation(prose, &tr) {
+			t.Fatalf("expected element content line %d to be absorbed", i+1)
+		}
+		tr.observe(prose.Text)
+	}
+	if matchXMLContinuation(prose, &tr) {
+		t.Error("expected the unbalanced block to give up instead of absorbing prose without end")
+	}
+
+	// A markup line in between resets the allowance: genuine element content
+	// interleaved with tags keeps the block together.
+	tr = xmlLineTracker{}
+	tr.observe(`<xs:annotation><xs:documentation>Template of a`)
+	if !matchXMLContinuation(prose, &tr) {
+		t.Fatal("expected element content to be absorbed")
+	}
+	tr.observe(`Service XML Schema`)
+	tr.observe(`</xs:documentation>`)
+	if !matchXMLContinuation(prose, &tr) {
+		t.Error("expected the plain-line allowance to reset after a markup line")
+	}
+}
+
+// An unterminated "<…" joined with a line that opens markup of its own must
+// not be counted as a start element: the fabricated tag both inflates the depth
+// and swallows the close tag that would balance it, so the depth would never
+// return to zero and the following prose would be absorbed (issue #136).
+func TestXMLLineTrackerPendingJoinNotAnElement(t *testing.T) {
+	prose := paragraphInfo{
+		Text: "Ordinary prose paragraph.",
+		Runs: []runInfo{{Text: "Ordinary prose paragraph."}},
+	}
+
+	var tr xmlLineTracker
+	tr.observe(`<a><b`)
+	if !tr.open || tr.depth != 1 {
+		t.Fatalf("expected open tracker at depth 1, got open=%v depth=%d", tr.open, tr.depth)
+	}
+	tr.observe(`</a>`)
+	if tr.open || tr.depth != 0 {
+		t.Errorf("expected the close tag to balance the block, got open=%v depth=%d", tr.open, tr.depth)
+	}
+	if matchXMLContinuation(prose, &tr) {
+		t.Error("expected prose not to continue the balanced block")
+	}
+
+	// The same join against a comment line: the comment is consumed normally
+	// and leaves the depth alone.
+	tr = xmlLineTracker{}
+	tr.observe(`<tuple id="t1"`)
+	tr.observe(`<!-- the tag above lost its ">" -->`)
+	if tr.open || tr.inComment || tr.depth != 0 {
+		t.Errorf("expected the comment consumed with no depth change, got open=%v inComment=%v depth=%d",
+			tr.open, tr.inComment, tr.depth)
+	}
+
+	// A quoted "<" inside a genuine attribute spill is not a bogus join.
+	tr = xmlLineTracker{}
+	tr.observe(`<elem attr="a`)
+	tr.observe(`< b">`)
+	if tr.open || tr.depth != 1 {
+		t.Errorf("expected the quoted '<' to complete one start element, got open=%v depth=%d", tr.open, tr.depth)
 	}
 }
 
@@ -265,6 +347,76 @@ func TestParseSections_XMLUnterminatedNotSwallowingProse(t *testing.T) {
 	}
 	if content[1] != "This prose paragraph must stay outside the fence." {
 		t.Errorf("expected first prose paragraph intact, got %q", content[1])
+	}
+}
+
+// An XML block whose closing tags are missing must not turn the rest of the
+// clause into code: absorption stops after a bounded run of prose paragraphs
+// instead of running to the next heading or table (issue #136).
+func TestParseSections_XMLUnbalancedStopsAbsorbingProse(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.4\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<presence>`),
+		xmlTestPara(`<tuple id="t1">`),
+	}
+	const proseCount = 5
+	for i := 1; i <= proseCount; i++ {
+		elements = append(elements, xmlTestPara(fmt.Sprintf("Prose paragraph %d of the clause.", i)))
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) < 2 || !strings.HasPrefix(content[0], "```xml\n") {
+		t.Fatalf("expected an xml fence followed by prose, got %v", content)
+	}
+	fenced := strings.Count(content[0], "Prose paragraph")
+	if fenced > xmlMaxOpenElementPlainLines {
+		t.Errorf("unbalanced block absorbed %d prose paragraphs, want at most %d: %q",
+			fenced, xmlMaxOpenElementPlainLines, content[0])
+	}
+	last := content[len(content)-1]
+	if last != fmt.Sprintf("Prose paragraph %d of the clause.", proseCount) {
+		t.Errorf("expected the trailing prose outside the fence, got %q", last)
+	}
+	for _, c := range content[1:] {
+		if strings.Contains(c, "```") {
+			t.Errorf("expected plain prose after the fence, got %q", c)
+		}
+	}
+}
+
+// An unterminated tag joined with the next line's comment must not fabricate
+// an element: the block stays balanced and the trailing prose stays out of the
+// fence (issue #136).
+func TestParseSections_XMLPendingJoinKeepsDepthBalanced(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.5\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<presence><tuple id="t1"`),
+		xmlTestPara(`<!-- the tag above lost its ">" -->`),
+		xmlTestPara(`</presence>`),
+		xmlTestPara("Trailing prose."),
+		xmlTestPara("More trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 3 {
+		t.Fatalf("expected fence + two prose paragraphs, got %v", content)
+	}
+	if !strings.Contains(content[0], `<!-- the tag above lost its ">" -->`) {
+		t.Errorf("expected the comment line inside the fence, got %q", content[0])
+	}
+	if strings.Contains(content[0], "Trailing prose.") {
+		t.Errorf("prose swallowed into the fence: %q", content[0])
+	}
+	if content[1] != "Trailing prose." || content[2] != "More trailing prose." {
+		t.Errorf("expected both prose paragraphs intact, got %v", content[1:])
 	}
 }
 

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -382,6 +382,77 @@ func TestParseSections_XMLLongElementContentStaysFenced(t *testing.T) {
 	}
 }
 
+// Element content interleaved with child elements is still confirmed by the
+// close of the element it belongs to, so mixed content stays in one fence.
+func TestParseSections_XMLMixedContentStaysFenced(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.6\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<tuple id="t1">`),
+		xmlTestPara("Text content of the tuple."),
+		xmlTestPara(`<status>`),
+		xmlTestPara(`<basic>open</basic>`),
+		xmlTestPara(`</status>`),
+		xmlTestPara("More text content."),
+		xmlTestPara(`</tuple>`),
+		xmlTestPara("Trailing prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected one fence + trailing prose, got %v", content)
+	}
+	for _, line := range []string{
+		"Text content of the tuple.", "<basic>open</basic>", "More text content.", "</tuple>",
+	} {
+		if !strings.Contains(content[0], line) {
+			t.Errorf("expected %q inside the fence, got %q", line, content[0])
+		}
+	}
+	if content[1] != "Trailing prose." {
+		t.Errorf("expected trailing prose outside the fence, got %q", content[1])
+	}
+}
+
+// Unconfirmed paragraphs must not be fenced by markup that merely turns up
+// later in the clause: an unrelated tag line does not close the element they
+// were absorbed under, so the clause text between the two stays prose.
+func TestParseSections_XMLHeldProseNotFencedByUnrelatedMarkup(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.7\tXML body"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<presence>`),
+		xmlTestPara("This clause text must stay prose."),
+		xmlTestPara("So must this second paragraph."),
+		xmlTestPara(`<status>Open</status>`),
+		xmlTestPara("Tail prose."),
+	}
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 5 {
+		t.Fatalf("expected the fence + 4 replayed paragraphs, got %v", content)
+	}
+	if !strings.HasPrefix(content[0], "```xml\n") || strings.Contains(content[0], "clause text") {
+		t.Errorf("expected a fence holding only the markup lines, got %q", content[0])
+	}
+	for i, want := range []string{
+		"This clause text must stay prose.",
+		"So must this second paragraph.",
+		"<status>Open</status>",
+		"Tail prose.",
+	} {
+		if content[i+1] != want {
+			t.Errorf("content[%d] = %q, want %q", i+1, content[i+1], want)
+		}
+	}
+}
+
 // An unterminated tag joined with the next line's comment must not fabricate
 // an element: the block stays balanced and the trailing prose stays out of the
 // fence (issue #136).

--- a/converter/docx/xmlblock_test.go
+++ b/converter/docx/xmlblock_test.go
@@ -107,45 +107,6 @@ func TestXMLLineTrackerUnterminatedNotSticky(t *testing.T) {
 	}
 }
 
-// An element that is never closed keeps depth above zero, but it only absorbs
-// a bounded run of markup-free paragraphs instead of every following one
-// (issue #136).
-func TestXMLLineTrackerUnbalancedDepthBounded(t *testing.T) {
-	prose := paragraphInfo{
-		Text: "Ordinary prose paragraph.",
-		Runs: []runInfo{{Text: "Ordinary prose paragraph."}},
-	}
-
-	var tr xmlLineTracker
-	tr.observe(`<root>`)
-	tr.observe(`<child>`)
-	if tr.depth != 2 {
-		t.Fatalf("expected depth 2 after two unclosed elements, got %d", tr.depth)
-	}
-	for i := 0; i < xmlMaxOpenElementPlainLines; i++ {
-		if !matchXMLContinuation(prose, &tr) {
-			t.Fatalf("expected element content line %d to be absorbed", i+1)
-		}
-		tr.observe(prose.Text)
-	}
-	if matchXMLContinuation(prose, &tr) {
-		t.Error("expected the unbalanced block to give up instead of absorbing prose without end")
-	}
-
-	// A markup line in between resets the allowance: genuine element content
-	// interleaved with tags keeps the block together.
-	tr = xmlLineTracker{}
-	tr.observe(`<xs:annotation><xs:documentation>Template of a`)
-	if !matchXMLContinuation(prose, &tr) {
-		t.Fatal("expected element content to be absorbed")
-	}
-	tr.observe(`Service XML Schema`)
-	tr.observe(`</xs:documentation>`)
-	if !matchXMLContinuation(prose, &tr) {
-		t.Error("expected the plain-line allowance to reset after a markup line")
-	}
-}
-
 // An unterminated "<…" joined with a line that opens markup of its own must
 // not be counted as a start element: the fabricated tag both inflates the depth
 // and swallows the close tag that would balance it, so the depth would never
@@ -351,8 +312,8 @@ func TestParseSections_XMLUnterminatedNotSwallowingProse(t *testing.T) {
 }
 
 // An XML block whose closing tags are missing must not turn the rest of the
-// clause into code: absorption stops after a bounded run of prose paragraphs
-// instead of running to the next heading or table (issue #136).
+// clause into code: paragraphs absorbed only because an element stayed open
+// are replayed as prose when no markup ever confirms them (issue #136).
 func TestParseSections_XMLUnbalancedStopsAbsorbingProse(t *testing.T) {
 	elements := []bodyElement{
 		xmlTestHeading("6.4\tXML body"),
@@ -369,22 +330,55 @@ func TestParseSections_XMLUnbalancedStopsAbsorbingProse(t *testing.T) {
 		t.Fatalf("expected 1 section, got %d", len(sections))
 	}
 	content := sections[0].Content
-	if len(content) < 2 || !strings.HasPrefix(content[0], "```xml\n") {
-		t.Fatalf("expected an xml fence followed by prose, got %v", content)
+	if len(content) != 1+proseCount {
+		t.Fatalf("expected the fence plus %d prose paragraphs, got %v", proseCount, content)
 	}
-	fenced := strings.Count(content[0], "Prose paragraph")
-	if fenced > xmlMaxOpenElementPlainLines {
-		t.Errorf("unbalanced block absorbed %d prose paragraphs, want at most %d: %q",
-			fenced, xmlMaxOpenElementPlainLines, content[0])
+	if !strings.HasPrefix(content[0], "```xml\n") || strings.Contains(content[0], "Prose paragraph") {
+		t.Errorf("expected an xml fence holding only the markup lines, got %q", content[0])
 	}
-	last := content[len(content)-1]
-	if last != fmt.Sprintf("Prose paragraph %d of the clause.", proseCount) {
-		t.Errorf("expected the trailing prose outside the fence, got %q", last)
-	}
-	for _, c := range content[1:] {
-		if strings.Contains(c, "```") {
-			t.Errorf("expected plain prose after the fence, got %q", c)
+	for i := 1; i <= proseCount; i++ {
+		want := fmt.Sprintf("Prose paragraph %d of the clause.", i)
+		if content[i] != want {
+			t.Errorf("content[%d] = %q, want %q", i, content[i], want)
 		}
+	}
+}
+
+// Element text content is confirmed by the markup that follows it, however
+// long the run: a well-formed element whose content spans many paragraphs
+// stays in one fence together with its closing tag (issue #136 follow-up).
+func TestParseSections_XMLLongElementContentStaysFenced(t *testing.T) {
+	elements := []bodyElement{
+		xmlTestHeading("6.4\tXML schema"),
+		xmlTestPara(`<?xml version="1.0" encoding="UTF-8"?>`),
+		xmlTestPara(`<xs:annotation><xs:documentation>`),
+	}
+	const contentLines = 6
+	for i := 1; i <= contentLines; i++ {
+		elements = append(elements, xmlTestPara(fmt.Sprintf("Documentation line %d.", i)))
+	}
+	elements = append(elements,
+		xmlTestPara(`</xs:documentation></xs:annotation>`),
+		xmlTestPara("Trailing prose."),
+	)
+	sections := parseSections(elements, map[string]string{"Heading1": "Heading 1"}, nil, nil, nil)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	content := sections[0].Content
+	if len(content) != 2 {
+		t.Fatalf("expected one fence + trailing prose, got %v", content)
+	}
+	for i := 1; i <= contentLines; i++ {
+		if !strings.Contains(content[0], fmt.Sprintf("Documentation line %d.", i)) {
+			t.Errorf("expected documentation line %d inside the fence, got %q", i, content[0])
+		}
+	}
+	if !strings.Contains(content[0], "</xs:documentation></xs:annotation>\n```") {
+		t.Errorf("expected the closing tags to end the fence, got %q", content[0])
+	}
+	if content[1] != "Trailing prose." {
+		t.Errorf("expected trailing prose outside the fence, got %q", content[1])
 	}
 }
 

--- a/versionstore/versionstore.go
+++ b/versionstore/versionstore.go
@@ -61,8 +61,11 @@ const DefaultFileName = "versions.db"
 // continuation from pulling prose after a blank line into an SDP fence,
 // generation 8 hardens XML fence tracking against malformed markup, limits
 // sip/sdp backslash continuation to the wrapped line, and emits run text
-// before an inline image in the same run.
-const cacheSchemaVersion = 8
+// before an inline image in the same run, generation 9 stops unbalanced XML
+// blocks and VML text boxes from absorbing surrounding paragraphs and clamps
+// headings to ATX level 6 (alongside the concurrent EMF naming, OMML and
+// link conversion changes, which this one bump covers as well).
+const cacheSchemaVersion = 9
 
 // schema mirrors the spec, section and image tables of the main database,
 // without the full-text index: cached versions must never appear in search


### PR DESCRIPTION
Three block-parsing bugs in `converter/docx/`, each with a regression test that fails on `main`.

**Unbalanced XML and pending-tag joins absorb prose (`xmlblock.go`, `parser.go`)** — two root causes with the same symptom. An element left open kept `depth` above zero forever, so every following paragraph was swallowed up to the next heading or table. A paragraph absorbed only because an element is still open is now held rather than committed: it joins the fence as soon as a line that looks like XML confirms it, and is replayed as an ordinary paragraph when the block ends before that happens. Element text content may therefore run to any length (an `<xs:documentation>` body spanning many paragraphs stays in one fence together with its closing tag), while a block whose closing tag never comes absorbs no prose at all. Separately, an unterminated `<…` joined with a line that starts markup of its own (a comment, a close tag) was counted as a start element, inflating the depth and eating the close tag that would balance it; a join whose tag body carries another unquoted `<` is now rejected, since a well-formed tag body cannot contain one.

**Nested paragraph in a VML textbox overwrites the outer paragraph (`paragraph.go`)** — a standalone `v:textbox` is not a grouped diagram, so its `w:txbxContent` was parsed as part of the enclosing paragraph: the nested `w:pStyle` replaced the outer `StyleID` and a nested monospace font could mark the paragraph as code, producing fake headings and bogus code fences. The text box's paragraphs are now parsed on their own and only their runs and images are folded in, including paragraphs nested in a `w:tbl` or `w:sdt` so no text is lost.

**Headings deeper than level 6 (`markdown.go`)** — `Heading 7`–`Heading 9` styles and deep annex numbering emitted seven or more hashes, which CommonMark renders as plain text. The emitted prefix is clamped to 6; `Section.Level` keeps the real depth for the TOC and nesting, and the clause number in the heading text still carries it.

Fixes #136
Fixes #137
Fixes #139

**Cache schema bump** — `versionstore.cacheSchemaVersion` goes 8 → 9 so caches built with the previous converter output are wiped on open, as required when conversion output changes. This single bump also covers the other in-flight conversion changes (EMF naming, OMML, link conversion), so those PRs do not need one of their own.

**Verification** — `gofmt -l .` (no output), `go vet ./...`, `golangci-lint run` (0 issues), `go test -short ./...` (all packages pass). Each new test was confirmed to fail against the unfixed code.