### PR TITLE
fix(web): rendering fixes (inline math, sanitizer, attributes, deep headings)

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -163,6 +163,31 @@ func (h *handler) initTemplates() {
 		"add": func(a, b int) int {
 			return a + b
 		},
+		// headingLevel maps a section level to the heading element that
+		// carries it. The page title is <h1>, so a section sits one level
+		// below, clamped to <h6>: 3GPP numbering goes deeper than HTML has
+		// headings (TS 36.523-1 has 7.1.13.1.1.2), and <h7> is not an element
+		// — browsers treat it as unknown, dropping both the heading semantics
+		// and the styling. The depth stays visible in the section number and
+		// in the sectionDepth class.
+		"headingLevel": func(level int) int {
+			switch {
+			case level < 1:
+				return 1
+			case level > 5:
+				return 6
+			default:
+				return level + 1
+			}
+		},
+		// sectionDepth keeps the visual hierarchy of levels the heading
+		// elements can no longer distinguish.
+		"sectionDepth": func(level int) int {
+			if level > 6 {
+				return 6
+			}
+			return level
+		},
 		"sub": func(a, b int) int {
 			return a - b
 		},

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -8,6 +8,7 @@ import (
 	htmlpkg "html"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -153,7 +154,7 @@ func renderMarkdown(content string, o renderOpts) string {
 	// placeholder token is random per render so literal text can never collide
 	// with a placeholder.
 	token := newMathToken()
-	var mathSpans []string
+	var mathSpans []mathSpan
 	segs := splitCodeSegments(content)
 	var sb strings.Builder
 	sb.Grow(len(content))
@@ -171,11 +172,7 @@ func renderMarkdown(content string, o renderOpts) string {
 	if err := md.Convert([]byte(content), &buf); err != nil {
 		return "<p>Error rendering content</p>"
 	}
-	out := buf.String()
-	for i, span := range mathSpans {
-		out = strings.Replace(out, mathPlaceholder(token, i), span, 1)
-	}
-	return sanitizeHTML(out)
+	return sanitizeHTML(injectMath(buf.String(), token, mathSpans))
 }
 
 // tableOpenRE matches the start of a converter-emitted table region: the
@@ -247,11 +244,74 @@ func mathPlaceholder(token string, i int) string {
 	return fmt.Sprintf("%s%dx", token, i)
 }
 
+// mathSpan is one extracted formula in the two forms re-injection needs:
+// element markup for text content, and delimited plain text for the inside of
+// an HTML attribute, where an element would break the tag.
+type mathSpan struct {
+	html  string
+	plain string
+}
+
+// injectMath replaces every placeholder in the converted HTML with its
+// formula. A placeholder that landed inside a tag — goldmark and the image
+// rewrite both put alt text into an attribute, so `![$x_1$](image://...)`
+// gets one there — becomes the plain LaTeX source instead of a <span>:
+// injecting an element into an attribute value truncated the tag and spilled
+// attribute fragments into the page as visible text.
+func injectMath(out, token string, spans []mathSpan) string {
+	if len(spans) == 0 {
+		return out
+	}
+	var b strings.Builder
+	b.Grow(len(out))
+	inTag := false
+	for i := 0; i < len(out); {
+		switch out[i] {
+		case '<':
+			inTag = true
+		case '>':
+			inTag = false
+		case token[0]:
+			if idx, n := parseMathPlaceholder(out[i:], token); n > 0 && idx < len(spans) {
+				if inTag {
+					b.WriteString(spans[idx].plain)
+				} else {
+					b.WriteString(spans[idx].html)
+				}
+				i += n
+				continue
+			}
+		}
+		b.WriteByte(out[i])
+		i++
+	}
+	return b.String()
+}
+
+// parseMathPlaceholder reports the span index of the placeholder at the start
+// of s and how many bytes it occupies, or n == 0 when s does not start with
+// one.
+func parseMathPlaceholder(s, token string) (idx, n int) {
+	if !strings.HasPrefix(s, token) {
+		return 0, 0
+	}
+	rest := s[len(token):]
+	end := strings.IndexByte(rest, 'x')
+	if end <= 0 {
+		return 0, 0
+	}
+	idx, err := strconv.Atoi(rest[:end])
+	if err != nil || idx < 0 {
+		return 0, 0
+	}
+	return idx, len(token) + end + 1
+}
+
 // protectMath extracts LaTeX math spans from text, replacing each with a
-// placeholder built from token, and appends the <span> HTML to re-inject
-// after conversion to spans. A $...$ span isInlineMath rejects is left alone,
-// so its dollar signs stay visible text.
-func protectMath(text, token string, spans *[]string) string {
+// placeholder built from token, and appends the formula to spans for
+// re-injection after conversion. A $...$ span isInlineMath rejects is left
+// alone, so its dollar signs stay visible text.
+func protectMath(text, token string, spans *[]mathSpan) string {
 	locs := mathRE.FindAllStringSubmatchIndex(text, -1)
 	if locs == nil {
 		return text
@@ -261,10 +321,10 @@ func protectMath(text, token string, spans *[]string) string {
 	last := 0
 	for _, loc := range locs {
 		display := loc[2] >= 0
-		class := "math-inline"
+		class, delim := "math-inline", "$"
 		var latex string
 		if display {
-			latex, class = text[loc[2]:loc[3]], "math-display"
+			latex, class, delim = text[loc[2]:loc[3]], "math-display", "$$"
 		} else {
 			latex = text[loc[4]:loc[5]]
 			if !isInlineMath(text[last:loc[0]], latex) {
@@ -273,7 +333,10 @@ func protectMath(text, token string, spans *[]string) string {
 		}
 		latex = htmlpkg.EscapeString(htmlpkg.UnescapeString(latex))
 		i := len(*spans)
-		*spans = append(*spans, fmt.Sprintf(`<span class="%s">%s</span>`, class, latex))
+		*spans = append(*spans, mathSpan{
+			html:  fmt.Sprintf(`<span class="%s">%s</span>`, class, latex),
+			plain: delim + latex + delim,
+		})
 		b.WriteString(text[last:loc[0]])
 		b.WriteString(mathPlaceholder(token, i))
 		last = loc[1]

--- a/web/markdown.go
+++ b/web/markdown.go
@@ -27,8 +27,12 @@ var (
 	imageRE     = regexp.MustCompile(`!\[([^\]]*)\]\(image://([^?)]+)(?:\?w=(\d+)&h=(\d+))?\)`)
 	htmlImageRE = regexp.MustCompile(`(<img\s+[^>]*?\bsrc=")image://([^"?]+)(?:\?[^"]*)?("[^>]*>)`)
 	// mathRE matches LaTeX math emitted by the DOCX converter: display
-	// ($$...$$) is tried before inline ($...$). Inline math may not span lines.
-	mathRE = regexp.MustCompile(`\$\$([^$]+)\$\$|\$([^$\n]+)\$`)
+	// ($$...$$) is tried before inline ($...$). Inline math may not span
+	// lines and — following the usual convention for dollar-delimited math —
+	// may not carry whitespace just inside its delimiters, so a sentence with
+	// two spaced-out dollar signs is not swallowed whole. isInlineMath
+	// rejects the rest.
+	mathRE = regexp.MustCompile(`\$\$([^$]+)\$\$|\$([^\s$](?:[^$\n]*[^\s$])?)\$`)
 
 	// fallbackTokenCount disambiguates math tokens minted in the same
 	// nanosecond when crypto/rand is unavailable.
@@ -245,20 +249,58 @@ func mathPlaceholder(token string, i int) string {
 
 // protectMath extracts LaTeX math spans from text, replacing each with a
 // placeholder built from token, and appends the <span> HTML to re-inject
-// after conversion to spans.
+// after conversion to spans. A $...$ span isInlineMath rejects is left alone,
+// so its dollar signs stay visible text.
 func protectMath(text, token string, spans *[]string) string {
-	return mathRE.ReplaceAllStringFunc(text, func(match string) string {
-		sub := mathRE.FindStringSubmatch(match)
-		display := sub[1] != ""
-		latex, class := sub[2], "math-inline"
+	locs := mathRE.FindAllStringSubmatchIndex(text, -1)
+	if locs == nil {
+		return text
+	}
+	var b strings.Builder
+	b.Grow(len(text))
+	last := 0
+	for _, loc := range locs {
+		display := loc[2] >= 0
+		class := "math-inline"
+		var latex string
 		if display {
-			latex, class = sub[1], "math-display"
+			latex, class = text[loc[2]:loc[3]], "math-display"
+		} else {
+			latex = text[loc[4]:loc[5]]
+			if !isInlineMath(text[last:loc[0]], latex) {
+				continue // prose, not math: leave the dollars as text
+			}
 		}
 		latex = htmlpkg.EscapeString(htmlpkg.UnescapeString(latex))
 		i := len(*spans)
 		*spans = append(*spans, fmt.Sprintf(`<span class="%s">%s</span>`, class, latex))
-		return mathPlaceholder(token, i)
-	})
+		b.WriteString(text[last:loc[0]])
+		b.WriteString(mathPlaceholder(token, i))
+		last = loc[1]
+	}
+	b.WriteString(text[last:])
+	return b.String()
+}
+
+// quoteBeforeRE matches a quote character — literal or entity — at the end of
+// the text preceding a math span.
+var quoteBeforeRE = regexp.MustCompile(`(?:["']|&(?:quot|apos|#34|#39);)$`)
+
+// isInlineMath reports whether the $...$ span latex, preceded by before, is
+// LaTeX rather than prose that happens to carry two dollar signs on one line.
+// 3GPP prose quotes the JSON Schema "$ref" keyword — '$ref', "$ref:
+// '#/components/schemas/X'" — and the text between two such mentions has no
+// whitespace at its edges, so the delimiter convention alone lets a whole
+// sentence render as math (TS 29.501 clause 5.3.9). Two shapes mark that
+// prose: an opening delimiter that a quote introduces, and a double quote
+// inside the span, which the converter's LaTeX never produces (a prime is an
+// apostrophe, so apostrophes stay legal). Both are checked after unescaping
+// because table-cell text reaches here already HTML-escaped.
+func isInlineMath(before, latex string) bool {
+	if quoteBeforeRE.MatchString(before) {
+		return false
+	}
+	return !strings.Contains(htmlpkg.UnescapeString(latex), `"`)
 }
 
 // highlightYAML applies Chroma syntax highlighting to YAML content.

--- a/web/sanitize.go
+++ b/web/sanitize.go
@@ -16,8 +16,13 @@ import (
 // skip in renderMarkdown). Any other angle bracket in body text is document
 // text — 3GPP prose is full of placeholders like <SUPI> — and must be
 // escaped so it stays visible instead of being parsed as markup.
+//
+// The match is case-sensitive on purpose: the pipeline only ever emits
+// lower-case tags, while 3GPP prose is full of upper-case abbreviations in
+// angle brackets (<UL>, <DL>, <TA>) that must stay visible text rather than
+// becoming real list elements and eating the paragraph around them.
 var allowedTagRE = regexp.MustCompile(
-	`(?i)^</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>`)
+	`^</?(?:img|li|ol|p|sub|sup|table|tbody|td|th|thead|tr|ul)(?:\s[^<>]*)?/?>`)
 
 // markerOpenRE and markerCloseRE match db.LinkifyRefs's unresolved-reference
 // markers in body text — only the exact class="ref-unresolved" form, so a

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -544,6 +544,16 @@ mark {
     font-weight: 400;
 }
 
+/* Section numbering goes deeper than HTML has heading elements, so headings
+   below level 5 all render as <h6>; the depth class keeps them visually
+   ordered. */
+.section-heading.depth-1 { font-size: 1.75rem; }
+.section-heading.depth-2 { font-size: 1.5rem; }
+.section-heading.depth-3 { font-size: 1.25rem; }
+.section-heading.depth-4 { font-size: 1.125rem; }
+.section-heading.depth-5 { font-size: 1.05rem; }
+.section-heading.depth-6 { font-size: 1rem; }
+
 .section-body {
     margin-top: 0.75rem;
 }

--- a/web/templates/spec.html
+++ b/web/templates/spec.html
@@ -41,9 +41,9 @@
 
         {{range .Sections}}
         <article class="section">
-            <h{{add .Level 1}} id="section-{{.Number}}">
+            <h{{headingLevel .Level}} class="section-heading depth-{{sectionDepth .Level}}" id="section-{{.Number}}">
                 {{if ne .Number .Title}}<span class="section-number">{{.Number}}</span> {{end}}{{.Title}}
-            </h{{add .Level 1}}>
+            </h{{headingLevel .Level}}>
             <div class="section-body">
                 {{.Content}}
             </div>

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -267,6 +267,61 @@ func TestRenderMarkdown_DollarProseNotMath(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_MathInAttributeStaysText verifies that a formula that
+// ends up inside an HTML attribute — figure captions like
+// "![$x_1$](image://...)" put one in alt — is re-injected as plain text.
+// Injecting the <span> there truncated the <img> tag and leaked attribute
+// fragments into the page as visible text.
+func TestRenderMarkdown_MathInAttributeStaysText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "sized image alt",
+			content: "![$x_1$](image://fig1.png?w=10&h=20)",
+			want:    `<img src="/specs/TS%2038.211/images/fig1.png" alt="$x_1$" width="10" height="20">`,
+		},
+		{
+			name:    "markdown image alt",
+			content: "![$x_1$](image://fig1.png)",
+			want:    `<img src="/specs/TS%2038.211/images/fig1.png" alt="$x_1$">`,
+		},
+		{
+			name:    "table cell image alt",
+			content: `<table><tbody><tr><td><img src="image://f.png" alt="$y^2$"></td></tr></tbody></table>`,
+			want:    `<img src="/specs/TS%2038.211/images/f.png" alt="$y^2$">`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderMarkdown(tt.content, renderOpts{specID: "TS 38.211"})
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("expected intact image %s, got:\n%s", tt.want, got)
+			}
+			if strings.Contains(got, `alt="&lt;span`) || strings.Contains(got, "&#34;&gt;") {
+				t.Errorf("no math element may be injected into an attribute, got:\n%s", got)
+			}
+			if strings.Contains(got, "math-inline") {
+				t.Errorf("attribute math must not become a span, got:\n%s", got)
+			}
+		})
+	}
+
+	// A formula in body text on the same page is still a KaTeX target.
+	t.Run("body math unaffected", func(t *testing.T) {
+		got := renderMarkdown("![$x_1$](image://fig1.png)\n\nwhere $x_1$ is the first value.",
+			renderOpts{specID: "TS 38.211"})
+		if !strings.Contains(got, `alt="$x_1$"`) {
+			t.Errorf("expected plain alt text, got:\n%s", got)
+		}
+		if !strings.Contains(got, `<span class="math-inline">x_1</span>`) {
+			t.Errorf("expected a math span in body text, got:\n%s", got)
+		}
+	})
+}
+
 func TestRefURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1000,6 +1000,43 @@ func TestRenderMarkdown_AngleBracketPlaceholderVisible(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_UppercasePlaceholderNotATag verifies that upper-case
+// abbreviations in angle brackets — <UL>, <DL>, <TD> are everyday 3GPP prose —
+// stay visible text. A case-insensitive tag allowlist turned them into real
+// list and table elements, which browsers use to restructure (and swallow)
+// the surrounding paragraph.
+func TestRenderMarkdown_UppercasePlaceholderNotATag(t *testing.T) {
+	content := "Scheduling for <UL> and <DL> is described per <TD> slot."
+	got := renderMarkdown(content, renderOpts{specID: "TS 38.300"})
+	for _, want := range []string{"&lt;UL&gt;", "&lt;DL&gt;", "&lt;TD&gt;"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s as escaped text, got:\n%s", want, got)
+		}
+	}
+	for _, bad := range []string{"<ul>", "<UL>", "<dl>", "<DL>", "<td>", "<TD>"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("placeholder must not become the %s element, got:\n%s", bad, got)
+		}
+	}
+	// The prose around the placeholders must survive intact.
+	if !strings.Contains(got, "Scheduling for") || !strings.Contains(got, "slot.") {
+		t.Errorf("paragraph text must not be swallowed, got:\n%s", got)
+	}
+}
+
+// TestRenderMarkdown_LowercasePipelineTagsAllowed guards the other side of
+// the case-sensitive allowlist: the tags the pipeline itself emits still pass
+// through unescaped.
+func TestRenderMarkdown_LowercasePipelineTagsAllowed(t *testing.T) {
+	content := "<ul><li>first</li><li>second</li></ul>"
+	got := renderMarkdown(content, renderOpts{specID: "TS 23.501"})
+	for _, want := range []string{"<ul>", "<li>first</li>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected pipeline markup %s to survive, got:\n%s", want, got)
+		}
+	}
+}
+
 // TestRenderMarkdown_EventHandlerStripped verifies the sanitizer half of the
 // defense: a tag that is in the allowlist (img) still cannot smuggle script
 // through attributes or a non-relative src.

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -536,6 +536,71 @@ func TestHandleSection_RawHTMLEscaped(t *testing.T) {
 	}
 }
 
+// TestHandleSection_DeepHeadingClamped verifies that a section deeper than
+// HTML has heading elements — TS 36.523-1 numbers clauses like 7.1.13.1.1.2 —
+// renders as a real <h6> instead of an unknown <h7> element.
+func TestHandleSection_DeepHeadingClamped(t *testing.T) {
+	ts, d := setupTestServer(t)
+
+	if err := d.UpsertSection(db.Section{
+		SpecID:  "TS 23.501",
+		Version: "18.6.0",
+		Number:  "7.1.13.1.1.2",
+		Title:   "Deeply nested test procedure",
+		Level:   6,
+		Content: "Body text of a level 6 section.",
+	}); err != nil {
+		t.Fatalf("UpsertSection: %v", err)
+	}
+
+	resp, err := http.Get(ts.URL + "/specs/TS 23.501/sections/7.1.13.1.1.2")
+	if err != nil {
+		t.Fatalf("GET section error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := readBody(t, resp)
+	for _, bad := range []string{"<h7", "</h7", "<h8", "</h8"} {
+		if strings.Contains(body, bad) {
+			t.Errorf("no %s element may be emitted, got:\n%s", bad, body)
+		}
+	}
+	if !strings.Contains(body, `<h6 class="section-heading depth-6" id="section-7.1.13.1.1.2">`) {
+		t.Errorf("expected the deep section to render as <h6>, got:\n%s", body)
+	}
+	if !strings.Contains(body, "</h6>") {
+		t.Errorf("expected a matching </h6> closer, got:\n%s", body)
+	}
+	if !strings.Contains(body, "Deeply nested test procedure") {
+		t.Errorf("expected the section title in the heading, got:\n%s", body)
+	}
+}
+
+// TestHandleSection_HeadingLevels checks the unclamped levels still map one
+// step below the page title.
+func TestHandleSection_HeadingLevels(t *testing.T) {
+	ts, _ := setupTestServer(t)
+
+	for _, tt := range []struct {
+		section string
+		want    string
+	}{
+		{"5", `<h2 class="section-heading depth-1" id="section-5">`},
+		{"5.1", `<h3 class="section-heading depth-2" id="section-5.1">`},
+		{"5.1.1", `<h4 class="section-heading depth-3" id="section-5.1.1">`},
+	} {
+		resp, err := http.Get(ts.URL + "/specs/TS 23.501/sections/" + tt.section)
+		if err != nil {
+			t.Fatalf("GET section %s error: %v", tt.section, err)
+		}
+		body := readBody(t, resp)
+		resp.Body.Close()
+		if !strings.Contains(body, tt.want) {
+			t.Errorf("section %s: expected %s, got:\n%s", tt.section, tt.want, body)
+		}
+	}
+}
+
 func TestHandleSection_PrevNext(t *testing.T) {
 	ts, _ := setupTestServer(t)
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -175,6 +175,98 @@ func TestRenderMarkdown_PlaceholderLiteralUntouched(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_DollarProseNotMath verifies that prose carrying two
+// dollar signs on one line — the JSON Schema "$ref" keyword, which TS 29.501
+// clause 5.3.9 mentions repeatedly — stays visible text instead of being
+// swallowed into a math span, while real math on the same page still renders.
+func TestRenderMarkdown_DollarProseNotMath(t *testing.T) {
+	proseCases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "double-quoted $ref mentions",
+			content: `a reference to the data type schema, i.e. "$ref: '#/components/schemas/ExType'" if that schema is in the same file and "$ref: 'other.yaml#/components/schemas/ExType'" otherwise;`,
+		},
+		{
+			name:    "single-quoted $ref mentions",
+			content: `the '$ref' keyword must be the only attribute of the JSON object, so no description may sit next to the '$ref' keyword.`,
+		},
+		{
+			name:    "table-cell $ref mentions are escaped before rendering",
+			content: `<table><tbody><tr><td><p>&quot;$ref: &#39;#/components/schemas/A&#39;&quot; or &quot;$ref: &#39;#/components/schemas/B&#39;&quot;</p></td></tr></tbody></table>`,
+		},
+		{
+			name:    "spaced dollars around prose",
+			content: `the value $ x $ is written with padding and $ y $ too.`,
+		},
+	}
+	for _, tt := range proseCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderMarkdown(tt.content, renderOpts{specID: "TS 29.501"})
+			if strings.Contains(got, "math-inline") || strings.Contains(got, "math-display") {
+				t.Errorf("prose must not become math, got:\n%s", got)
+			}
+			if !strings.Contains(got, "$") {
+				t.Errorf("the literal dollar signs must stay visible, got:\n%s", got)
+			}
+		})
+	}
+
+	mathCases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "modulo formula",
+			content: `the value $n \bmod 2$ is used`,
+			want:    `<span class="math-inline">n \bmod 2</span>`,
+		},
+		{
+			name:    "single symbol",
+			content: `on antenna port $p$ and subcarrier spacing $\mu$`,
+			want:    `<span class="math-inline">p</span>`,
+		},
+		{
+			name:    "math with inner spaces",
+			content: `$\left\{\begin{matrix} 0 & l=0 \\ 1 & otherwise \end{matrix}\right.$`,
+			want:    `<span class="math-inline">\left\{\begin{matrix} 0 &amp; l=0 \\ 1 &amp; otherwise \end{matrix}\right.</span>`,
+		},
+		{
+			name:    "prose and math on the same line",
+			content: `the '$ref' keyword and the '$ref' value, but $x^2$ is math`,
+			want:    `<span class="math-inline">x^2</span>`,
+		},
+		{
+			// The converter renders U+2032/U+2033 as ASCII apostrophes
+			// (converter/docx/omml.go mathSymbols), so primes must not read
+			// as prose quoting.
+			name:    "prime derivative",
+			content: `the derivative ${f}'\left(x\right)$ of the function`,
+			want:    `<span class="math-inline">{f}&#39;\left(x\right)</span>`,
+		},
+		{
+			name:    "bare prime",
+			content: `the value $f'$ follows`,
+			want:    `<span class="math-inline">f&#39;</span>`,
+		},
+		{
+			name:    "double prime",
+			content: `the second derivative $f''(x)$ follows`,
+			want:    `<span class="math-inline">f&#39;&#39;(x)</span>`,
+		},
+	}
+	for _, tt := range mathCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderMarkdown(tt.content, renderOpts{specID: "TS 38.211"})
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("expected math span %s, got:\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestRefURL(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Four rendering defects in the web viewer.

- **Inline math no longer swallows prose.** `$...$` now requires a non-space
  character at each delimiter, and a span that a quote introduces (`'$ref'`,
  `"$ref: '#/components/schemas/X'"`) or that contains a double quote is
  treated as prose, so TS 29.501 clause 5.3.9 keeps its text. Prime notation
  stays math: the converter renders U+2032/U+2033 as apostrophes, so
  apostrophes remain legal inside a span.
- **The pre-goldmark tag allowlist matches case-sensitively.** The pipeline
  only emits lower-case tags, so upper-case placeholders (`<UL>`, `<DL>`,
  `<TD>`) stay visible text instead of becoming real elements that
  restructure and swallow the paragraph around them.
- **Math placeholders inside an HTML attribute are re-injected as plain
  LaTeX.** A figure caption like `[$x_1$](image://...)` put one in `alt`,
  where injecting a `<span>` truncated the `<img>` tag and leaked attribute
  fragments into the page as visible text.
- **Sections deeper than level 5 render as `<h6>`.** 3GPP numbering goes
  deeper than HTML has headings (TS 36.523-1 has 7.1.13.1.1.2), and `<h7>` is
  an unknown element with neither heading semantics nor styling. A `depth-N`
  class keeps the visual hierarchy.

Fixes #148
Fixes #149
Fixes #151
Fixes #152

## Verification

- `go test -short ./...` — regression tests added per issue: `$ref` prose vs.
  real math (including primes), `<UL>` placeholder vs. lower-case pipeline
  markup, math in `alt` attributes, and heading levels through template
  rendering.
- `gofmt -l .`, `go vet ./...`, `golangci-lint run` (0 issues); every commit
  builds on its own.
- ocr-review run twice against `origin/main`: the first pass caught the prime
  regression above, which is fixed and covered by tests; the second pass
  reported no findings.
- Playwright pass over a synthetic database carrying each reproduction —
  checked that `$ref` prose stays text, `<UL>` stays visible, images keep
  intact markup, deep sections render as `<h6>`, KaTeX still renders real
  formulas, and the page has no horizontal overflow.