### PR TITLE
feat(cli): add query subcommands mirroring MCP read tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,10 @@ make web                  # HTTP server with web viewer at :8080
 
 ## Package Map
 
-- `cmd/3gpp-mcp/` — CLI entry point (serve, build, download, import, import-dir, update)
+- `cmd/3gpp-mcp/` — CLI entry point (serve, build, download, import, import-dir,
+  update, plus query subcommands mirroring the MCP read tools 1:1 in `query.go`).
+  New subcommands register in the `commands` slice in `main.go` — dispatch, the
+  usage line and the shell completion scripts are all generated from it
 - `converter/docx/` — DOCX → Markdown parser; `converter/pipeline/` — streaming download + convert worker pool
 - `db/` — SQLite schema, queries, FTS5
 - `versionstore/` — on-demand cache of spec versions not in the prebuilt database

--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ Conventions shared by all of them:
   wait for an on-demand download to finish instead of asking you to retry;
   interrupt with Ctrl-C. They share `serve`'s fetch flags: `--no-fetch`,
   `--version-cache`, `--version-cache-mb`, `--fetch-budget`. Queries that name
-  no version never touch the version cache.
+  no version never create the version cache (`list-versions` reads an existing
+  cache to report `cached` availability, but will not create one).
 - Every command takes `--db` (default `3gpp.db`).
 
 ### `list-specs`
@@ -586,7 +587,7 @@ Usage: `3gpp-mcp compare-versions [flags] --old <version> <spec-id>`
 | `--new` | Newer version to compare to | the database version |
 | `--section` | Compare only this section's text as a unified diff | |
 | `--subsections` | With `--section`: include subsections in the diff | `false` |
-| `--context` | Unchanged lines shown around each change in a section diff | `3` |
+| `--context` | Unchanged lines shown around each change in a section diff (`0` shows none) | `3` |
 
 ### `search`
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ To run on Cloud Run, see `cloudbuild.yaml` (build + push + deploy) and
 
 ## MCP Tools
 
+Every tool below also has a CLI twin (`list_specs` → `3gpp-mcp list-specs`, and
+so on) for shell use and scripting — see the
+[query commands](#query-commands) in the Command Reference.
+
 ### Browsing specifications
 
 | Tool | Description | Key Parameters |
@@ -506,6 +510,152 @@ Update specifications in the database to latest versions.
 | `--no-cache` | Disable the spec list cache | `false` |
 | `--scrape-workers` | Concurrency for scraping spec listings (`0` = auto) | `0` |
 | `--timeout` | HTTP timeout | `30s` |
+
+### Query commands
+
+The query commands mirror the MCP read tools 1:1, so the database can be
+inspected and scripted from a shell without an MCP client:
+
+```bash
+3gpp-mcp search --db data/3gpp.db --limit 3 "AMF AND authentication" | jq '.results[].section_number'
+3gpp-mcp get-section --db data/3gpp.db "TS 23.501" 5.15.2 | less
+```
+
+Conventions shared by all of them:
+
+- Flags must come before positional arguments.
+- JSON results print to stdout indented and unpaginated — pipe to `jq`,
+  `head` or `less`. Warnings and progress notes go to stderr, so stdout stays
+  parseable.
+- Commands that accept `--version` (and `compare-versions`) take the same
+  version forms as the MCP tools (`15.8.0`, `f80`, `Rel-15`, `latest`) and
+  wait for an on-demand download to finish instead of asking you to retry;
+  interrupt with Ctrl-C. They share `serve`'s fetch flags: `--no-fetch`,
+  `--version-cache`, `--version-cache-mb`, `--fetch-budget`. Queries that name
+  no version never touch the version cache.
+- Every command takes `--db` (default `3gpp.db`).
+
+### `list-specs`
+
+List specifications in the database as JSON.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--series` | Filter by series number (e.g. `23`) | |
+| `--query` | Filter specs whose ID starts with this text (e.g. `38.21`) | |
+| `--limit` | Maximum number of results | `20` |
+| `--offset` | Number of results to skip | `0` |
+
+### `list-versions`
+
+List the versions of a specification as JSON, newest first, with each
+version's availability (`database`, `cached` or `archive`). An unreachable
+archive is reported as a warning on stderr and the listing continues with the
+cache and the database.
+
+Usage: `3gpp-mcp list-versions [flags] <spec-id>`
+
+### `get-toc`
+
+Print a specification's table of contents as Markdown.
+
+Usage: `3gpp-mcp get-toc [--version <v>] [fetch flags] <spec-id>`
+
+### `get-section`
+
+Print a section's Markdown content, prefixed with the same provenance header
+as the MCP tool, without pagination.
+
+Usage: `3gpp-mcp get-section [flags] <spec-id> <section-number>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--version` | Specification version to read | the database version |
+| `--subsections` | Include all subsections | `false` |
+
+### `compare-versions`
+
+Compare two versions of a specification: a structural summary, or a unified
+diff of one section with `--section`.
+
+Usage: `3gpp-mcp compare-versions [flags] --old <version> <spec-id>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--old` | Older version to compare from (required) | |
+| `--new` | Newer version to compare to | the database version |
+| `--section` | Compare only this section's text as a unified diff | |
+| `--subsections` | With `--section`: include subsections in the diff | `false` |
+| `--context` | Unchanged lines shown around each change in a section diff | `3` |
+
+### `search`
+
+Full-text search; results print as JSON. The query supports the same FTS5
+syntax as the MCP tool, and everything after the flags is joined into one
+query, so multi-term queries need no quoting: `3gpp-mcp search AMF AND authentication`.
+
+Usage: `3gpp-mcp search [flags] <query>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--specs` | Limit search to specific specs, comma-separated (e.g. `"TS 23.501,TS 23.502"`) | |
+| `--limit` | Maximum number of results per page (max 200) | `10` |
+| `--offset` | Number of results to skip | `0` |
+
+### `list-openapi`
+
+List OpenAPI definitions as JSON.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--spec` | Filter by specification ID (e.g. `TS 29.510`) | |
+
+### `get-openapi`
+
+Print an OpenAPI definition as YAML, without pagination.
+
+Usage: `3gpp-mcp get-openapi [flags] <spec-id> <api-name>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--path` | Filter by API path (e.g. `/nf-instances`) | |
+| `--schema` | Filter by schema name (e.g. `NFProfile`) | |
+
+### `get-references`
+
+Print cross-references as JSON. Unlike the MCP tool, the full result is
+printed with no 500-row cap — that cap protects an LLM context window, which
+a shell pipeline does not have.
+
+Usage: `3gpp-mcp get-references [flags] <spec-id> [section-number]`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--direction` | `outgoing`: references FROM a section (section number required); `incoming`: references TO this spec | `outgoing` |
+| `--subsections` | Include subsections when collecting outgoing references | `false` |
+
+### `list-images`
+
+List a specification's embedded images as JSON (`{images, count}`).
+
+Usage: `3gpp-mcp list-images [--version <v>] [fetch flags] <spec-id>`
+
+### `get-image`
+
+Write an embedded image's raw bytes to a file or stdout. Name, MIME type and
+size go to stderr. Unlike the MCP tool, an EMF/WMF image is still written —
+a shell user can open it — with a conversion note on stderr.
+
+Usage: `3gpp-mcp get-image [flags] <spec-id> <image-name>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--version` | Specification version to read | the database version |
+| `-o` | Write the image to this file | stdout |
+
+```bash
+3gpp-mcp get-image --db data/3gpp.db -o figure1.png "TS 23.501" image1.png
+```
 
 ### `completion`
 

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -654,13 +654,15 @@ complete -F _3gpp_mcp 3gpp-mcp
 	case "zsh":
 		fmt.Print("#compdef 3gpp-mcp\n\n_3gpp_mcp() {\n    local -a commands\n    commands=(\n")
 		for _, c := range commands {
-			fmt.Printf("        '%s:%s'\n", c.name, c.desc)
+			// A description with an apostrophe would terminate the quoted
+			// string and corrupt the script.
+			fmt.Printf("        '%s:%s'\n", c.name, strings.ReplaceAll(c.desc, "'", `'\''`))
 		}
 		fmt.Print("    )\n    _describe '3gpp-mcp command' commands\n}\n\n_3gpp_mcp\n")
 	case "fish":
 		fmt.Print("# fish completion for 3gpp-mcp\ncomplete -c 3gpp-mcp -f\n")
 		for _, c := range commands {
-			fmt.Printf("complete -c 3gpp-mcp -n \"not __fish_seen_subcommand_from %s\" -a %s -d '%s'\n", names, c.name, c.desc)
+			fmt.Printf("complete -c 3gpp-mcp -n \"not __fish_seen_subcommand_from %s\" -a %s -d '%s'\n", names, c.name, strings.ReplaceAll(c.desc, "'", `\'`))
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown shell: %s (supported: bash, zsh, fish)\n", args[0])

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -109,6 +109,17 @@ func init() {
 		{name: "import", aliases: []string{"convert"}, desc: "Import a single DOCX file into database", run: cmdConvert},
 		{name: "import-dir", aliases: []string{"convert-dir"}, desc: "Import a directory of DOCX files into database", run: cmdConvertDir},
 		{name: "update", desc: "Update database to latest spec versions", run: cmdUpdate},
+		{name: "list-specs", desc: "List specifications in the database", run: cmdListSpecs},
+		{name: "list-versions", desc: "List versions of a specification", run: cmdListVersions},
+		{name: "get-toc", desc: "Print a specification's table of contents", run: cmdGetTOC},
+		{name: "get-section", desc: "Print a section's markdown content", run: cmdGetSection},
+		{name: "compare-versions", desc: "Compare two versions of a specification", run: cmdCompareVersions},
+		{name: "search", desc: "Full-text search across specifications", run: cmdSearch},
+		{name: "list-openapi", desc: "List OpenAPI definitions", run: cmdListOpenAPI},
+		{name: "get-openapi", desc: "Print an OpenAPI definition", run: cmdGetOpenAPI},
+		{name: "get-references", desc: "Print cross-references as JSON", run: cmdGetReferences},
+		{name: "list-images", desc: "List embedded images in a specification", run: cmdListImages},
+		{name: "get-image", desc: "Write an embedded image to a file or stdout", run: cmdGetImage},
 		{name: "completion", desc: "Generate shell completion scripts", run: cmdCompletion},
 	}
 }

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -85,36 +85,73 @@ func buildHTTPHandler(src *tools.Source, s *mcp.Server, bearerToken string, enab
 	return mux
 }
 
