### PR TITLE
fix(web): wrap compare filter form on narrow viewports

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -215,6 +215,7 @@ mark {
 /* === Filter Form === */
 .filter-form {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
The compare filter form gained a fourth input (`old_section`, #158) and now overflows horizontally at 1280px-wide viewports, pushing the Compare button off-screen: `.filter-form` is a flex row without wrapping. Allow the row to wrap.

Verification: Playwright against the deployed viewer reproduced a 62px horizontal overflow on the compare page at 1280×900; with this change the form wraps, the page has no horizontal overflow, and the Compare button is fully visible. `go build ./...` and `go test -short ./web/` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFXkBPs6Kc8AKXwLtkoow7)_