### PR TITLE
fix(pipeline): repeat .doc conversion runs and empty zip listing cache

### DIFF
--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -257,9 +257,10 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 
 	sem := make(chan struct{}, parallel)
 	type result struct {
-		specID   string
-		status   string
-		docFiles []string
+		specID    string
+		status    string
+		docFiles  []string
+		docxFiles []string
 	}
 	results := make(chan result, total)
 	var wg sync.WaitGroup
@@ -281,12 +282,13 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				log.Printf("  %s: download error: %v", spec.SpecID, err)
 			}
 			status := "FAILED"
-			var docFiles []string
+			var docFiles, docxFiles []string
 			if r != nil {
 				status = r.Status
 				docFiles = r.DocFiles
+				docxFiles = r.DocxFiles
 			}
-			results <- result{spec.SpecID, status, docFiles}
+			results <- result{spec.SpecID, status, docFiles, docxFiles}
 		}()
 	}
 
@@ -299,6 +301,11 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 	// extracted for it into the shared docDir below, so a later conversion
 	// pass can attribute success or failure back to the right spec.
 	docFilesBySpec := make(map[string][]string)
+	// directDocxBasenames is the set of .docx basenames this run extracted
+	// straight into outputDir. The publish step below uses it to tell a
+	// destination another spec just claimed (collision case 2) apart from one
+	// left over by an earlier invocation (case 5).
+	directDocxBasenames := make(map[string]bool)
 	i := 0
 	for r := range results {
 		i++
@@ -306,6 +313,9 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 		log.Printf("[%d/%d] %s: %s", i, total, r.specID, r.status)
 		if r.status == "DOC_ONLY" && len(r.docFiles) > 0 {
 			docFilesBySpec[r.specID] = r.docFiles
+		}
+		for _, p := range r.docxFiles {
+			directDocxBasenames[filepath.Base(p)] = true
 		}
 	}
 
@@ -333,9 +343,9 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 	//  2. direct .docx x converted .doc->.docx (one spec's archive ships a
 	//     .docx directly; a different DOC_ONLY spec's .doc converts to that
 	//     same basename): handled by the no-clobber publish below -- a
-	//     converted file is never allowed to overwrite an existing file in
-	//     outputDir. The spec that lost the race stays DOC_ONLY with a
-	//     logged warning instead of destroying the other spec's real
+	//     converted file is never allowed to overwrite a file another spec
+	//     extracted this run. The spec that lost the race stays DOC_ONLY
+	//     with a logged warning instead of destroying the other spec's real
 	//     output.
 	//  3. converted .doc x converted .doc, different specs (two DOC_ONLY
 	//     specs' .doc files share a basename): handled below via
@@ -355,9 +365,11 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 	//     definitely belongs to this spec, since no other spec claims it.
 	//  5. this run's converted output vs. a stale file already sitting at
 	//     the same outputDir path (a leftover from an earlier invocation,
-	//     since outputDir is never cleared between runs): handled by the
-	//     same no-clobber publish as case 2; a spec is only promoted when
-	//     its own file actually lands in outputDir this run.
+	//     since outputDir is never cleared between runs): the leftover is
+	//     replaced, the same refresh-on-rerun behaviour as case 1. By the
+	//     naming argument in case 1 it can only be this spec's own earlier
+	//     output, and refusing to publish over it would leave every repeat
+	//     run reporting the spec DOC_ONLY forever (see the publish step).
 	//
 	// docPathClaimants maps each shared docDir path to the set of distinct
 	// DOC_ONLY specs that recorded it (case 3), after deduplicating each
@@ -447,35 +459,64 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				// file. Only a file that is confirmed published counts as
 				// evidence a spec's conversion succeeded.
 				//
-				// Publishing uses os.Link (not os.Rename) so it fails
-				// closed on an existing destination instead of silently
-				// overwriting it (collision cases 2 and 5 in the survey
-				// above): a converted file may not be the only thing that
-				// ever wanted that outputDir path -- another spec's own
-				// .docx may already be sitting there from this very run, or
-				// from an earlier invocation of this command. Since convDir
-				// is a subdirectory of outputDir (same filesystem), the
-				// hard link always succeeds or fails atomically; there is
-				// no separate existence check to race against.
+				// Publishing tries os.Link (not os.Rename) first so it
+				// fails closed on an existing destination instead of
+				// silently overwriting it (collision case 2 in the survey
+				// above): another spec's own .docx may already be sitting
+				// at that path from this very run. Since convDir is a
+				// subdirectory of outputDir (same filesystem), the hard
+				// link always succeeds or fails atomically; there is no
+				// separate existence check to race against.
+				//
+				// An occupied destination that this run did not itself
+				// write is a stale leftover from an earlier invocation
+				// (case 5), and there it is replaced rather than refused.
+				// Refusing would make every repeat run of this command a
+				// no-op for .doc specs: the first run leaves its converted
+				// .docx in outputDir, so every later run hits EEXIST,
+				// reports the spec DOC_ONLY even though its output is
+				// sitting right there, and throws the fresh conversion
+				// away. Such a leftover can only be this spec's own earlier
+				// output -- archive filenames carry the spec's own
+				// series+number, so no other spec produces the basename --
+				// which makes replacing it the same refresh-on-rerun
+				// behaviour direct .docx downloads already have (case 1).
+				//
+				// keepScratch records that convDir still holds a converted
+				// file which reached neither outputDir nor a deliberate
+				// skip. The cleanup below must not delete those: they are
+				// the only copy in existence.
+				keepScratch := false
 				published := make(map[string]bool)