+// command is one CLI subcommand. The dispatch in main, the usage line and
+// the shell completion scripts are all generated from the commands table, so
+// registering a command there is the only step needed to expose it everywhere.
+type command struct {
+	name    string
+	aliases []string
+	desc    string
+	run     func(args []string)
+}
+
+// commands is ordered for the usage line and completion listings. Aliases are
+// dispatchable but stay out of both. Populated in init because cmdCompletion
+// renders this very table, which a composite literal would turn into an
+// initialization cycle.
+var commands []command
+
+func init() {
+	commands = []command{
+		{name: "serve", desc: "Start the MCP server", run: cmdServe},
+		{name: "build", aliases: []string{"pipeline"}, desc: "Download and import specs into database", run: cmdPipeline},
+		{name: "download", desc: "Download spec files from 3GPP archive", run: cmdDownload},
+		{name: "import", aliases: []string{"convert"}, desc: "Import a single DOCX file into database", run: cmdConvert},
+		{name: "import-dir", aliases: []string{"convert-dir"}, desc: "Import a directory of DOCX files into database", run: cmdConvertDir},
+		{name: "update", desc: "Update database to latest spec versions", run: cmdUpdate},
+		{name: "completion", desc: "Generate shell completion scripts", run: cmdCompletion},
+	}
+}
+
+// commandNames returns the primary command names in table order.
+func commandNames() []string {
+	names := make([]string, len(commands))
+	for i, c := range commands {
+		names[i] = c.name
+	}
+	return names
+}
+
+// lookupCommand resolves a primary name or alias to its command.
+func lookupCommand(name string) *command {
+	for i := range commands {
+		c := &commands[i]
+		if c.name == name {
+			return c
+		}
+		for _, a := range c.aliases {
+			if a == name {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp <command> [options]")
-		fmt.Fprintln(os.Stderr, "Commands: serve, build, download, import, import-dir, update, completion")
+		fmt.Fprintln(os.Stderr, "Commands: "+strings.Join(commandNames(), ", "))
 		os.Exit(1)
 	}
 
-	command := os.Args[1]
-	args := os.Args[2:]
-
-	switch command {
-	case "serve":
-		cmdServe(args)
-	case "download":
-		cmdDownload(args)
-	case "import", "convert":
-		cmdConvert(args)
-	case "import-dir", "convert-dir":
-		cmdConvertDir(args)
-	case "build", "pipeline":
-		cmdPipeline(args)
-	case "update":
-		cmdUpdate(args)
-	case "completion":
-		cmdCompletion(args)
-	default:
-		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", command)
-		fmt.Fprintln(os.Stderr, "Commands: serve, build, download, import, import-dir, update, completion")
+	c := lookupCommand(os.Args[1])
+	if c == nil {
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
+		fmt.Fprintln(os.Stderr, "Commands: "+strings.Join(commandNames(), ", "))
 		os.Exit(1)
 	}
+	c.run(os.Args[2:])
 }
 
 // defaultVersionCacheMB reads the version cache limit from the environment,
@@ -590,48 +627,30 @@ func cmdCompletion(args []string) {
 		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp completion <bash|zsh|fish>")
 		os.Exit(1)
 	}
+	names := strings.Join(commandNames(), " ")
 	switch args[0] {
 	case "bash":
-		fmt.Print(`# bash completion for 3gpp-mcp
+		fmt.Printf(`# bash completion for 3gpp-mcp
 _3gpp_mcp() {
-    local commands="serve build download import import-dir update completion"
+    local commands="%s"
     local cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ ${COMP_CWORD} -eq 1 ]]; then
         COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
     fi
 }
 complete -F _3gpp_mcp 3gpp-mcp
-`)
+`, names)
 	case "zsh":
-		fmt.Print(`#compdef 3gpp-mcp
-
-_3gpp_mcp() {
-    local -a commands
-    commands=(
-        'serve:Start the MCP server'
-        'build:Download and import specs into database'
-        'download:Download spec files from 3GPP archive'
-        'import:Import a single DOCX file into database'
-        'import-dir:Import a directory of DOCX files into database'
-        'update:Update database to latest spec versions'
-        'completion:Generate shell completion scripts'
-    )
-    _describe '3gpp-mcp command' commands
-}
-
-_3gpp_mcp
-`)
+		fmt.Print("#compdef 3gpp-mcp\n\n_3gpp_mcp() {\n    local -a commands\n    commands=(\n")
+		for _, c := range commands {
+			fmt.Printf("        '%s:%s'\n", c.name, c.desc)
+		}
+		fmt.Print("    )\n    _describe '3gpp-mcp command' commands\n}\n\n_3gpp_mcp\n")
 	case "fish":
-		fmt.Print(`# fish completion for 3gpp-mcp
-complete -c 3gpp-mcp -f
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a serve      -d 'Start the MCP server'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a build      -d 'Download and import specs into database'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a download   -d 'Download spec files from 3GPP archive'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a import     -d 'Import a single DOCX file into database'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a import-dir -d 'Import a directory of DOCX files into database'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a update     -d 'Update database to latest spec versions'
-complete -c 3gpp-mcp -n "not __fish_seen_subcommand_from serve build download import import-dir update completion" -a completion -d 'Generate shell completion scripts'
-`)
+		fmt.Print("# fish completion for 3gpp-mcp\ncomplete -c 3gpp-mcp -f\n")
+		for _, c := range commands {
+			fmt.Printf("complete -c 3gpp-mcp -n \"not __fish_seen_subcommand_from %s\" -a %s -d '%s'\n", names, c.name, c.desc)
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown shell: %s (supported: bash, zsh, fish)\n", args[0])
 		os.Exit(1)

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -196,6 +196,23 @@ func TestCmdCompletion_ListsEveryCommand(t *testing.T) {
 	}
 }
 
+// TestLookupCommand pins registry dispatch: primary names and aliases both
+// resolve, unknown names do not.
+func TestLookupCommand(t *testing.T) {
+	if c := lookupCommand("build"); c == nil || c.name != "build" {
+		t.Errorf("lookupCommand(build) = %v", c)
+	}
+	if c := lookupCommand("pipeline"); c == nil || c.name != "build" {
+		t.Errorf("expected alias pipeline to resolve to build, got %v", c)
+	}
+	if c := lookupCommand("convert-dir"); c == nil || c.name != "import-dir" {
+		t.Errorf("expected alias convert-dir to resolve to import-dir, got %v", c)
+	}
+	if c := lookupCommand("no-such-command"); c != nil {
+		t.Errorf("expected nil for unknown command, got %v", c)
+	}
+}
+
 // TestCmdCompletion_EscapesQuotes pins the quoting of descriptions containing
 // apostrophes ("Print a specification's ..."): unescaped, the apostrophe
 // would terminate the script's single-quoted string and corrupt it.

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -196,6 +196,20 @@ func TestCmdCompletion_ListsEveryCommand(t *testing.T) {
 	}
 }
 
+// TestCmdCompletion_EscapesQuotes pins the quoting of descriptions containing
+// apostrophes ("Print a specification's ..."): unescaped, the apostrophe
+// would terminate the script's single-quoted string and corrupt it.
+func TestCmdCompletion_EscapesQuotes(t *testing.T) {
+	zsh := captureStdout(t, func() { cmdCompletion([]string{"zsh"}) })
+	if !strings.Contains(zsh, `specification'\''s`) {
+		t.Errorf("zsh completion does not escape apostrophes:\n%s", zsh)
+	}
+	fish := captureStdout(t, func() { cmdCompletion([]string{"fish"}) })
+	if !strings.Contains(fish, `specification\'s`) {
+		t.Errorf("fish completion does not escape apostrophes:\n%s", fish)
+	}
+}
+
 // projectRoot returns the path to the repository root by walking up from the
 // current test file location.
 func projectRoot(t *testing.T) string {

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -178,6 +178,24 @@ func TestCmdCompletion(t *testing.T) {
 	}
 }
 
+// TestCmdCompletion_ListsEveryCommand pins the completion scripts to the
+// command registry: a command registered in commands must appear in all three
+// shells' output.
+func TestCmdCompletion_ListsEveryCommand(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				cmdCompletion([]string{shell})
+			})
+			for _, c := range commands {
+				if !strings.Contains(out, c.name) {
+					t.Errorf("%s completion is missing command %q", shell, c.name)
+				}
+			}
+		})
+	}
+}
+
 // projectRoot returns the path to the repository root by walking up from the
 // current test file location.
 func projectRoot(t *testing.T) string {

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -366,16 +366,27 @@ const defaultCLIContextLines = 3
 // compareSides reads both versions' sections in one poll round so both
 // on-demand fetches run concurrently, mirroring the MCP handler.
 func compareSides(ctx context.Context, errOut io.Writer, read func() (oldErr, newErr error)) error {
+	var oldSeen, newSeen bool
 	return waitForFetch(ctx, errOut, func() error {
 		oldErr, newErr := read()
+		var ip *tools.FetchInProgressError
+		oldFetching, newFetching := errors.As(oldErr, &ip), errors.As(newErr, &ip)
+		// A side that had its content and is fetching again lost it to the
+		// other side's fetch: the cache cannot hold both versions (a version
+		// cache limit of 0 keeps only the newest), so polling on would
+		// alternate the two downloads forever.
+		if (oldSeen && oldFetching) || (newSeen && newFetching) {
+			return fmt.Errorf("the version cache cannot hold both versions at once; raise -version-cache-mb")
+		}
+		oldSeen = oldSeen || oldErr == nil
+		newSeen = newSeen || newErr == nil
 		// Report the in-progress side so waitForFetch keeps polling even when
 		// the other side already failed for good; the terminal error surfaces
 		// once its partner's fetch has finished.
-		var ip *tools.FetchInProgressError
-		if errors.As(oldErr, &ip) {
+		if oldFetching {
 			return oldErr
 		}
-		if errors.As(newErr, &ip) {
+		if newFetching {
 			return newErr
 		}
 		if oldErr != nil {
@@ -700,8 +711,13 @@ func runGetImage(ctx context.Context, out, errOut io.Writer, src *tools.Source, 
 	}
 	fmt.Fprintf(errOut, "%s (%s, %d bytes)\n", img.Name, img.MIMEType, len(img.Data))
 	if output != "" {
-		return os.WriteFile(output, img.Data, 0o644)
+		if err := os.WriteFile(output, img.Data, 0o644); err != nil {
+			return fmt.Errorf("write image: %w", err)
+		}
+		return nil
 	}
-	_, err = out.Write(img.Data)
-	return err
+	if _, err := out.Write(img.Data); err != nil {
+		return fmt.Errorf("write image: %w", err)
+	}
+	return nil
 }

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -51,6 +52,12 @@ func addQueryFlags(fs *flag.FlagSet, withFetch bool) *queryFlags {
 	return qf
 }
 
+// queryClient is the HTTP client the query commands hand to their Source for
+// archive access. It is nil in production — the pipeline then falls back to
+// its default client, same as serve — and is swapped in tests to keep them
+// off the network, mirroring newHTTPClient.
+var queryClient *http.Client
+
 // openSource opens the database read-only and wraps it in a Source. The
 // version cache — which creates its directory and a SQLite file on open — is
 // only touched when needStore is set, so plain database queries stay pure
@@ -63,6 +70,7 @@ func (qf *queryFlags) openSource(needStore bool) (*tools.Source, func(), error) 
 	}
 	src := tools.NewSource(d)
 	src.Budget = qf.fetchBudget
+	src.Client = queryClient
 	cleanup := func() { _ = d.Close() }
 	if needStore && !qf.noFetch {
 		store, err := versionstore.Open(versionstore.Options{

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -82,6 +82,20 @@ func (qf *queryFlags) openSource(needStore bool) (*tools.Source, func(), error) 
 	return src, cleanup, nil
 }
 
+// versionCacheExists reports whether the on-demand version cache file is
+// already on disk, so a command can read it without ever creating one.
+func (qf *queryFlags) versionCacheExists() bool {
+	path := qf.versionCache
+	if path == "" {
+		var err error
+		if path, err = versionstore.DefaultPath(); err != nil {
+			return false
+		}
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // requireArgs exits with usage unless exactly want positional arguments were
 // given. flag stops parsing at the first non-flag argument, so options placed
 // after a positional would be silently ignored — the reminder mirrors import's.
@@ -201,9 +215,10 @@ func cmdListVersions(args []string) {
 	requireArgs(fs, 1, "3gpp-mcp list-versions [options] <spec-id>")
 
 	runQuery("list-versions", func(ctx context.Context) error {
-		// The store is opened so cached versions are reported; without it the
-		// listing still covers the database and the archive.
-		src, cleanup, err := qf.openSource(true)
+		// An existing cache is read so its versions are reported as cached,
+		// but a listing must not create one; without the store the listing
+		// still covers the database and the archive.
+		src, cleanup, err := qf.openSource(qf.versionCacheExists())
 		if err != nil {
 			return err
 		}
@@ -413,7 +428,7 @@ func runCompareVersions(ctx context.Context, out, errOut io.Writer, src *tools.S
 	oldLabel, newLabel := tools.VersionLabel(oldSecs, oldRes), tools.VersionLabel(newSecs, newRes)
 
 	if section == "" {
-		fmt.Fprintf(out, "[Compare: %s — %s → %s]\n", specID, oldLabel, newLabel)
+		fmt.Fprintln(out, tools.CompareHeader(specID, "", oldLabel, newLabel))
 		_, err := io.WriteString(out, tools.RenderStructuralSummary(structdiff.Diff(oldSecs, newSecs), oldLabel, newLabel))
 		if err == nil {
 			_, err = io.WriteString(out, "\n")
@@ -433,10 +448,12 @@ func runCompareVersions(ctx context.Context, out, errOut io.Writer, src *tools.S
 		return nil
 	}
 
-	if contextLines <= 0 {
+	// Only a negative value falls back to the default: an explicit -context 0
+	// is a deliberate request for a diff with no context lines.
+	if contextLines < 0 {
 		contextLines = defaultCLIContextLines
 	}
-	fmt.Fprintf(out, "[Compare: %s — Section %s — %s → %s]\n", specID, section, oldLabel, newLabel)
+	fmt.Fprintln(out, tools.CompareHeader(specID, section, oldLabel, newLabel))
 	diff := textdiff.UnifiedKeyed(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), contextLines, structdiff.NormalizeImageRefs)
 	if diff == "" {
 		fmt.Fprintf(out, "Section %s is identical between %s and %s.\n", section, oldLabel, newLabel)

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -133,8 +133,10 @@ var fetchPollInterval = 5 * time.Second
 
 // waitForFetch runs call and, unlike the MCP tools which tell the caller to
 // retry, polls until an on-demand fetch finishes: a CLI user expects the
-// command to come back with the content. The underlying fetch is deduplicated
-// and detached, so re-calling is cheap and Ctrl-C does not discard the work.
+// command to come back with the content. Re-calling is cheap — the
+// versionstore deduplicates the fetch within this process. Ctrl-C exits the
+// process and abandons the fetch with it; the next invocation restarts it
+// from scratch.
 func waitForFetch(ctx context.Context, errOut io.Writer, call func() error) error {
 	announced := false
 	for {
@@ -698,12 +700,13 @@ func cmdGetImage(args []string) {
 
 func runGetImage(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, name, version, output string) error {
 	var img *db.Image
+	var res tools.Resolution
 	err := waitForFetch(ctx, errOut, func() error {
 		var err error
 		// A missing image comes back as a nil image, not an error, so an error
 		// here is a real failure (bad version, failed download, database
 		// trouble) and must not be labeled "not found".
-		img, _, err = src.GetImage(ctx, specID, version, name)
+		img, res, err = src.GetImage(ctx, specID, version, name)
 		return err
 	})
 	if err != nil {
@@ -713,9 +716,15 @@ func runGetImage(ctx context.Context, out, errOut io.Writer, src *tools.Source, 
 		return fmt.Errorf("image %q not found in %s", name, specID)
 	}
 	// Unlike the MCP tool, an EMF/WMF image is still written out — a shell
-	// user can open it — with a note about the conversion option.
+	// user can open it — with a note about the conversion option. An archived
+	// version's images are converted at fetch time, not at build time, so
+	// rebuilding the database would not help there.
 	if !img.LLMReadable {
-		fmt.Fprintf(errOut, "NOTE: %s is in %s format; rebuild with --convert-image to store PNG instead.\n", img.Name, img.MIMEType)
+		hint := "rebuild with --convert-image to store PNG instead."
+		if res.Archived {
+			hint = "converting it needs LibreOffice (soffice), which was missing or failed when this version's images were fetched."
+		}
+		fmt.Fprintf(errOut, "NOTE: %s is in %s format; %s\n", img.Name, img.MIMEType, hint)
 	}
 	fmt.Fprintf(errOut, "%s (%s, %d bytes)\n", img.Name, img.MIMEType, len(img.Data))
 	if output != "" {

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -1,0 +1,690 @@
+package main
+
+// The query subcommands mirror the MCP read tools 1:1 (list_specs →
+// list-specs, and so on) so the corpus can be inspected and scripted from a
+// shell without an MCP client. They call the same tools.Source / db.DB layer
+// as the MCP handlers and the web viewer, but render for a shell: JSON
+// payloads go to stdout unpaginated (pipe to jq/head/less), warnings go to
+// stderr, and an on-demand version fetch is waited out instead of answered
+// with "call again".
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/structdiff"
+	"github.com/higebu/3gpp-mcp/internal/textdiff"
+	"github.com/higebu/3gpp-mcp/tools"
+	"github.com/higebu/3gpp-mcp/versionstore"
+)
+
+// queryFlags holds the flags shared by every query subcommand.
+type queryFlags struct {
+	db             string
+	noFetch        bool
+	versionCache   string
+	versionCacheMB int64
+	fetchBudget    time.Duration
+}
+
+// addQueryFlags registers the shared flags. withFetch adds the on-demand
+// version fetch flags, mirroring serve's names and environment defaults;
+// commands that only read the prebuilt database skip them.
+func addQueryFlags(fs *flag.FlagSet, withFetch bool) *queryFlags {
+	qf := &queryFlags{}
+	fs.StringVar(&qf.db, "db", "3gpp.db", "Path to SQLite database")
+	if withFetch {
+		fs.BoolVar(&qf.noFetch, "no-fetch", false, "Disable on-demand fetching of spec versions that are not in the database")
+		fs.StringVar(&qf.versionCache, "version-cache", "", "Path to the on-demand version cache (default: $XDG_CACHE_HOME/3gpp-mcp/versions.db)")
+		fs.Int64Var(&qf.versionCacheMB, "version-cache-mb", defaultVersionCacheMB(), "Size limit of the version cache in MB, or -1 for unlimited (env: THREEGPP_VERSION_CACHE_MB)")
+		fs.DurationVar(&qf.fetchBudget, "fetch-budget", defaultFetchBudget(), "How long one fetch attempt waits before the command polls again (env: THREEGPP_FETCH_BUDGET)")
+	}
+	return qf
+}
+
+// openSource opens the database read-only and wraps it in a Source. The
+// version cache — which creates its directory and a SQLite file on open — is
+// only touched when needStore is set, so plain database queries stay pure
+// reads. A cache that cannot open disables past-version reads with a warning,
+// same as serve.
+func (qf *queryFlags) openSource(needStore bool) (*tools.Source, func(), error) {
+	d, err := db.Open(qf.db)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open database: %w", err)
+	}
+	src := tools.NewSource(d)
+	src.Budget = qf.fetchBudget
+	cleanup := func() { _ = d.Close() }
+	if needStore && !qf.noFetch {
+		store, err := versionstore.Open(versionstore.Options{
+			Path:       qf.versionCache,
+			LimitBytes: qf.versionCacheMB << 20,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: on-demand version fetching disabled: %v\n", err)
+		} else {
+			src.Store = store
+			cleanup = func() {
+				_ = store.Close()
+				_ = d.Close()
+			}
+		}
+	}
+	return src, cleanup, nil
+}
+
+// requireArgs exits with usage unless exactly want positional arguments were
+// given. flag stops parsing at the first non-flag argument, so options placed
+// after a positional would be silently ignored — the reminder mirrors import's.
+func requireArgs(fs *flag.FlagSet, want int, usage string) {
+	if fs.NArg() != want {
+		fmt.Fprintln(os.Stderr, "Usage: "+usage)
+		fmt.Fprintln(os.Stderr, "Options must come before positional arguments.")
+		os.Exit(1)
+	}
+}
+
+// runQuery drives one query command: interruptible context, error to stderr,
+// exit 1 on failure. cleanupOnErr-style resource release lives in fn itself so
+// it runs before exit.
+func runQuery(name string, fn func(ctx context.Context) error) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	if err := fn(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%s failed: %v\n", name, err)
+		exit(1)
+	}
+}
+
+// fetchPollInterval is how often a query command re-checks an on-demand fetch.
+// It is a variable so tests can shorten it.
+var fetchPollInterval = 5 * time.Second
+
+// waitForFetch runs call and, unlike the MCP tools which tell the caller to
+// retry, polls until an on-demand fetch finishes: a CLI user expects the
+// command to come back with the content. The underlying fetch is deduplicated
+// and detached, so re-calling is cheap and Ctrl-C does not discard the work.
+func waitForFetch(ctx context.Context, errOut io.Writer, call func() error) error {
+	announced := false
+	for {
+		err := call()
+		var inProgress *tools.FetchInProgressError
+		if !errors.As(err, &inProgress) {
+			return err
+		}
+		if !announced {
+			subject := fmt.Sprintf("%s v%s", inProgress.SpecID, inProgress.Version)
+			if inProgress.Images {
+				subject = "images for " + subject
+			}
+			fmt.Fprintf(errOut, "Downloading and converting %s; this takes up to a few minutes...\n", subject)
+			announced = true
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(fetchPollInterval):
+		}
+	}
+}
+
+// familyPartsErr reports a split-file family ID ("TS 38.101") as its parts
+// listing, the same hint the MCP handlers give. Returns nil when specID is
+// not a family.
+func familyPartsErr(ctx context.Context, d *db.DB, specID string) error {
+	if parts, err := d.FindSpecIDsByFamily(ctx, specID); err == nil && len(parts) > 0 {
+		return fmt.Errorf("%s has multiple parts: %s — specify one", specID, strings.Join(parts, ", "))
+	}
+	return nil
+}
+
+// printJSON writes v to out as indented, jq-ready JSON.
+func printJSON(out io.Writer, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	_, err = fmt.Fprintln(out, string(data))
+	return err
+}
+
+// list-specs
+
+func cmdListSpecs(args []string) {
+	fs := flag.NewFlagSet("list-specs", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	series := fs.String("series", "", "Filter by series number (e.g. 23)")
+	query := fs.String("query", "", "Filter specs whose ID starts with this text (e.g. 38.21)")
+	limit := fs.Int("limit", 0, "Maximum number of results (default: 20)")
+	offset := fs.Int("offset", 0, "Number of results to skip")
+	_ = fs.Parse(args)
+	requireArgs(fs, 0, "3gpp-mcp list-specs [options]")
+
+	runQuery("list-specs", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runListSpecs(ctx, os.Stdout, src.DB, *series, *query, *limit, *offset)
+	})
+}
+
+func runListSpecs(ctx context.Context, out io.Writer, d *db.DB, series, query string, limit, offset int) error {
+	// A negative limit means "no limit" inside db.ListSpecs, which is reserved
+	// for internal callers.
+	if limit < 0 {
+		limit = 0
+	}
+	result, err := d.ListSpecs(ctx, series, query, limit, offset)
+	if err != nil {
+		return err
+	}
+	return printJSON(out, result)
+}
+
+// list-versions
+
+func cmdListVersions(args []string) {
+	fs := flag.NewFlagSet("list-versions", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	_ = fs.Parse(args)
+	requireArgs(fs, 1, "3gpp-mcp list-versions [options] <spec-id>")
+
+	runQuery("list-versions", func(ctx context.Context) error {
+		// The store is opened so cached versions are reported; without it the
+		// listing still covers the database and the archive.
+		src, cleanup, err := qf.openSource(true)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runListVersions(ctx, os.Stdout, os.Stderr, src, fs.Arg(0))
+	})
+}
+
+func runListVersions(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID string) error {
+	versions, archiveErr, err := src.ListVersions(ctx, specID)
+	if err != nil {
+		return err
+	}
+	if len(versions) == 0 {
+		if archiveErr != nil {
+			return fmt.Errorf("no versions found for %s: %w", specID, archiveErr)
+		}
+		if err := familyPartsErr(ctx, src.DB, specID); err != nil {
+			return err
+		}
+		return fmt.Errorf("no versions found for %s", specID)
+	}
+	// The archive listing may have failed while the cache and/or database
+	// still produced versions; the warning goes to stderr so stdout stays
+	// parseable.
+	if archiveErr != nil {
+		fmt.Fprintf(errOut, "WARNING: failed to list archive versions for %s, so this list may be incomplete: %v\n", specID, archiveErr)
+	}
+	return printJSON(out, tools.ListVersionsOutput{SpecID: specID, Versions: versions})
+}
+
+// get-toc
+
+func cmdGetTOC(args []string) {
+	fs := flag.NewFlagSet("get-toc", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	version := fs.String("version", "", "Specification version to read (e.g. 18.6.0, i60, Rel-18; default: the database version)")
+	_ = fs.Parse(args)
+	requireArgs(fs, 1, "3gpp-mcp get-toc [options] <spec-id>")
+
+	runQuery("get-toc", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(*version != "")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runGetTOC(ctx, os.Stdout, os.Stderr, src, fs.Arg(0), *version)
+	})
+}
+
+func runGetTOC(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, version string) error {
+	var sections []db.Section
+	err := waitForFetch(ctx, errOut, func() error {
+		var err error
+		sections, _, err = src.GetTOC(ctx, specID, version)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if len(sections) == 0 {
+		if err := familyPartsErr(ctx, src.DB, specID); err != nil {
+			return err
+		}
+		return fmt.Errorf("no sections found for %s", specID)
+	}
+	_, err = io.WriteString(out, tools.RenderTOC(sections))
+	return err
+}
+
+// get-section
+
+func cmdGetSection(args []string) {
+	fs := flag.NewFlagSet("get-section", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	version := fs.String("version", "", "Specification version to read (e.g. 18.6.0, i60, Rel-18; default: the database version)")
+	subsections := fs.Bool("subsections", false, "Include all subsections")
+	_ = fs.Parse(args)
+	requireArgs(fs, 2, "3gpp-mcp get-section [options] <spec-id> <section-number>")
+
+	runQuery("get-section", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(*version != "")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runGetSection(ctx, os.Stdout, os.Stderr, src, fs.Arg(0), fs.Arg(1), *version, *subsections)
+	})
+}
+
+func runGetSection(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, sectionNumber, version string, subsections bool) error {
+	var sections []db.Section
+	var res tools.Resolution
+	err := waitForFetch(ctx, errOut, func() error {
+		var err error
+		sections, res, err = src.GetSection(ctx, specID, version, sectionNumber, subsections)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if len(sections) == 0 {
+		if err := familyPartsErr(ctx, src.DB, specID); err != nil {
+			return err
+		}
+		return fmt.Errorf("section %s not found in %s", sectionNumber, specID)
+	}
+	fmt.Fprintln(out, tools.SourceHeader(sections[0], subsections && len(sections) > 1, res.Archived))
+	for _, s := range sections {
+		fmt.Fprintf(out, "%s\n\n", s.Content)
+	}
+	return nil
+}
+
+// compare-versions
+
+func cmdCompareVersions(args []string) {
+	fs := flag.NewFlagSet("compare-versions", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	oldVersion := fs.String("old", "", "Older version to compare from (e.g. 17.9.0, h90, Rel-17; required)")
+	newVersion := fs.String("new", "", "Newer version to compare to (default: the database version)")
+	section := fs.String("section", "", "Compare only this section's text as a unified diff (default: structural summary)")
+	subsections := fs.Bool("subsections", false, "With -section: include subsections in the diff")
+	contextLines := fs.Int("context", defaultCLIContextLines, "Unchanged lines shown around each change in a section diff")
+	_ = fs.Parse(args)
+	requireArgs(fs, 1, "3gpp-mcp compare-versions [options] -old <version> <spec-id>")
+	if *oldVersion == "" {
+		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp compare-versions [options] -old <version> <spec-id>")
+		fmt.Fprintln(os.Stderr, "-old is required.")
+		os.Exit(1)
+	}
+
+	runQuery("compare-versions", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(true)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runCompareVersions(ctx, os.Stdout, os.Stderr, src, fs.Arg(0), *oldVersion, *newVersion, *section, *subsections, *contextLines)
+	})
+}
+
+const defaultCLIContextLines = 3
+
+// compareSides reads both versions' sections in one poll round so both
+// on-demand fetches run concurrently, mirroring the MCP handler.
+func compareSides(ctx context.Context, errOut io.Writer, read func() (oldErr, newErr error)) error {
+	return waitForFetch(ctx, errOut, func() error {
+		oldErr, newErr := read()
+		// Report the in-progress side so waitForFetch keeps polling even when
+		// the other side already failed for good; the terminal error surfaces
+		// once its partner's fetch has finished.
+		var ip *tools.FetchInProgressError
+		if errors.As(oldErr, &ip) {
+			return oldErr
+		}
+		if errors.As(newErr, &ip) {
+			return newErr
+		}
+		if oldErr != nil {
+			return fmt.Errorf("read old version: %w", oldErr)
+		}
+		if newErr != nil {
+			return fmt.Errorf("read new version: %w", newErr)
+		}
+		return nil
+	})
+}
+
+func runCompareVersions(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, oldVersion, newVersion, section string, subsections bool, contextLines int) error {
+	var oldSecs, newSecs []db.Section
+	var oldRes, newRes tools.Resolution
+	err := compareSides(ctx, errOut, func() (error, error) {
+		var oldErr, newErr error
+		if section != "" {
+			oldSecs, oldRes, oldErr = src.GetSection(ctx, specID, oldVersion, section, subsections)
+			newSecs, newRes, newErr = src.GetSection(ctx, specID, newVersion, section, subsections)
+		} else {
+			oldSecs, oldRes, oldErr = src.AllSections(ctx, specID, oldVersion)
+			newSecs, newRes, newErr = src.AllSections(ctx, specID, newVersion)
+		}
+		return oldErr, newErr
+	})
+	if err != nil {
+		// A family ID like "TS 38.101" never resolves to content of its own;
+		// the parts listing is the useful answer, not the resolve error.
+		if familyErr := familyPartsErr(ctx, src.DB, specID); familyErr != nil {
+			return familyErr
+		}
+		return err
+	}
+
+	if len(oldSecs) == 0 && len(newSecs) == 0 {
+		if err := familyPartsErr(ctx, src.DB, specID); err != nil {
+			return err
+		}
+		if section != "" {
+			return fmt.Errorf("section %s does not exist in %s in either version; section numbers move between releases — compare without -section, or use get-toc, to locate it", section, specID)
+		}
+		return fmt.Errorf("no sections found for %s in either version", specID)
+	}
+	oldV, newV := tools.ResolvedVersion(oldSecs, oldRes), tools.ResolvedVersion(newSecs, newRes)
+	if oldV != "" && oldV == newV {
+		fmt.Fprintf(out, "%s: -old and -new both resolve to v%s; nothing to compare.\n", specID, oldV)
+		return nil
+	}
+	oldLabel, newLabel := tools.VersionLabel(oldSecs, oldRes), tools.VersionLabel(newSecs, newRes)
+
+	if section == "" {
+		fmt.Fprintf(out, "[Compare: %s — %s → %s]\n", specID, oldLabel, newLabel)
+		_, err := io.WriteString(out, tools.RenderStructuralSummary(structdiff.Diff(oldSecs, newSecs), oldLabel, newLabel))
+		if err == nil {
+			_, err = io.WriteString(out, "\n")
+		}
+		return err
+	}
+
+	// A section present on one side only is an informational answer, not a
+	// failure: numbers move between releases.
+	if len(oldSecs) == 0 || len(newSecs) == 0 {
+		missing, present := oldLabel, newLabel
+		if len(newSecs) == 0 {
+			missing, present = newLabel, oldLabel
+		}
+		fmt.Fprintf(out, "Section %s of %s does not exist in %s (it exists in %s). Section numbers move between releases — compare without -section, or use get-toc for %s, to locate it.\n",
+			section, specID, missing, present, missing)
+		return nil
+	}
+
+	if contextLines <= 0 {
+		contextLines = defaultCLIContextLines
+	}
+	fmt.Fprintf(out, "[Compare: %s — Section %s — %s → %s]\n", specID, section, oldLabel, newLabel)
+	diff := textdiff.UnifiedKeyed(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), contextLines, structdiff.NormalizeImageRefs)
+	if diff == "" {
+		fmt.Fprintf(out, "Section %s is identical between %s and %s.\n", section, oldLabel, newLabel)
+		return nil
+	}
+	_, err = io.WriteString(out, diff)
+	return err
+}
+
+// search
+
+func cmdSearch(args []string) {
+	fs := flag.NewFlagSet("search", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	specs := fs.String("specs", "", "Limit search to specific specs, comma-separated (e.g. \"TS 23.501,TS 23.502\")")
+	limit := fs.Int("limit", 0, "Maximum number of results per page (default: 10, max: 200)")
+	offset := fs.Int("offset", 0, "Number of results to skip")
+	_ = fs.Parse(args)
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp search [options] <query>")
+		fmt.Fprintln(os.Stderr, "Options must come before the query.")
+		os.Exit(1)
+	}
+
+	runQuery("search", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		// Joining the remaining arguments lets multi-term FTS queries go
+		// unquoted: 3gpp-mcp search AMF AND authentication.
+		return runSearch(ctx, os.Stdout, src.DB, strings.Join(fs.Args(), " "), *specs, *limit, *offset)
+	})
+}
+
+func runSearch(ctx context.Context, out io.Writer, d *db.DB, query, specs string, limit, offset int) error {
+	var specIDs []string
+	if specs != "" {
+		for _, s := range strings.Split(specs, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				specIDs = append(specIDs, s)
+			}
+		}
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	results, err := d.Search(ctx, query, specIDs, limit, offset)
+	if err != nil {
+		return err
+	}
+	return printJSON(out, results)
+}
+
+// list-openapi
+
+func cmdListOpenAPI(args []string) {
+	fs := flag.NewFlagSet("list-openapi", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	spec := fs.String("spec", "", "Filter by specification ID (e.g. TS 29.510)")
+	_ = fs.Parse(args)
+	requireArgs(fs, 0, "3gpp-mcp list-openapi [options]")
+
+	runQuery("list-openapi", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runListOpenAPI(ctx, os.Stdout, src.DB, *spec)
+	})
+}
+
+func runListOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID string) error {
+	specs, err := d.ListOpenAPI(ctx, specID)
+	if err != nil {
+		return err
+	}
+	if specs == nil {
+		specs = []db.OpenAPISpec{}
+	}
+	return printJSON(out, specs)
+}
+
+// get-openapi
+
+func cmdGetOpenAPI(args []string) {
+	fs := flag.NewFlagSet("get-openapi", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	path := fs.String("path", "", "Filter by API path (e.g. /nf-instances)")
+	schema := fs.String("schema", "", "Filter by schema name (e.g. NFProfile)")
+	_ = fs.Parse(args)
+	requireArgs(fs, 2, "3gpp-mcp get-openapi [options] <spec-id> <api-name>")
+
+	runQuery("get-openapi", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runGetOpenAPI(ctx, os.Stdout, src.DB, fs.Arg(0), fs.Arg(1), *path, *schema)
+	})
+}
+
+func runGetOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID, apiName, path, schema string) error {
+	content, err := d.GetOpenAPI(ctx, specID, apiName)
+	if err != nil {
+		return err
+	}
+	if path != "" || schema != "" {
+		if content, err = tools.FilterOpenAPI(content, path, schema); err != nil {
+			return err
+		}
+	}
+	_, err = io.WriteString(out, content)
+	return err
+}
+
+// get-references
+
+func cmdGetReferences(args []string) {
+	fs := flag.NewFlagSet("get-references", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	direction := fs.String("direction", db.DirectionOutgoing, "outgoing: references FROM a section; incoming: references TO this spec")
+	subsections := fs.Bool("subsections", false, "Include subsections when collecting outgoing references")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 && fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp get-references [options] <spec-id> [section-number]")
+		fmt.Fprintln(os.Stderr, "Options must come before positional arguments.")
+		os.Exit(1)
+	}
+
+	runQuery("get-references", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runGetReferences(ctx, os.Stdout, src.DB, fs.Arg(0), fs.Arg(1), *direction, *subsections)
+	})
+}
+
+func runGetReferences(ctx context.Context, out io.Writer, d *db.DB, specID, sectionNumber, direction string, subsections bool) error {
+	if direction == db.DirectionOutgoing && sectionNumber == "" {
+		return fmt.Errorf("a section number is required for outgoing direction")
+	}
+	// Unlike the MCP tool, the full result is printed: the 500-row cap there
+	// protects an LLM context window, which a shell pipeline does not have.
+	refs, err := d.GetReferences(ctx, specID, "", sectionNumber, direction, subsections)
+	if err != nil {
+		return err
+	}
+	if refs == nil {
+		refs = []db.Reference{}
+	}
+	return printJSON(out, refs)
+}
+
+// list-images
+
+func cmdListImages(args []string) {
+	fs := flag.NewFlagSet("list-images", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	version := fs.String("version", "", "Specification version to read (e.g. 18.6.0, i60, Rel-18; default: the database version)")
+	_ = fs.Parse(args)
+	requireArgs(fs, 1, "3gpp-mcp list-images [options] <spec-id>")
+
+	runQuery("list-images", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(*version != "")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runListImages(ctx, os.Stdout, os.Stderr, src, fs.Arg(0), *version)
+	})
+}
+
+func runListImages(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, version string) error {
+	var images []db.ImageInfo
+	var res tools.Resolution
+	err := waitForFetch(ctx, errOut, func() error {
+		var err error
+		images, res, err = src.ListImages(ctx, specID, version)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if len(images) == 0 && !res.Archived {
+		if err := familyPartsErr(ctx, src.DB, specID); err != nil {
+			return err
+		}
+	}
+	if images == nil {
+		images = []db.ImageInfo{}
+	}
+	return printJSON(out, struct {
+		Images []db.ImageInfo `json:"images"`
+		Count  int            `json:"count"`
+	}{Images: images, Count: len(images)})
+}
+
+// get-image
+
+func cmdGetImage(args []string) {
+	fs := flag.NewFlagSet("get-image", flag.ExitOnError)
+	qf := addQueryFlags(fs, true)
+	version := fs.String("version", "", "Specification version to read (e.g. 18.6.0, i60, Rel-18; default: the database version)")
+	output := fs.String("o", "", "Write the image to this file (default: stdout)")
+	_ = fs.Parse(args)
+	requireArgs(fs, 2, "3gpp-mcp get-image [options] <spec-id> <image-name>")
+
+	runQuery("get-image", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(*version != "")
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		return runGetImage(ctx, os.Stdout, os.Stderr, src, fs.Arg(0), fs.Arg(1), *version, *output)
+	})
+}
+
+func runGetImage(ctx context.Context, out, errOut io.Writer, src *tools.Source, specID, name, version, output string) error {
+	var img *db.Image
+	err := waitForFetch(ctx, errOut, func() error {
+		var err error
+		// A missing image comes back as a nil image, not an error, so an error
+		// here is a real failure (bad version, failed download, database
+		// trouble) and must not be labeled "not found".
+		img, _, err = src.GetImage(ctx, specID, version, name)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if img == nil {
+		return fmt.Errorf("image %q not found in %s", name, specID)
+	}
+	// Unlike the MCP tool, an EMF/WMF image is still written out — a shell
+	// user can open it — with a note about the conversion option.
+	if !img.LLMReadable {
+		fmt.Fprintf(errOut, "NOTE: %s is in %s format; rebuild with --convert-image to store PNG instead.\n", img.Name, img.MIMEType)
+	}
+	fmt.Fprintf(errOut, "%s (%s, %d bytes)\n", img.Name, img.MIMEType, len(img.Data))
+	if output != "" {
+		return os.WriteFile(output, img.Data, 0o644)
+	}
+	_, err = out.Write(img.Data)
+	return err
+}

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -347,6 +347,44 @@ func TestRunListVersions_ArchiveUnreachable(t *testing.T) {
 	}
 }
 
+// TestCompareSides_CacheThrash covers the eviction-livelock guard: when two
+// archived versions evict each other from a cache too small to hold both,
+// each poll would re-download the side the previous poll evicted, forever.
+func TestCompareSides_CacheThrash(t *testing.T) {
+	orig := fetchPollInterval
+	fetchPollInterval = time.Millisecond
+	defer func() { fetchPollInterval = orig }()
+
+	inProgress := &tools.FetchInProgressError{SpecID: "TS 23.501", Version: "17.9.0"}
+	round := 0
+	var errOut bytes.Buffer
+	// Round 1: old ready, new fetching. Round 2: fetching new evicted old.
+	err := compareSides(t.Context(), &errOut, func() (error, error) {
+		round++
+		if round == 1 {
+			return nil, inProgress
+		}
+		return inProgress, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot hold both versions") {
+		t.Errorf("expected cache-thrash error, got: %v", err)
+	}
+
+	// A side that simply finishes while the other is still fetching must not
+	// trip the guard.
+	round = 0
+	err = compareSides(t.Context(), &errOut, func() (error, error) {
+		round++
+		if round < 3 {
+			return nil, inProgress
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Errorf("expected success once both sides are ready, got: %v", err)
+	}
+}
+
 // TestVersionCacheExists covers the guard that keeps list-versions from
 // creating a cache that is not already on disk.
 func TestVersionCacheExists(t *testing.T) {

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,9 +15,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/higebu/3gpp-mcp/internal/testutil"
 	"github.com/higebu/3gpp-mcp/tools"
+	"github.com/higebu/3gpp-mcp/versionstore"
 )
 
 func TestRunListSpecs(t *testing.T) {
@@ -740,6 +744,61 @@ func TestRunGetImage_NotConverted(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), "--convert-image") {
 		t.Errorf("expected conversion note on stderr, got: %s", errOut.String())
+	}
+}
+
+// TestRunGetImage_ArchivedHint covers the archived branch of the EMF note: an
+// image fetched on demand is converted at fetch time, so the note must point
+// at LibreOffice, not at rebuilding the prebuilt database.
+func TestRunGetImage_ArchivedHint(t *testing.T) {
+	origPoll := fetchPollInterval
+	fetchPollInterval = 10 * time.Millisecond
+	defer func() { fetchPollInterval = origPoll }()
+
+	d := testutil.SetupTestDB(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/23_series/23.501/", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `<a href="23501-j50.zip">23501-j50.zip</a>`+"\n")
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	data := []byte{0x01, 0x00, 0x00, 0x00}
+	store, err := versionstore.Open(versionstore.Options{
+		Path:       filepath.Join(t.TempDir(), "versions.db"),
+		LimitBytes: -1,
+		Fetcher: func(ctx context.Context, sv *pipeline.SpecVersion) (db.Spec, []db.Section, error) {
+			return db.Spec{Title: "System architecture", Release: "19", Series: "23"},
+				[]db.Section{{Number: "5.1", Title: "General", Level: 2, Content: "Archived text."}}, nil
+		},
+		ImageFetcher: func(ctx context.Context, sv *pipeline.SpecVersion) ([]db.Image, error) {
+			return []db.Image{{Name: "figure3.emf", MIMEType: "image/emf", Data: data, LLMReadable: false}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("versionstore.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	src := tools.NewSource(d)
+	src.Store = store
+	src.Client = &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+	src.UseCache = false
+	src.Budget = 5 * time.Second
+
+	var out, errOut bytes.Buffer
+	if err := runGetImage(t.Context(), &out, &errOut, src, "TS 23.501", "figure3.emf", "19.5.0", ""); err != nil {
+		t.Fatalf("runGetImage archived: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), data) {
+		t.Error("expected raw image bytes on stdout")
+	}
+	if !strings.Contains(errOut.String(), "LibreOffice") {
+		t.Errorf("expected the fetch-time LibreOffice hint for an archived image, got: %s", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "--convert-image") {
+		t.Errorf("the rebuild hint does not apply to archived versions, got: %s", errOut.String())
 	}
 }
 

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -39,6 +39,16 @@ func TestRunListSpecs(t *testing.T) {
 	if !strings.Contains(out.String(), "TS 29.510") || strings.Contains(out.String(), "TS 23.501") {
 		t.Errorf("series filter not applied:\n%s", out.String())
 	}
+
+	// A negative limit is reserved for internal callers and clamps to the
+	// default rather than dumping the whole table.
+	out.Reset()
+	if err := runListSpecs(t.Context(), &out, d, "", "", -1, 0); err != nil {
+		t.Fatalf("runListSpecs negative limit: %v", err)
+	}
+	if !strings.Contains(out.String(), `"limit": 20`) {
+		t.Errorf("expected default limit for a negative input, got:\n%s", out.String())
+	}
 }
 
 func TestRunSearch(t *testing.T) {
@@ -308,6 +318,10 @@ func TestRunGetOpenAPI(t *testing.T) {
 	if !strings.Contains(out.String(), "/nf-instances") {
 		t.Errorf("path filter not applied:\n%s", out.String())
 	}
+
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nope_API", "", ""); err == nil {
+		t.Error("expected error for unknown API name")
+	}
 }
 
 // seedTestImage inserts one PNG image row for TS 23.501.
@@ -508,6 +522,23 @@ func TestWaitForFetch(t *testing.T) {
 		t.Errorf("expected one announcement, got %d: %s", got, errOut.String())
 	}
 
+	// An image fetch names the images, not the spec text.
+	errOut.Reset()
+	calls = 0
+	err = waitForFetch(t.Context(), &errOut, func() error {
+		calls++
+		if calls == 1 {
+			return &tools.FetchInProgressError{SpecID: "TS 23.501", Version: "17.9.0", Images: true}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waitForFetch images: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "images for TS 23.501") {
+		t.Errorf("expected images announcement, got: %s", errOut.String())
+	}
+
 	// A terminal error passes through unchanged.
 	sentinel := errors.New("boom")
 	if err := waitForFetch(t.Context(), &errOut, func() error { return sentinel }); !errors.Is(err, sentinel) {
@@ -609,6 +640,106 @@ func TestCmdGetImage_ToFile(t *testing.T) {
 	}
 	if !bytes.Equal(written, data) {
 		t.Error("file bytes differ from stored image")
+	}
+}
+
+// TestCmdListVersions_Offline drives list-versions through its full cmd
+// layer with the archive unreachable: the database version still lists, the
+// incomplete-listing warning goes to stderr, and no version cache is created.
+func TestCmdListVersions_Offline(t *testing.T) {
+	path := seedDBPath(t)
+	cacheRoot := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheRoot)
+	orig := queryClient
+	queryClient = &http.Client{Transport: errorRoundTripper{}}
+	t.Cleanup(func() { queryClient = orig })
+
+	out := captureStdout(t, func() {
+		cmdListVersions([]string{"-db", path, "TS 23.501"})
+	})
+	if !strings.Contains(out, "18.6.0") {
+		t.Errorf("expected the database version in the listing, got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(cacheRoot, "3gpp-mcp", "versions.db")); err == nil {
+		t.Error("list-versions must not create the version cache")
+	}
+}
+
+// TestOpenSource_Store covers the store-open path shared by all version-aware
+// commands.
+func TestOpenSource_Store(t *testing.T) {
+	path := seedDBPath(t)
+	qf := &queryFlags{db: path, versionCache: filepath.Join(t.TempDir(), "versions.db"), versionCacheMB: 1}
+	src, cleanup, err := qf.openSource(true)
+	if err != nil {
+		t.Fatalf("openSource: %v", err)
+	}
+	defer cleanup()
+	if src.Store == nil {
+		t.Error("expected the version store to be opened")
+	}
+
+	// -no-fetch skips the store even when a version was requested.
+	qf.noFetch = true
+	src, cleanup, err = qf.openSource(true)
+	if err != nil {
+		t.Fatalf("openSource with -no-fetch: %v", err)
+	}
+	defer cleanup()
+	if src.Store != nil {
+		t.Error("expected no store with -no-fetch")
+	}
+}
+
+// TestFamilyPartsHint covers the split-file family hint shared by the query
+// commands: a family ID never resolves to content of its own, so the parts
+// listing is the useful answer.
+func TestFamilyPartsHint(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	if err := d.ExecScript(`
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 38.101-1', '18.0.0', 'i00', 'NR UE radio Part 1', '18', '38'),
+    ('TS 38.101-2', '18.0.0', 'i00', 'NR UE radio Part 2', '18', '38');`); err != nil {
+		t.Fatalf("seed family parts: %v", err)
+	}
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+
+	err := runGetTOC(t.Context(), &out, &errOut, src, "TS 38.101", "")
+	if err == nil || !strings.Contains(err.Error(), "multiple parts") {
+		t.Errorf("expected family parts hint from get-toc, got: %v", err)
+	}
+	err = runGetSection(t.Context(), &out, &errOut, src, "TS 38.101", "1", "", false)
+	if err == nil || !strings.Contains(err.Error(), "multiple parts") {
+		t.Errorf("expected family parts hint from get-section, got: %v", err)
+	}
+	err = runListImages(t.Context(), &out, &errOut, src, "TS 38.101", "")
+	if err == nil || !strings.Contains(err.Error(), "multiple parts") {
+		t.Errorf("expected family parts hint from list-images, got: %v", err)
+	}
+}
+
+// TestRunGetImage_NotConverted pins the EMF passthrough: unlike the MCP tool,
+// the bytes are still written, with a conversion note on stderr.
+func TestRunGetImage_NotConverted(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	data := []byte{0x01, 0x00, 0x00, 0x00}
+	if err := d.Exec(
+		"INSERT INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, 0)",
+		"TS 23.501", "18.6.0", "figure2.emf", "image/emf", data,
+	); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if err := runGetImage(t.Context(), &out, &errOut, src, "TS 23.501", "figure2.emf", "", ""); err != nil {
+		t.Fatalf("runGetImage: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), data) {
+		t.Error("expected raw EMF bytes on stdout")
+	}
+	if !strings.Contains(errOut.String(), "--convert-image") {
+		t.Errorf("expected conversion note on stderr, got: %s", errOut.String())
 	}
 }
 

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -128,6 +128,83 @@ func TestRunCompareVersions_SameVersion(t *testing.T) {
 	}
 }
 
+// seedSecondVersion inserts a second version of TS 23.501 directly. The build
+// pipeline keeps one version per spec, but resolve serves any version the
+// specs table has, so this exercises the comparison paths without network.
+func seedSecondVersion(t *testing.T, d *db.DB) {
+	t.Helper()
+	if err := d.ExecScript(`
+INSERT INTO specs (id, version, version_token, title, release, series) VALUES
+    ('TS 23.501', '18.7.0', 'i70', 'System architecture for the 5G System (5GS)', '18', '23');
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.7.0', '1', 'Scope', 1, NULL, '# 1 Scope
+This document defines the system architecture.'),
+    ('TS 23.501', '18.7.0', '5', 'Architecture', 1, NULL, '# 5 Architecture
+The 5G system architecture is defined here, with amendments.'),
+    ('TS 23.501', '18.7.0', '5.2', 'Additions', 2, '5', '## 5.2 Additions
+A section that only the newer version has.');
+`); err != nil {
+		t.Fatalf("seed second version: %v", err)
+	}
+}
+
+func TestRunCompareVersions_Structural(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	seedSecondVersion(t, d)
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+	err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "18.7.0", "", false, 0)
+	if err != nil {
+		t.Fatalf("runCompareVersions: %v", err)
+	}
+	for _, want := range []string{"[Compare: TS 23.501", "Structural changes", "5.2 Additions"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRunCompareVersions_SectionDiff(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	seedSecondVersion(t, d)
+	src := tools.NewSource(d)
+
+	// Changed content renders as a unified diff.
+	var out, errOut bytes.Buffer
+	err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "18.7.0", "5", false, 0)
+	if err != nil {
+		t.Fatalf("runCompareVersions section: %v", err)
+	}
+	for _, want := range []string{"Section 5", "with amendments"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected diff output to contain %q, got:\n%s", want, out.String())
+		}
+	}
+
+	// Identical content is an informational answer.
+	out.Reset()
+	if err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "18.7.0", "1", false, 0); err != nil {
+		t.Fatalf("runCompareVersions identical section: %v", err)
+	}
+	if !strings.Contains(out.String(), "identical between") {
+		t.Errorf("expected identical notice, got:\n%s", out.String())
+	}
+
+	// A section on one side only is an informational answer, not a failure.
+	out.Reset()
+	if err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "18.7.0", "5.2", false, 0); err != nil {
+		t.Fatalf("runCompareVersions one-sided section: %v", err)
+	}
+	if !strings.Contains(out.String(), "does not exist in") {
+		t.Errorf("expected one-sided notice, got:\n%s", out.String())
+	}
+
+	// A section in neither version is an error.
+	if err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "18.7.0", "9.9", false, 0); err == nil {
+		t.Error("expected error for a section absent from both versions")
+	}
+}
+
 func TestRunCompareVersions_UnavailableVersion(t *testing.T) {
 	d := testutil.SetupTestDB(t)
 	src := tools.NewSource(d) // no Store: archived versions cannot be fetched
@@ -345,6 +422,11 @@ func TestRunListVersions_ArchiveUnreachable(t *testing.T) {
 	if !strings.Contains(errOut.String(), "WARNING") {
 		t.Errorf("expected archive warning on stderr, got: %s", errOut.String())
 	}
+
+	// A spec with no versions anywhere reports the archive failure.
+	if err := runListVersions(t.Context(), &out, &errOut, src, "TS 99.999"); err == nil {
+		t.Error("expected error for a spec with no versions")
+	}
 }
 
 // TestCompareSides_CacheThrash covers the eviction-livelock guard: when two
@@ -440,6 +522,107 @@ func TestWaitForFetch(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// seedDBPath writes the standard schema and seed data to a closed database
+// file, so cmd-level tests can open it by path the way a user would.
+func seedDBPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if err := d.ExecScript(db.Schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	if err := d.ExecScript(testutil.SeedData); err != nil {
+		t.Fatalf("seed data: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close seed db: %v", err)
+	}
+	return path
+}
+
+// TestCmdQueryCommands drives each query command through its full cmd layer —
+// flag parsing, source setup, output — the way a shell invocation would.
+func TestCmdQueryCommands(t *testing.T) {
+	path := seedDBPath(t)
+	// Keep any cache access inside the test's sandbox.
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	tests := []struct {
+		name string
+		run  func()
+		want []string
+	}{
+		{"list-specs", func() { cmdListSpecs([]string{"-db", path, "-series", "23"}) }, []string{"TS 23.501", "total_count"}},
+		{"search", func() { cmdSearch([]string{"-db", path, "-limit", "2", "architecture"}) }, []string{"results", "total_count"}},
+		{"search multi-arg", func() { cmdSearch([]string{"-db", path, "architecture", "AND", "5G"}) }, []string{"total_count"}},
+		{"get-toc", func() { cmdGetTOC([]string{"-db", path, "TS 23.501"}) }, []string{"Table of Contents", "5.1.1 Overview"}},
+		{"get-section", func() { cmdGetSection([]string{"-db", path, "-subsections", "TS 23.501", "5.1"}) }, []string{"[Source: TS 23.501", "Overview of the architecture"}},
+		{"compare-versions", func() {
+			cmdCompareVersions([]string{"-db", path, "-no-fetch", "-old", "18.6.0", "TS 23.501"})
+		}, []string{"nothing to compare"}},
+		{"get-references", func() { cmdGetReferences([]string{"-db", path, "TS 24.229", "5.1"}) }, []string{"TS 23.228"}},
+		{"list-openapi", func() { cmdListOpenAPI([]string{"-db", path}) }, []string{"Nnrf_NFManagement"}},
+		{"get-openapi", func() { cmdGetOpenAPI([]string{"-db", path, "-schema", "NFProfile", "TS 29.510", "Nnrf_NFManagement"}) }, []string{"NFProfile"}},
+		{"list-images", func() { cmdListImages([]string{"-db", path, "TS 23.501"}) }, []string{`"count"`}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, tt.run)
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %q, got:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestCmdGetImage_ToFile covers the -o path through the cmd layer.
+func TestCmdGetImage_ToFile(t *testing.T) {
+	path := seedDBPath(t)
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte{0x89, 'P', 'N', 'G'}
+	if err := d.Exec(
+		"INSERT INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, 1)",
+		"TS 23.501", "18.6.0", "figure1.png", "image/png", data,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	outFile := filepath.Join(t.TempDir(), "img.png")
+	cmdGetImage([]string{"-db", path, "-o", outFile, "TS 23.501", "figure1.png"})
+	written, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !bytes.Equal(written, data) {
+		t.Error("file bytes differ from stored image")
+	}
+}
+
+// TestCmdQuery_ExitsOnError pins the failure path: a query command against a
+// missing database reports the error and exits 1.
+func TestCmdQuery_ExitsOnError(t *testing.T) {
+	orig := exit
+	code := 0
+	exit = func(c int) { code = c }
+	t.Cleanup(func() { exit = orig })
+
+	cmdListSpecs([]string{"-db", filepath.Join(t.TempDir(), "missing.db")})
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
 	}
 }
 

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -1,0 +1,410 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/testutil"
+	"github.com/higebu/3gpp-mcp/tools"
+)
+
+func TestRunListSpecs(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	var out bytes.Buffer
+	if err := runListSpecs(t.Context(), &out, d, "", "", 0, 0); err != nil {
+		t.Fatalf("runListSpecs: %v", err)
+	}
+	var result db.ListSpecsResult
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if result.TotalCount != 3 {
+		t.Errorf("expected 3 specs, got %d", result.TotalCount)
+	}
+
+	out.Reset()
+	if err := runListSpecs(t.Context(), &out, d, "29", "", 0, 0); err != nil {
+		t.Fatalf("runListSpecs series filter: %v", err)
+	}
+	if !strings.Contains(out.String(), "TS 29.510") || strings.Contains(out.String(), "TS 23.501") {
+		t.Errorf("series filter not applied:\n%s", out.String())
+	}
+}
+
+func TestRunSearch(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	var out bytes.Buffer
+	if err := runSearch(t.Context(), &out, d, "architecture", "", 0, 0); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	var results db.SearchResults
+	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if results.TotalCount == 0 {
+		t.Error("expected search hits for 'architecture'")
+	}
+
+	// The comma-separated spec filter must narrow the search.
+	out.Reset()
+	if err := runSearch(t.Context(), &out, d, "Scope", "TS 29.510, ", 0, 0); err != nil {
+		t.Fatalf("runSearch with spec filter: %v", err)
+	}
+	if strings.Contains(out.String(), "TS 23.501") {
+		t.Errorf("spec filter not applied:\n%s", out.String())
+	}
+}
+
+func TestRunGetTOC(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+	if err := runGetTOC(t.Context(), &out, &errOut, src, "TS 23.501", ""); err != nil {
+		t.Fatalf("runGetTOC: %v", err)
+	}
+	for _, want := range []string{"Table of Contents", "5.1.1 Overview", "TS 23.501 v18.6.0"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out.String())
+		}
+	}
+
+	if err := runGetTOC(t.Context(), &out, &errOut, src, "TS 99.999", ""); err == nil {
+		t.Error("expected error for unknown spec")
+	}
+}
+
+func TestRunGetSection(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+	if err := runGetSection(t.Context(), &out, &errOut, src, "TS 23.501", "5.1", "", false); err != nil {
+		t.Fatalf("runGetSection: %v", err)
+	}
+	if !strings.Contains(out.String(), "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]") {
+		t.Errorf("missing provenance header:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "General architecture description") {
+		t.Errorf("missing section content:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "Overview of the architecture") {
+		t.Errorf("subsection content leaked without -subsections:\n%s", out.String())
+	}
+
+	out.Reset()
+	if err := runGetSection(t.Context(), &out, &errOut, src, "TS 23.501", "5.1", "", true); err != nil {
+		t.Fatalf("runGetSection subsections: %v", err)
+	}
+	if !strings.Contains(out.String(), "Overview of the architecture") {
+		t.Errorf("expected subsection content with -subsections:\n%s", out.String())
+	}
+
+	if err := runGetSection(t.Context(), &out, &errOut, src, "TS 23.501", "9.9", "", false); err == nil {
+		t.Error("expected error for missing section")
+	}
+}
+
+func TestRunCompareVersions_SameVersion(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+	// -old resolves in the database and -new defaults to the database
+	// version, so both sides land on 18.6.0: an informational answer.
+	err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "18.6.0", "", "", false, 0)
+	if err != nil {
+		t.Fatalf("runCompareVersions: %v", err)
+	}
+	if !strings.Contains(out.String(), "nothing to compare") {
+		t.Errorf("expected same-version notice, got:\n%s", out.String())
+	}
+}
+
+func TestRunCompareVersions_UnavailableVersion(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d) // no Store: archived versions cannot be fetched
+	var out, errOut bytes.Buffer
+	err := runCompareVersions(t.Context(), &out, &errOut, src, "TS 23.501", "17.9.0", "", "", false, 0)
+	if err == nil {
+		t.Fatal("expected error for a version that cannot be fetched")
+	}
+	var unavailable *tools.VersionUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected VersionUnavailableError, got: %v", err)
+	}
+}
+
+func TestRunGetReferences(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	var out bytes.Buffer
+	if err := runGetReferences(t.Context(), &out, d, "TS 24.229", "5.1", db.DirectionOutgoing, false); err != nil {
+		t.Fatalf("runGetReferences: %v", err)
+	}
+	var refs []db.Reference
+	if err := json.Unmarshal(out.Bytes(), &refs); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(refs) != 5 {
+		t.Errorf("expected 5 outgoing references, got %d", len(refs))
+	}
+
+	out.Reset()
+	if err := runGetReferences(t.Context(), &out, d, "TS 33.203", "", db.DirectionIncoming, false); err != nil {
+		t.Fatalf("runGetReferences incoming: %v", err)
+	}
+	refs = nil
+	if err := json.Unmarshal(out.Bytes(), &refs); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(refs) != 2 {
+		t.Errorf("expected 2 incoming references, got %d", len(refs))
+	}
+
+	// Outgoing without a section number cannot be answered.
+	if err := runGetReferences(t.Context(), &out, d, "TS 24.229", "", db.DirectionOutgoing, false); err == nil {
+		t.Error("expected error for outgoing direction without section number")
+	}
+
+	// No matches must still print valid JSON.
+	out.Reset()
+	if err := runGetReferences(t.Context(), &out, d, "TS 99.999", "", db.DirectionIncoming, false); err != nil {
+		t.Fatalf("runGetReferences no matches: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "[]" {
+		t.Errorf("expected [] for no matches, got:\n%s", out.String())
+	}
+}
+
+func TestRunListOpenAPI(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	var out bytes.Buffer
+	if err := runListOpenAPI(t.Context(), &out, d, ""); err != nil {
+		t.Fatalf("runListOpenAPI: %v", err)
+	}
+	var specs []db.OpenAPISpec
+	if err := json.Unmarshal(out.Bytes(), &specs); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(specs) != 1 || specs[0].APIName != "Nnrf_NFManagement" {
+		t.Errorf("unexpected listing: %+v", specs)
+	}
+
+	out.Reset()
+	if err := runListOpenAPI(t.Context(), &out, d, "TS 23.501"); err != nil {
+		t.Fatalf("runListOpenAPI filtered: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "[]" {
+		t.Errorf("expected [] for a spec without OpenAPI, got:\n%s", out.String())
+	}
+}
+
+func TestRunGetOpenAPI(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	var out bytes.Buffer
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nnrf_NFManagement", "", ""); err != nil {
+		t.Fatalf("runGetOpenAPI: %v", err)
+	}
+	if !strings.Contains(out.String(), "openapi: 3.0.0") {
+		t.Errorf("expected full YAML output, got:\n%s", out.String())
+	}
+
+	out.Reset()
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nnrf_NFManagement", "", "NFProfile"); err != nil {
+		t.Fatalf("runGetOpenAPI schema filter: %v", err)
+	}
+	if !strings.Contains(out.String(), "NFProfile") || strings.Contains(out.String(), "/nf-instances") {
+		t.Errorf("schema filter not applied:\n%s", out.String())
+	}
+
+	out.Reset()
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nnrf_NFManagement", "/nf-instances", ""); err != nil {
+		t.Fatalf("runGetOpenAPI path filter: %v", err)
+	}
+	if !strings.Contains(out.String(), "/nf-instances") {
+		t.Errorf("path filter not applied:\n%s", out.String())
+	}
+}
+
+// seedTestImage inserts one PNG image row for TS 23.501.
+func seedTestImage(t *testing.T, d *db.DB) []byte {
+	t.Helper()
+	data := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
+	err := d.Exec(
+		"INSERT INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES (?, ?, ?, ?, ?, 1)",
+		"TS 23.501", "18.6.0", "figure1.png", "image/png", data,
+	)
+	if err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+	return data
+}
+
+func TestRunListImages(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	var out, errOut bytes.Buffer
+
+	// No images must still print valid JSON with a zero count.
+	if err := runListImages(t.Context(), &out, &errOut, src, "TS 23.501", ""); err != nil {
+		t.Fatalf("runListImages empty: %v", err)
+	}
+	var listing struct {
+		Images []db.ImageInfo `json:"images"`
+		Count  int            `json:"count"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &listing); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if listing.Count != 0 || listing.Images == nil {
+		t.Errorf("expected empty listing with non-null images array, got:\n%s", out.String())
+	}
+
+	seedTestImage(t, d)
+	out.Reset()
+	if err := runListImages(t.Context(), &out, &errOut, src, "TS 23.501", ""); err != nil {
+		t.Fatalf("runListImages: %v", err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &listing); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if listing.Count != 1 || listing.Images[0].Name != "figure1.png" {
+		t.Errorf("unexpected listing:\n%s", out.String())
+	}
+}
+
+func TestRunGetImage(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	data := seedTestImage(t, d)
+
+	var out, errOut bytes.Buffer
+	if err := runGetImage(t.Context(), &out, &errOut, src, "TS 23.501", "figure1.png", "", ""); err != nil {
+		t.Fatalf("runGetImage: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), data) {
+		t.Errorf("stdout bytes differ from stored image")
+	}
+	if !strings.Contains(errOut.String(), "image/png") {
+		t.Errorf("expected MIME type on stderr, got: %s", errOut.String())
+	}
+
+	outFile := filepath.Join(t.TempDir(), "img.png")
+	if err := runGetImage(t.Context(), &out, &errOut, src, "TS 23.501", "figure1.png", "", outFile); err != nil {
+		t.Fatalf("runGetImage -o: %v", err)
+	}
+	written, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !bytes.Equal(written, data) {
+		t.Errorf("file bytes differ from stored image")
+	}
+
+	if err := runGetImage(t.Context(), &out, &errOut, src, "TS 23.501", "nope.png", "", ""); err == nil {
+		t.Error("expected error for missing image")
+	}
+}
+
+// errorRoundTripper fails every request, so the archive listing errors without
+// touching the network.
+type errorRoundTripper struct{}
+
+func (errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("no network in tests")
+}
+
+func TestRunListVersions_ArchiveUnreachable(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	src := tools.NewSource(d)
+	src.UseCache = false
+	src.Client = &http.Client{Transport: errorRoundTripper{}}
+
+	var out, errOut bytes.Buffer
+	if err := runListVersions(t.Context(), &out, &errOut, src, "TS 23.501"); err != nil {
+		t.Fatalf("runListVersions: %v", err)
+	}
+	var listing tools.ListVersionsOutput
+	if err := json.Unmarshal(out.Bytes(), &listing); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(listing.Versions) != 1 || listing.Versions[0].Version != "18.6.0" {
+		t.Errorf("expected the database version, got:\n%s", out.String())
+	}
+	if listing.Versions[0].Availability != tools.AvailabilityDatabase {
+		t.Errorf("expected database availability, got %q", listing.Versions[0].Availability)
+	}
+	// The incomplete listing must be flagged on stderr, not silently returned.
+	if !strings.Contains(errOut.String(), "WARNING") {
+		t.Errorf("expected archive warning on stderr, got: %s", errOut.String())
+	}
+}
+
+func TestWaitForFetch(t *testing.T) {
+	orig := fetchPollInterval
+	fetchPollInterval = time.Millisecond
+	defer func() { fetchPollInterval = orig }()
+
+	calls := 0
+	var errOut bytes.Buffer
+	err := waitForFetch(t.Context(), &errOut, func() error {
+		calls++
+		if calls < 3 {
+			return &tools.FetchInProgressError{SpecID: "TS 23.501", Version: "17.9.0"}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waitForFetch: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+	// The progress note is announced once, not on every poll.
+	if got := strings.Count(errOut.String(), "Downloading"); got != 1 {
+		t.Errorf("expected one announcement, got %d: %s", got, errOut.String())
+	}
+
+	// A terminal error passes through unchanged.
+	sentinel := errors.New("boom")
+	if err := waitForFetch(t.Context(), &errOut, func() error { return sentinel }); !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+
+	// Cancellation stops the polling.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err = waitForFetch(ctx, &errOut, func() error {
+		return &tools.FetchInProgressError{SpecID: "TS 23.501", Version: "17.9.0"}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestCmdGetSection_ArgOrder covers the options-before-positionals guard via
+// subprocess, mirroring TestCmdCompletion_UnknownShell.
+func TestCmdGetSection_ArgOrder(t *testing.T) {
+	if os.Getenv("CMD_GET_SECTION_ARGS_HELPER") == "1" {
+		cmdGetSection([]string{"TS 23.501"})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCmdGetSection_ArgOrder")
+	cmd.Env = append(os.Environ(), "CMD_GET_SECTION_ARGS_HELPER=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit for missing section number")
+	}
+	if !strings.Contains(stderr.String(), "Options must come before positional arguments.") {
+		t.Errorf("expected usage reminder on stderr, got: %s", stderr.String())
+	}
+}

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -347,6 +347,22 @@ func TestRunListVersions_ArchiveUnreachable(t *testing.T) {
 	}
 }
 
+// TestVersionCacheExists covers the guard that keeps list-versions from
+// creating a cache that is not already on disk.
+func TestVersionCacheExists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "versions.db")
+	qf := &queryFlags{versionCache: path}
+	if qf.versionCacheExists() {
+		t.Error("expected false for a missing cache file")
+	}
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !qf.versionCacheExists() {
+		t.Error("expected true once the cache file exists")
+	}
+}
+
 func TestWaitForFetch(t *testing.T) {
 	orig := fetchPollInterval
 	fetchPollInterval = time.Millisecond

--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -65,8 +65,15 @@ func compareStructure(ctx context.Context, src *Source, input CompareVersionsInp
 	}
 
 	d := structdiff.Diff(oldSecs, newSecs)
-	oldLabel, newLabel := versionLabel(oldSecs, oldRes), versionLabel(newSecs, newRes)
+	oldLabel, newLabel := VersionLabel(oldSecs, oldRes), VersionLabel(newSecs, newRes)
 
+	header := compareHeader(input.SpecID, "", oldLabel, newLabel)
+	return prependLine(header, paginateText(RenderStructuralSummary(d, oldLabel, newLabel), input.Offset, input.MaxLines, input.MaxChars))
+}
+
+// RenderStructuralSummary renders a structural diff between two versions as
+// Markdown. It is shared with the CLI's compare-versions command.
+func RenderStructuralSummary(d structdiff.Result, oldLabel, newLabel string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# Structural changes: %d sections in %s, %d in %s\n", d.OldCount, oldLabel, d.NewCount, newLabel)
 	fmt.Fprintf(&sb, "Added: %d | Removed: %d | Renumbered: %d | Title changed: %d | Content changed: %d | Unchanged: %d\n",
@@ -106,9 +113,7 @@ func compareStructure(ctx context.Context, src *Source, input CompareVersionsInp
 		}
 		sb.WriteString("\nUse compare_versions with section_number to see the text diff of a changed section.")
 	}
-
-	header := compareHeader(input.SpecID, "", oldLabel, newLabel)
-	return prependLine(header, paginateText(sb.String(), input.Offset, input.MaxLines, input.MaxChars))
+	return sb.String()
 }
 
 // compareSection renders a unified diff of one section's text.
@@ -125,7 +130,7 @@ func compareSection(ctx context.Context, src *Source, input CompareVersionsInput
 		return r
 	}
 
-	oldLabel, newLabel := versionLabel(oldSecs, oldRes), versionLabel(newSecs, newRes)
+	oldLabel, newLabel := VersionLabel(oldSecs, oldRes), VersionLabel(newSecs, newRes)
 
 	// A section present on one side only is an informational answer, not a
 	// failure: numbers move between releases, and the structural summary or
@@ -204,16 +209,16 @@ func checkComparable(ctx context.Context, src *Source, specID, sectionNumber str
 		}
 		return errorResult(fmt.Sprintf("no sections found for %s in either version", specID))
 	}
-	oldV, newV := resolvedVersion(oldSecs, oldRes), resolvedVersion(newSecs, newRes)
+	oldV, newV := ResolvedVersion(oldSecs, oldRes), ResolvedVersion(newSecs, newRes)
 	if oldV != "" && oldV == newV {
 		return textResult(fmt.Sprintf("%s: old_version and new_version both resolve to v%s; nothing to compare.", specID, oldV))
 	}
 	return nil
 }
 
-// resolvedVersion names the version a request landed on. The Resolution knows
+// ResolvedVersion names the version a request landed on. The Resolution knows
 // it except on the database default path, where the rows do.
-func resolvedVersion(secs []db.Section, res Resolution) string {
+func ResolvedVersion(secs []db.Section, res Resolution) string {
 	if res.Version != "" {
 		return res.Version
 	}
@@ -223,9 +228,9 @@ func resolvedVersion(secs []db.Section, res Resolution) string {
 	return ""
 }
 
-// versionLabel renders one side of a comparison, e.g. "v17.9.0 (Rel-17, archived)".
-func versionLabel(secs []db.Section, res Resolution) string {
-	name := resolvedVersion(secs, res)
+// VersionLabel renders one side of a comparison, e.g. "v17.9.0 (Rel-17, archived)".
+func VersionLabel(secs []db.Section, res Resolution) string {
+	name := ResolvedVersion(secs, res)
 	if name == "" {
 		return "the database version"
 	}

--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -67,7 +67,7 @@ func compareStructure(ctx context.Context, src *Source, input CompareVersionsInp
 	d := structdiff.Diff(oldSecs, newSecs)
 	oldLabel, newLabel := VersionLabel(oldSecs, oldRes), VersionLabel(newSecs, newRes)
 
-	header := compareHeader(input.SpecID, "", oldLabel, newLabel)
+	header := CompareHeader(input.SpecID, "", oldLabel, newLabel)
 	return prependLine(header, paginateText(RenderStructuralSummary(d, oldLabel, newLabel), input.Offset, input.MaxLines, input.MaxChars))
 }
 
@@ -150,7 +150,7 @@ func compareSection(ctx context.Context, src *Source, input CompareVersionsInput
 		ctxLines = defaultContextLines
 	}
 
-	header := compareHeader(input.SpecID, input.SectionNumber, oldLabel, newLabel)
+	header := CompareHeader(input.SpecID, input.SectionNumber, oldLabel, newLabel)
 	diff := textdiff.UnifiedKeyed(structdiff.SectionLines(oldSecs), structdiff.SectionLines(newSecs), ctxLines, structdiff.NormalizeImageRefs)
 	if diff == "" {
 		msg := fmt.Sprintf("Section %s is identical between %s and %s.", input.SectionNumber, oldLabel, newLabel)
@@ -250,8 +250,9 @@ func VersionLabel(secs []db.Section, res Resolution) string {
 	return label
 }
 
-// compareHeader builds the provenance line prepended to every page.
-func compareHeader(specID, sectionNumber, oldLabel, newLabel string) string {
+// CompareHeader builds the provenance line prepended to every page of a
+// comparison. It is shared with the CLI's compare-versions command.
+func CompareHeader(specID, sectionNumber, oldLabel, newLabel string) string {
 	h := "[Compare: " + specID
 	if sectionNumber != "" {
 		h += " — Section " + sectionNumber

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -53,18 +53,19 @@ func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRe
 		}
 
 		result := paginateText(full.String(), input.Offset, input.MaxLines, input.MaxChars)
-		header := sourceHeader(sections[0], input.IncludeSubsections && len(sections) > 1, res.Archived)
+		header := SourceHeader(sections[0], input.IncludeSubsections && len(sections) > 1, res.Archived)
 		return prependLine(header, result), nil, nil
 	}
 }
 
-// sourceHeader builds the provenance line prepended to every get_section page,
+// SourceHeader builds the provenance line prepended to every get_section page,
 // e.g. "[Source: TS 23.501 v18.6.0 (Rel-18) — Section 5.1]". Archived versions
 // say so, because get_references only covers the version the database was
 // built with and would silently answer about a different one; images are
 // downloaded on first use, but only when the image tools are told the version,
-// so the header reminds the caller to pass it.
-func sourceHeader(s db.Section, withSubsections, archived bool) string {
+// so the header reminds the caller to pass it. It is shared with the CLI's
+// get-section command.
+func SourceHeader(s db.Section, withSubsections, archived bool) string {
 	h := fmt.Sprintf("[Source: %s — Section %s", specLabel(s), s.Number)
 	if withSubsections {
 		h += " (+subsections)"

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -36,17 +37,22 @@ func HandleGetTOC(src *Source) func(ctx context.Context, req *mcp.CallToolReques
 			return errorResult(fmt.Sprintf("no sections found for %s%s", input.SpecID, versionSuffix(res))), nil, nil
 		}
 
-		var sb strings.Builder
-		fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", specLabel(sections[0]))
-		for _, s := range sections {
-			indent := strings.Repeat("  ", s.Level-1)
-			if s.Number != "" && s.Number != s.Title {
-				fmt.Fprintf(&sb, "%s- %s %s\n", indent, s.Number, s.Title)
-			} else {
-				fmt.Fprintf(&sb, "%s- %s\n", indent, s.Title)
-			}
-		}
-
-		return textResult(sb.String()), nil, nil
+		return textResult(RenderTOC(sections)), nil, nil
 	}
+}
+
+// RenderTOC renders a specification's sections as a Markdown table of
+// contents. It is shared with the CLI's get-toc command.
+func RenderTOC(sections []db.Section) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", specLabel(sections[0]))
+	for _, s := range sections {
+		indent := strings.Repeat("  ", s.Level-1)
+		if s.Number != "" && s.Number != s.Title {
+			fmt.Fprintf(&sb, "%s- %s %s\n", indent, s.Number, s.Title)
+		} else {
+			fmt.Fprintf(&sb, "%s- %s\n", indent, s.Title)
+		}
+	}
+	return sb.String()
 }

--- a/tools/openapi.go
+++ b/tools/openapi.go
@@ -75,7 +75,7 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 
 		// If path or schema filter is specified, parse YAML and extract
 		if input.Path != "" || input.Schema != "" {
-			filtered, err := filterOpenAPI(content, input.Path, input.Schema)
+			filtered, err := FilterOpenAPI(content, input.Path, input.Schema)
 			if err != nil {
 				return errorResult(fmt.Sprintf("failed to filter openapi: %v", err)), nil, nil
 			}
@@ -86,7 +86,9 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 	}
 }
 
-func filterOpenAPI(content, pathFilter, schemaFilter string) (string, error) {
+// FilterOpenAPI narrows an OpenAPI YAML document to a path and/or schema
+// subset. It is shared with the CLI's get-openapi command.
+func FilterOpenAPI(content, pathFilter, schemaFilter string) (string, error) {
 	var doc map[string]any
 	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
 		return "", fmt.Errorf("parse yaml: %w", err)

--- a/web/compare.go
+++ b/web/compare.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
-	"github.com/higebu/3gpp-mcp/internal/specver"
 	"github.com/higebu/3gpp-mcp/internal/structdiff"
 	"github.com/higebu/3gpp-mcp/internal/textdiff"
 	"github.com/higebu/3gpp-mcp/tools"
@@ -207,7 +206,7 @@ func (h *handler) compareNotice(ctx context.Context, specID string, oldSecs, new
 		}
 		return fmt.Sprintf("No sections found for %s in either version.", specID)
 	}
-	oldV, newV := resolvedVersion(oldSecs, oldRes), resolvedVersion(newSecs, newRes)
+	oldV, newV := tools.ResolvedVersion(oldSecs, oldRes), tools.ResolvedVersion(newSecs, newRes)
 	if oldV != "" && oldV == newV {
 		return fmt.Sprintf("Both versions resolve to v%s; nothing to compare.", oldV)
 	}
@@ -217,49 +216,14 @@ func (h *handler) compareNotice(ctx context.Context, specID string, oldSecs, new
 // fillLabels derives the display labels and the version each side's section
 // links must carry.
 func (d *compareData) fillLabels(oldSecs []db.Section, oldRes tools.Resolution, newSecs []db.Section, newRes tools.Resolution) {
-	d.OldLabel = versionLabel(oldSecs, oldRes)
-	d.NewLabel = versionLabel(newSecs, newRes)
+	d.OldLabel = tools.VersionLabel(oldSecs, oldRes)
+	d.NewLabel = tools.VersionLabel(newSecs, newRes)
 	if oldRes.Archived {
 		d.OldURLVersion = oldRes.Version
 	}
 	if newRes.Archived {
 		d.NewURLVersion = newRes.Version
 	}
-}
-
-// resolvedVersion names the version a request landed on. The Resolution knows
-// it except on the database default path, where the rows do.
-func resolvedVersion(secs []db.Section, res tools.Resolution) string {
-	if res.Version != "" {
-		return res.Version
-	}
-	if len(secs) > 0 {
-		return secs[0].Version
-	}
-	return ""
-}
-
-// versionLabel renders one side of a comparison, e.g. "v17.9.0 (Rel-17,
-// archived)", matching the compare_versions tool's wording.
-func versionLabel(secs []db.Section, res tools.Resolution) string {
-	name := resolvedVersion(secs, res)
-	if name == "" {
-		return "the database version"
-	}
-	label := "v" + name
-	var notes []string
-	if len(secs) > 0 {
-		if rel := specver.ReleaseLabel(secs[0].Release); rel != "" {
-			notes = append(notes, rel)
-		}
-	}
-	if res.Archived {
-		notes = append(notes, "archived")
-	}
-	if len(notes) > 0 {
-		label += " (" + strings.Join(notes, ", ") + ")"
-	}
-	return label
 }
 
 // classifyDiff splits unified-diff text into display lines. Every line of


### PR DESCRIPTION
## Summary

Adds CLI query subcommands mirroring all 11 MCP read tools 1:1, so the database can be inspected and scripted from a shell without an MCP client:

`list-specs`, `list-versions`, `get-toc`, `get-section`, `compare-versions`, `search`, `list-openapi`, `get-openapi`, `get-references`, `list-images`, `get-image`

```bash
3gpp-mcp search --db data/3gpp.db --limit 3 "AMF AND authentication" | jq '.results[].section_number'
3gpp-mcp get-section --db data/3gpp.db "TS 23.501" 5.15.2 | less
3gpp-mcp get-image --db data/3gpp.db -o figure1.png "TS 23.501" image1.png
```

## Design

- The CLI calls the same `tools.Source` / `db.DB` layer as the MCP handlers and the web viewer — MCP handlers are not invoked, so output is shell-shaped: indented JSON to stdout (jq-ready), warnings/progress to stderr, no `[Lines a-b of N]` pagination banners.
- Nontrivial renderings are shared instead of duplicated: `RenderTOC`, `RenderStructuralSummary`, `VersionLabel`, `ResolvedVersion`, `SourceHeader`, `CompareHeader`, `FilterOpenAPI` are now exported from `tools/`, and `web/compare.go` drops its private copies of the label helpers.
- Version-aware commands (`-version`, `compare-versions`) reuse `serve`'s fetch flags (`-no-fetch`, `-version-cache`, `-version-cache-mb`, `-fetch-budget`) and wait for an on-demand download to finish (5s polling, Ctrl-C to interrupt) instead of asking the caller to retry. Queries that name no version never create the version cache; `list-versions` reads an existing cache but will not create one.
- `get-references` prints the full result with no 500-row cap (that cap protects an LLM context window), and `get-image` writes raw bytes to `-o`/stdout, including EMF/WMF with a conversion note on stderr.
- The command table in `main.go` is now a registry: dispatch, the usage line and the bash/zsh/fish completion scripts are all generated from it, with tests pinning that every registered command appears in all three shells and that apostrophes in descriptions are escaped.

## Testing

- `gofmt` / `go vet` / `go test -short ./...` / `go test -short -race ./cmd/... ./tools/... ./web/...` all pass.
- New `cmd/3gpp-mcp/query_test.go` covers every `runX` against `testutil.SetupTestDB` (no network), the fetch-wait loop, the version-cache guard, and the options-before-positionals usage path.
- Smoke-tested the built binary end to end against a database imported from the testdata `.docx` (all 11 commands, JSON shape, provenance headers, error paths, completion script syntax).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U196Jdd94induTSoUR4jdS)_