### PR TITLE
docs: add TeleQnA benchmark results

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,55 @@
+# Benchmark: TeleQnA
+
+How much does 3gpp-mcp improve LLM accuracy on 3GPP questions? Measured with
+[teleqna-eval](https://github.com/higebu/teleqna-eval) on
+[TeleQnA](https://github.com/netop-team/TeleQnA): each model answers the same
+multiple-choice questions twice — once with the MCP tools of a running
+3gpp-mcp server bridged into the request, once without — and the paired
+difference is the effect of 3gpp-mcp.
+
+## Results
+
+All 1,509 `Standards specifications` TeleQnA questions tagged `3GPP`,
+each model on its vendor's own API, evaluated 2026-08-09 against a
+database holding the latest version of every spec:
+
+| Model | No tools | With 3gpp-mcp | Δ | Win/loss pairs¹ | McNemar |
+|---|---|---|---|---|---|
+| DeepSeek V4 Flash | 75.3% | **86.5%** | +11.1pt | 225 / 57 | χ²=98.9, p<10⁻²² |
+| Claude Sonnet 5 | 73.5% | **84.5%** | +11.0pt | 241 / 75 | χ²=86.2, p<10⁻¹⁹ |
+| GPT 5.6 Luna | 73.6% | **85.0%** | **+11.4pt** | 242 / 70 | χ²=93.7, p<10⁻²¹ |
+
+¹ questions only the tools run answered correctly / only the baseline answered correctly.
+
+## Takeaways
+
+- **The gain is model-independent**: three unrelated model families, each on
+  its own vendor's API, improve by about 11 points — the three deltas land
+  within 0.4pt of each other — each significant at p < 10⁻¹⁹ or better.
+- **68 of 1,509 questions (5%) were answered correctly by all three models
+  with tools and by none without** — questions that effectively require the
+  specification text.
+- Models use the tools differently but land in the same place: Claude
+  Sonnet 5 averaged 3.3 tool calls per question, GPT 5.6 Luna 5.7, DeepSeek
+  V4 Flash 10.1 — Sonnet reaches the same gain with a third of the searches.
+
+## Method (summary)
+
+- Same 1,509-question set for every run; questions whose text lacks `3GPP`
+  (IEEE 802.11 etc.) are excluded from the category.
+- Tools condition: all 11 MCP tools bridged as function tools into the
+  model's API, up to 20 tool rounds per question. Every model ran on its
+  vendor's own API: OpenAI's Responses API (GPT 5.6 Luna), Anthropic's
+  chat completions endpoint (Claude Sonnet 5), `api.deepseek.com`
+  (DeepSeek V4 Flash).
+- No token limit and no temperature, matching the TeleQnA paper's settings,
+  identical within every pair, one run per condition; answers scored by exact
+  option match, unanswered counts as wrong. Re-running an unchanged condition
+  moves it by up to a point, so the differences between models are not
+  meaningful — the ~11pt gain is.
+- Absolute numbers are not comparable to Telco-RAG / TelcoAI / GSMA
+  leaderboard figures (different models, prompt formats, and subsets); the
+  paired same-model delta is the measurement.
+
+Harness, full methodology, and reproduction scripts:
+[higebu/teleqna-eval](https://github.com/higebu/teleqna-eval).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This tool addresses these challenges by parsing the `.docx` files, structuring t
 
 Embedding-based RAG is a common way to improve accuracy on document Q&A, and RAG systems specialized for 3GPP documents exist ([Telco-RAG](https://arxiv.org/abs/2404.15939), [TelcoAI](https://arxiv.org/abs/2601.16984)). This tool takes a simpler approach: instead of building a retrieval pipeline in front of the model, it gives the model search and navigation tools and lets it explore the specifications the way an engineer would — full-text search, then following the section hierarchy and cross-references. Since retrieval is plain FTS5 search over structured sections, there is no embedding model or vector database to run, and everything lives in a single SQLite file.
 
+Measured on TeleQnA, this lifts accuracy on 3GPP standards questions by about 11 percentage points across three model families — see [BENCHMARK.md](BENCHMARK.md).
+
 ## Getting Started
 
 ### 1. Install


### PR DESCRIPTION
## Summary

Add BENCHMARK.md with measured results on TeleQnA: each of three models (DeepSeek V4 Flash, Claude Sonnet 5, GPT 5.6 Luna) answered all 1,509 3GPP-tagged Standards-specifications questions twice — with and without 3gpp-mcp tools bridged into the request. Every model ran on its vendor's own API, with no token limit and no temperature, matching the TeleQnA paper's generation settings.

- With tools, accuracy rises by about 11 percentage points on every model (73.5–75.3% → 84.5–86.5%), with the three deltas within 0.4pt of each other, each significant at p < 10⁻¹⁹ (McNemar)
- 68 questions were answered correctly by all three models with tools and by none without
- Claude Sonnet 5 reaches the same gain with a third of the searches (3.3 tool calls per question vs 10.1 for DeepSeek)
- README: one-sentence pointer from the "Why not RAG?" section to BENCHMARK.md

Harness and reproduction scripts live in [higebu/teleqna-eval](https://github.com/higebu/teleqna-eval). No cost figures are included (provider pricing changes make them meaningless); usage is reported in tokens in the harness repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)