-				if convEntries, err := os.ReadDir(convDir); err == nil {
-					for _, e := range convEntries {
-						if unattributableBasenames[e.Name()] {
-							log.Printf("  publish converted %s: skipped, ambiguous ownership (shared .doc basename, see warning above)", e.Name())
-							continue
-						}
-						src := filepath.Join(convDir, e.Name())
-						dst := filepath.Join(outputDir, e.Name())
-						if err := os.Link(src, dst); err != nil {
-							if os.IsExist(err) {
-								log.Printf("  publish converted %s: skipped, %s already exists in outputDir", e.Name(), e.Name())
-							} else {
-								log.Printf("  publish converted %s: %v", e.Name(), err)
-							}
-							continue
-						}
-						published[e.Name()] = true
+				convEntries, readErr := os.ReadDir(convDir)
+				if readErr != nil {
+					// Nothing can be published or attributed, and whatever
+					// was converted is still in there unread.
+					log.Printf("  read doc conversion scratch dir %s: %v", convDir, readErr)
+					keepScratch = true
+				}
+				for _, e := range convEntries {
+					if unattributableBasenames[e.Name()] {
+						log.Printf("  publish converted %s: skipped, ambiguous ownership (shared .doc basename, see warning above)", e.Name())
+						continue
 					}
+					src := filepath.Join(convDir, e.Name())
+					dst := filepath.Join(outputDir, e.Name())
+					err := os.Link(src, dst)
+					if os.IsExist(err) {
+						if directDocxBasenames[e.Name()] {
+							log.Printf("  publish converted %s: skipped, another spec's own .docx already occupies that path", e.Name())
+							continue
+						}
+						log.Printf("  publish converted %s: replacing stale output from an earlier run", e.Name())
+						err = os.Rename(src, dst)
+					}
+					if err != nil {
+						log.Printf("  publish converted %s: %v", e.Name(), err)
+						keepScratch = true
+						continue
+					}
+					published[e.Name()] = true
 				}
 
 				// A spec is promoted from DOC_ONLY to OK only when one of
@@ -487,7 +528,17 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 				// several .doc files could absorb the whole converted-file
 				// budget and drag an unrelated, fully-failed spec's status
 				// up to OK along with it.
+				//
+				// consumed collects the source .doc files whose conversion
+				// did reach outputDir, so they can be dropped from the
+				// shared docDir. Nothing else ever clears that directory,
+				// and it is converted wholesale on every run: leaving a
+				// finished .doc behind means every later invocation feeds
+				// it through LibreOffice again (serially, one process per
+				// file) only to discard the result.
+				var consumed []string
 				for _, docFiles := range docFilesBySpec {
+					promoted := false
 					for _, docPath := range docFiles {
 						if unattributable[docPath] {
 							continue
@@ -496,13 +547,26 @@ func DownloadSpecs(ctx context.Context, client *http.Client, specs []*SpecVersio
 						if !published[base] {
 							continue
 						}
-						stats["DOC_ONLY"]--
-						stats["OK"]++
-						break
+						consumed = append(consumed, docPath)
+						if !promoted {
+							promoted = true
+							stats["DOC_ONLY"]--
+							stats["OK"]++
+						}
+					}
+				}
+				for _, docPath := range consumed {
+					// Duplicate basenames within one spec's archive (case 4)
+					// resolve to the same extracted path, so a repeat
+					// removal is expected, not an error.
+					if err := os.Remove(docPath); err != nil && !os.IsNotExist(err) {
+						log.Printf("  remove converted source %s: %v", filepath.Base(docPath), err)
 					}
 				}
 
-				if err := os.RemoveAll(convDir); err != nil {
+				if keepScratch {
+					log.Printf("  doc conversion scratch dir kept at %s: it holds converted file(s) that could not be published", convDir)
+				} else if err := os.RemoveAll(convDir); err != nil {
 					log.Printf("  cleanup doc conversion scratch dir: %v", err)
 				}
 			}

--- a/converter/pipeline/download_test.go
+++ b/converter/pipeline/download_test.go
@@ -557,9 +557,13 @@ func TestDownloadSpecs_ConvertDocDuplicateBasenameWithinOneSpec(t *testing.T) {
 // counted OK, and the scratch-dir cleanup that follows would delete the only
 // copy of the file that had ever existed -- leaving an "OK" spec with no
 // .docx anywhere. This plants a directory at the exact path the converted
-// .docx would publish to, which makes os.Rename fail deterministically
-// (renaming a regular file onto a directory always errors), and checks the
-// spec stays DOC_ONLY with the scratch file gone rather than orphaned.
+// .docx would publish to, which makes the publish fail deterministically
+// (neither linking nor renaming a regular file onto a directory can succeed),
+// and checks the spec stays DOC_ONLY.
+//
+// The scratch directory is kept in that case: an unpublishable converted file
+// is the only copy that exists, so deleting it destroys the conversion's only
+// result on any publish failure that is not the deliberate no-clobber skip.
 func TestDownloadSpecs_ConvertDocPublishFailureStaysDocOnly(t *testing.T) {
 	writeFakeLibreOffice(t)
 
@@ -593,10 +597,82 @@ func TestDownloadSpecs_ConvertDocPublishFailureStaysDocOnly(t *testing.T) {
 	}
 
 	// The blocking directory must still be the untouched directory it was:
-	// the rename must not have partially clobbered it.
+	// the publish must not have partially clobbered it.
 	info, err := os.Stat(filepath.Join(outputDir, "blocked.docx"))
 	if err != nil || !info.IsDir() {
 		t.Errorf("blocked.docx = %v (isDir=%v), want the original directory intact", err, info != nil && info.IsDir())
+	}
+
+	// The converted file is unreachable from outputDir, so the scratch copy
+	// is all there is; the cleanup must have left it alone.
+	if !scratchDocxExists(t, outputDir, "blocked.docx") {
+		t.Error("converted blocked.docx not found in any scratch dir: an unpublishable conversion result must not be deleted")
+	}
+}
+
+// scratchDocxExists reports whether a converted file with the given basename
+// survives in one of the .doc-convert-* scratch directories under outputDir.
+func scratchDocxExists(t *testing.T, outputDir, name string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		t.Fatalf("read outputDir: %v", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), ".doc-convert-") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(outputDir, e.Name(), name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDownloadSpecs_ConvertDocRepeatRunPromotes verifies that running the same
+// download --convert-doc into the same persistent --output-dir twice reports
+// the spec OK both times. The publish step deliberately refuses to clobber an
+// existing destination, but the file a second run collides with is the first
+// run's own converted output: treating that as a lost race left the spec
+// reported DOC_ONLY forever, with the freshly converted .docx thrown away by
+// the scratch-dir cleanup even though the spec was fully converted on disk.
+func TestDownloadSpecs_ConvertDocRepeatRunPromotes(t *testing.T) {
+	writeFakeLibreOffice(t)
+
+	zip := makeZipWithFiles(t, map[string][]byte{
+		"specJ.doc": []byte("j1"),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zip)
+	}))
+	defer ts.Close()
+
+	specs := []*SpecVersion{
+		{SpecID: "TS 88.010", URL: ts.URL + "/j.zip"},
+	}
+
+	outputDir := t.TempDir()
+	if stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second); stats["OK"] != 1 {
+		t.Fatalf("first run: OK = %d, want 1", stats["OK"])
+	}
+
+	// A converted .doc must not be left in the shared _doc_files directory:
+	// it is converted wholesale on every run, so a finished file left behind
+	// is re-run through LibreOffice on every later invocation.
+	if _, err := os.Stat(filepath.Join(outputDir, "_doc_files", "specJ.doc")); !os.IsNotExist(err) {
+		t.Errorf("specJ.doc stat = %v, want it removed after a successful conversion", err)
+	}
+
+	stats := DownloadSpecs(context.Background(), &http.Client{}, specs, outputDir, 2, true, 10*time.Second)
+	if stats["OK"] != 1 {
+		t.Errorf("second run: OK = %d, want 1 (the existing .docx is this spec's own output from the first run)", stats["OK"])
+	}
+	if stats["DOC_ONLY"] != 0 {
+		t.Errorf("second run: DOC_ONLY = %d, want 0", stats["DOC_ONLY"])
+	}
+	if scratchDocxExists(t, outputDir, "specJ.docx") {
+		t.Error("scratch dir kept after a successful publish: the converted file did reach outputDir")
 	}
 }
 

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -217,7 +217,17 @@ func FetchSpecZips(ctx context.Context, client *http.Client, specID string, useC
 	log.Printf("Found %d versions for %s", len(entries), specDir)
 
 	if useCache {
-		if err := SaveCache(cacheKey, entries); err != nil {
+		// A listing with no .zip in it is not a real answer: every spec
+		// directory in the archive holds at least one version, so an empty
+		// result means the response was unusable (an error page served as
+		// 200, a redirect, a truncated body). Caching it would pin the spec
+		// to "no versions available" for the whole TTL, because an empty
+		// cache file counts as a hit and never triggers a re-fetch.
+		// FetchSpecList refuses to cache its own partial results for the
+		// same reason.
+		if len(entries) == 0 {
+			log.Printf("warning: no .zip entries found for %s; not caching this empty listing", specDir)
+		} else if err := SaveCache(cacheKey, entries); err != nil {
 			log.Printf("warning: failed to save cache: %v", err)
 		}
 	}

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -281,6 +281,52 @@ func TestFetchSpecZips(t *testing.T) {
 	})
 }
 
+// TestFetchSpecZips_EmptyListingNotCached verifies that a directory listing
+// which yields no .zip at all is never written to the cache. An empty cache
+// file is a hit rather than a miss (see TestLoadCache_EmptyResultIsCacheHit),
+// so caching one unusable response -- an error page served as 200, a redirect,
+// a truncated body -- would pin the spec to "no versions available" for the
+// full 24h TTL with no way to re-fetch.
+func TestFetchSpecZips_EmptyListingNotCached(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	var zipsServed bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, r *http.Request) {
+		if !zipsServed {
+			// First response looks fine to HTTP but lists no archive.
+			fmt.Fprint(w, `<a href="index.html">index.html</a>`+"\n")
+			return
+		}
+		fmt.Fprint(w, `<a href="23501-k10.zip">23501-k10.zip</a>`+"\n")
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL},
+	}
+
+	entries, err := FetchSpecZips(context.Background(), client, "23.501", true)
+	if err != nil {
+		t.Fatalf("FetchSpecZips: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("got %d entries, want 0: %v", len(entries), entries)
+	}
+
+	// The next call must reach the server again instead of replaying the
+	// empty result from cache.
+	zipsServed = true
+	entries, err = FetchSpecZips(context.Background(), client, "23.501", true)
+	if err != nil {
+		t.Fatalf("FetchSpecZips (retry): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("got %d entries, want 1: the empty listing must not have been cached", len(entries))
+	}
+}
+
 // TestFetchSpecList_Race exercises FetchSpecList with a mock 3GPP directory
 // structure to detect race conditions in the two-phase goroutine fan-out.
 func TestFetchSpecList_Race(t *testing.T) {


### PR DESCRIPTION
Three fixes found while reviewing #161.

## Repeat `download --convert-doc` runs never promote a spec

The no-clobber publish refused any occupied destination. On a second run into the same `--output-dir`, `os.Link` hits EEXIST on the first run's own `.docx`, so the spec stays DOC_ONLY forever and the fresh conversion is discarded.

A leftover from an earlier invocation is now replaced, matching the refresh-on-rerun behaviour direct `.docx` downloads already have. Only a path another spec claimed in the same run is still refused, which is what collision case 2 is about; those two cases are told apart with the `.docx` basenames extracted this run.

## `_doc_files` accumulates forever

Nothing ever cleared the shared doc directory, and it is converted wholesale on every run, so each invocation fed every already-converted `.doc` through LibreOffice again (serially, one process per file) only to throw the result away. Each source `.doc` is now removed once its conversion reaches `outputDir`.

## `os.RemoveAll(convDir)` could destroy the only copy

Cleanup ran unconditionally. When `os.Link` failed for a reason other than an existing destination (no hard-link support, ENOSPC, EPERM), or when the scratch dir could not be read at all, the converted `.docx` was deleted with nothing left in `outputDir`. The scratch dir is now kept and its path logged when it still holds an unpublished file. The `os.ReadDir` error is no longer swallowed either.

## `FetchSpecZips` caches empty listings

An empty cache file counts as a hit, so a 200 response containing no `.zip` link pinned the spec to "no versions available" for the full 24h TTL with no way to re-fetch. `FetchSpecList` already refuses to cache its own partial results; `FetchSpecZips` now does the same.

## Tests

Three regression tests, each failing on the current `main` and passing here:

- `TestDownloadSpecs_ConvertDocRepeatRunPromotes` — two runs into the same output dir, both OK, `_doc_files` cleaned
- `TestDownloadSpecs_ConvertDocPublishFailureStaysDocOnly` — extended to assert the unpublishable conversion result survives
- `TestFetchSpecZips_EmptyListingNotCached`

`gofmt`, `go vet`, `golangci-lint run` (v2.6.2) and `go test -race ./...` are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGkoZac754FspMZv2kARfv)_