### PR TITLE
feat: add --max-release to cap the newest release used

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ cannot easily discover from the code.
 make build                # Build to bin/3gpp-mcp
 go test ./...             # Run tests (-short skips tests that hit the 3GPP FTP)
 gofmt -l . && go vet ./... && golangci-lint run   # Lint (CI also runs go test -race)
-make build-db             # Download + import latest version of every spec (RELEASE=19 to restrict)
+make build-db             # Download + import latest version of every spec (RELEASE=19 for one release, MAX_RELEASE=19 to cap)
 make web                  # HTTP server with web viewer at :8080
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 # 2) Build the database. By default the latest version of every spec across all
 #    releases is baked in; pass --build-arg RELEASE=19 to restrict to a single
-#    release. LibreOffice is required for --convert-doc / --convert-image but
-#    lives only in this stage, so it never bloats the final image. Temp files are
-#    deleted as each spec is processed, keeping disk usage low.
+#    release, or --build-arg MAX_RELEASE=19 to cap the newest release while
+#    keeping specs that have no version in it. LibreOffice is required for
+#    --convert-doc / --convert-image but lives only in this stage, so it never
+#    bloats the final image. Temp files are deleted as each spec is processed,
+#    keeping disk usage low.
 FROM golang:1.26-bookworm@sha256:6c5605ab3a9a9fb3c4eafe5b3d63cdbf3881caf113262b67862547b54a9db599 AS db-builder
 ARG RELEASE=latest
+ARG MAX_RELEASE=
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libreoffice ca-certificates sqlite3 \
     && rm -rf /var/lib/apt/lists/*
@@ -28,6 +31,7 @@ RUN if [ "${RELEASE}" = "latest" ] || [ -z "${RELEASE}" ]; then \
     else \
         set -- --release "${RELEASE}"; \
     fi \
+    && if [ -n "${MAX_RELEASE}" ]; then set -- "$@" --max-release "${MAX_RELEASE}"; fi \
     && /3gpp-mcp build "$@" \
     --db /3gpp.db \
     --convert-doc \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ BIN_DIR ?= bin
 # number (e.g. RELEASE=19) to restrict to a single release.
 RELEASE ?= latest
 release_flag = $(if $(filter latest,$(RELEASE)),--latest,--release $(RELEASE))
+# MAX_RELEASE caps the newest release used: every spec is taken at its newest
+# version at or below it, so a spec without a version in that release is kept
+# at an older one instead of dropping out, which is what RELEASE=<n> does. Use
+# it with the default RELEASE=latest — combining it with RELEASE=<n> is an
+# error. Pass the same MAX_RELEASE to update-specs, or the update lifts the
+# database to the newest release on the archive.
+MAX_RELEASE ?=
+max_release_flag = $(if $(MAX_RELEASE),--max-release $(MAX_RELEASE))
 
 # Build the MCP server
 build:
@@ -29,23 +37,25 @@ import-dir: build
 	./$(BIN_DIR)/3gpp-mcp import-dir --db $(DB_PATH) $(SPECS_DIR)
 
 # Download + import in one step (recommended). Builds the latest version of
-# every spec by default; pass RELEASE=19 to restrict to a single release.
+# every spec by default; pass RELEASE=19 to restrict to a single release, or
+# MAX_RELEASE=19 to cap the newest release without dropping specs.
 build-db: build
-	./$(BIN_DIR)/3gpp-mcp build $(release_flag) --db $(DB_PATH) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp build $(release_flag) $(max_release_flag) --db $(DB_PATH) --convert-doc
 
 # Download specs (no database import; legacy .doc files are converted to
 # .docx). Latest of every spec by default; pass RELEASE=19 to restrict to a
-# single release.
+# single release, or MAX_RELEASE=19 to cap the newest release.
 download-specs: build
-	./$(BIN_DIR)/3gpp-mcp download $(release_flag) --output-dir $(SPECS_DIR) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp download $(release_flag) $(max_release_flag) --output-dir $(SPECS_DIR) --convert-doc
 
 # Download the single latest version of each spec across all releases
 download-latest-specs: build
-	./$(BIN_DIR)/3gpp-mcp download --latest --output-dir $(SPECS_DIR) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp download --latest $(max_release_flag) --output-dir $(SPECS_DIR) --convert-doc
 
-# Update specs in DB to latest versions
+# Update specs in DB to latest versions. Pass the same MAX_RELEASE the database
+# was built with to keep the cap.
 update-specs: build
-	./$(BIN_DIR)/3gpp-mcp update --db $(DB_PATH) --convert-doc
+	./$(BIN_DIR)/3gpp-mcp update $(max_release_flag) --db $(DB_PATH) --convert-doc
 
 # Show database info
 db-info:

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ docker build -t 3gpp-mcp:latest .
 # ...or restrict the database to a single release
 docker build --build-arg RELEASE=19 -t 3gpp-mcp:rel19 .
 
+# ...or cap the newest release, keeping specs that have no version in it
+docker build --build-arg MAX_RELEASE=19 -t 3gpp-mcp:max-rel19 .
+
 # stdio transport (Claude Code / IDE integration)
 docker run --rm -i 3gpp-mcp:latest
 
@@ -196,7 +199,9 @@ docker run --rm -p 8080:8080 3gpp-mcp:latest serve --db /3gpp.db --transport htt
 
 `RELEASE` defaults to `latest`, which bakes in the latest version of every spec
 across all releases. Set `--build-arg RELEASE=<n>` (e.g. `19`) to restrict the
-database to a single release.
+database to a single release, or `--build-arg MAX_RELEASE=<n>` to cap the newest
+release without dropping specs that have no version in it. The two cannot be
+combined.
 
 ### Cloud Run
 
@@ -382,6 +387,21 @@ For spot comparisons across releases, `compare_versions` and the `version` param
 3gpp-mcp build --release 19 --db data/3gpp-rel19.db --convert-doc --convert-image
 ```
 
+`--release` keeps only specs that have a version in that exact release, so a
+spec frozen in an earlier release (TS 34.108, for example) is missing from the
+database entirely. To pin a release without losing those specs, cap the
+selection instead — every spec is taken at its newest version at or below the
+cap:
+
+```bash
+# Everything as of Release 19: specs with no Rel-19 version fall back to their
+# newest older version rather than dropping out.
+3gpp-mcp build --max-release 19 --db data/3gpp-rel19.db --convert-doc --convert-image
+
+# Keep the cap when refreshing the database later.
+3gpp-mcp update --max-release 19 --db data/3gpp-rel19.db --convert-doc
+```
+
 Register them as separate MCP servers:
 
 ```bash
@@ -453,6 +473,7 @@ Download and import specifications into the database (recommended for initial se
 |------|-------------|---------|
 | `--db` | Output SQLite database path | `3gpp.db` |
 | `--release` | Process specs for a specific release (e.g. `19`) | |
+| `--max-release` | Cap the selection at a release (e.g. `19`): take each spec at its newest version at or below it | |
 | `--latest` | Select every spec at its latest version (use when no other selector is given) | `false` |
 | `--spec` | Process a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated (e.g. `23,29`) | |
@@ -464,8 +485,13 @@ Download and import specifications into the database (recommended for initial se
 | `--scrape-workers` | Concurrency for scraping spec listings (`0` = auto) | `0` |
 | `--timeout` | HTTP timeout | `30s` |
 
-One of `--release`, `--latest`, `--series` or `--spec` must be given, `--spec-list`
-included: the file supplies the candidate entries and the selector filters them.
+One of `--release`, `--max-release`, `--latest`, `--series` or `--spec` must be
+given, `--spec-list` included: the file supplies the candidate entries and the
+selector filters them.
+
+`--release` and `--max-release` differ in what happens to a spec that has no
+version in the named release: `--release 19` drops it, `--max-release 19` keeps
+it at its newest version below the cap. They cannot be combined.
 
 ### `download`
 
@@ -474,6 +500,7 @@ Download specifications without conversion.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--release` | Download specs for a specific release | |
+| `--max-release` | Cap the selection at a release (e.g. `19`): take each spec at its newest version at or below it | |
 | `--latest` | Select every spec at its latest version (use when no other selector is given) | `false` |
 | `--spec` | Download a specific spec (e.g. `23.501`) | |
 | `--series` | Filter by series, comma-separated | |
@@ -485,8 +512,8 @@ Download specifications without conversion.
 | `--scrape-workers` | Concurrency for scraping spec listings (`0` = auto) | `0` |
 | `--timeout` | HTTP timeout | `30s` |
 
-Like `build`, this command requires one of `--release`, `--latest`, `--series` or
-`--spec`, even with `--spec-list`.
+Like `build`, this command requires one of `--release`, `--max-release`,
+`--latest`, `--series` or `--spec`, even with `--spec-list`.
 
 ### `import`
 
@@ -523,6 +550,7 @@ Update specifications in the database to latest versions.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--db` | SQLite database path | `3gpp.db` |
+| `--max-release` | Cap updates at a release (e.g. `19`): update each spec to its newest version at or below it | |
 | `--workers` | Number of parallel workers | NumCPU |
 | `--convert-doc` | Convert `.doc` to `.docx` using LibreOffice | `false` |
 | `--convert-image` | Convert EMF/WMF images to PNG using LibreOffice | `false` |
@@ -530,6 +558,12 @@ Update specifications in the database to latest versions.
 | `--no-cache` | Disable the spec list cache | `false` |
 | `--scrape-workers` | Concurrency for scraping spec listings (`0` = auto) | `0` |
 | `--timeout` | HTTP timeout | `30s` |
+
+The cap is not stored in the database, so a database built with
+`--max-release 19` needs the same flag here — otherwise the update lifts every
+spec to the newest release on the archive. With a cap the update moves a spec
+in either direction, so it also brings an already-built uncapped database down
+to the cap.
 
 ### Query commands
 

--- a/README.md
+++ b/README.md
@@ -563,7 +563,10 @@ The cap is not stored in the database, so a database built with
 `--max-release 19` needs the same flag here — otherwise the update lifts every
 spec to the newest release on the archive. With a cap the update moves a spec
 in either direction, so it also brings an already-built uncapped database down
-to the cap.
+to the cap; a spec whose every version is above the cap is removed, since no
+version of it belongs in a capped database. A spec missing from the archive
+listing is left untouched, as a failed listing looks the same as a withdrawn
+spec.
 
 ### Query commands
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,9 @@
 #
 # _RELEASE defaults to "latest", baking in the latest version of every spec
 # across all releases. Set it to a release number (e.g. _RELEASE=19) to restrict
-# the database to a single release.
+# the database to a single release, or leave it at "latest" and set
+# _MAX_RELEASE=19 to cap the newest release while keeping specs that have no
+# version in it.
 #
 # Manual run (latest of every spec):
 #   gcloud builds submit --no-source --config cloudbuild.yaml \
@@ -16,6 +18,16 @@
 # Manual run (single release):
 #   gcloud builds submit --no-source --config cloudbuild.yaml \
 #     --substitutions=_REF=main,_RELEASE=19,_REGION=asia-northeast1,_REPO=3gpp-mcp,_SERVICE=3gpp-mcp
+#
+# Manual run (capped at a release):
+#   gcloud builds submit --no-source --config cloudbuild.yaml \
+#     --substitutions=_REF=main,_MAX_RELEASE=19,_REGION=asia-northeast1,_REPO=3gpp-mcp,_SERVICE=3gpp-mcp
+#
+# The image tag is rel${_RELEASE}${_MAX_RELEASE}, so the three configurations
+# above tag "rellatest", "rel19" and "rellatest19" respectively. Keeping the cap
+# in the tag matters because the scheduled build runs with the defaults: with a
+# shared tag it would overwrite a capped image with an uncapped database and
+# deploy it.
 #
 # Scheduled run: start it from Cloud Scheduler via the Cloud Build API.
 #
@@ -29,6 +41,9 @@ substitutions:
   # "latest" = latest version of every spec across all releases; or a release
   # number such as "19" to restrict the database to a single release.
   _RELEASE: "latest"
+  # Optional cap: a release number such as "19" takes every spec at its newest
+  # version at or below it. Cannot be combined with a numeric _RELEASE.
+  _MAX_RELEASE: ""
   _REGION: "asia-northeast1"
   _REPO: "3gpp-mcp"
   _SERVICE: "3gpp-mcp"
@@ -60,15 +75,16 @@ steps:
     args:
       - build
       - --build-arg=RELEASE=${_RELEASE}
+      - --build-arg=MAX_RELEASE=${_MAX_RELEASE}
       - -t
-      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}${_MAX_RELEASE}
       - .
 
   - id: push
     name: gcr.io/cloud-builders/docker@sha256:617f98016081e2978c0b44184d7b09446027b909f1078b8fdc23efc4c74c5f20
     args:
       - push
-      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}${_MAX_RELEASE}
 
   # Deploy via a service spec so we can configure the startup/liveness probes
   # (gcloud run deploy has no flags for probes). add-iam-policy-binding replaces
@@ -83,7 +99,7 @@ steps:
         set -euo pipefail
         sed \
           -e "s|__SERVICE__|${_SERVICE}|g" \
-          -e "s|__IMAGE__|${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}|g" \
+          -e "s|__IMAGE__|${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:rel${_RELEASE}${_MAX_RELEASE}|g" \
           service.yaml > /workspace/service.rendered.yaml
         gcloud run services replace /workspace/service.rendered.yaml --region=${_REGION}
         gcloud run services add-iam-policy-binding ${_SERVICE} \

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -467,22 +467,33 @@ var newHTTPClient = func(timeout time.Duration) *http.Client {
 	return &http.Client{Timeout: timeout}
 }
 
-// requireSelector exits unless at least one spec selector flag was provided.
-func requireSelector(release int, latest bool, spec, series string) {
-	if release != 0 || latest || spec != "" || series != "" {
-		return
+// specFilterFromFlags builds the selector shared by build and download. It
+// exits unless at least one spec selector flag was provided, and rejects
+// release flags that contradict each other.
+func specFilterFromFlags(release, maxRelease int, latest bool, spec, series string) pipeline.SpecFilter {
+	switch {
+	case release != 0 && maxRelease != 0:
+		fmt.Fprintln(os.Stderr, "Specify only one of --release and --max-release")
+		exit(1)
+	case release < 0 || maxRelease < 0:
+		fmt.Fprintln(os.Stderr, "--release and --max-release must not be negative")
+		exit(1)
+	case release == 0 && maxRelease == 0 && !latest && spec == "" && series == "":
+		fmt.Fprintln(os.Stderr, "Specify --release, --max-release, --latest, --series, or --spec")
+		exit(1)
 	}
-	fmt.Fprintln(os.Stderr, "Specify --release, --latest, --series, or --spec")
-	exit(1)
+
+	f := pipeline.SpecFilter{Release: release, MaxRelease: maxRelease, SpecID: spec}
+	if series != "" {
+		f.Series = strings.Split(series, ",")
+	}
+	return f
 }
 
-// resolveSpecs fetches, parses, and filters specs based on CLI flags.
-func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, seriesFlag string, release int, useCache bool, scrapeConcurrency int) []*pipeline.SpecVersion {
-	var seriesFilter []string
-	if seriesFlag != "" {
-		seriesFilter = strings.Split(seriesFlag, ",")
-	}
-
+// resolveSpecs fetches and parses archive entries, then applies the caller's
+// selector. Build and download always keep one version per spec, so LatestOnly
+// is set here rather than by every caller.
+func resolveSpecs(ctx context.Context, client *http.Client, specList string, filter pipeline.SpecFilter, useCache bool, scrapeConcurrency int) []*pipeline.SpecVersion {
 	var entries []string
 	var err error
 	if specList != "" {
@@ -491,15 +502,15 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 		if err != nil {
 			log.Fatalf("Failed to load spec list: %v", err)
 		}
-	} else if specFlag != "" {
-		fmt.Printf("Fetching versions for %s...\n", specFlag)
-		entries, err = pipeline.FetchSpecZips(ctx, client, specFlag, useCache)
+	} else if filter.SpecID != "" {
+		fmt.Printf("Fetching versions for %s...\n", filter.SpecID)
+		entries, err = pipeline.FetchSpecZips(ctx, client, filter.SpecID, useCache)
 		if err != nil {
 			log.Fatalf("Failed to fetch spec versions: %v", err)
 		}
 	} else {
 		fmt.Println("Fetching spec list from 3GPP archive...")
-		entries, err = pipeline.FetchSpecList(ctx, client, seriesFilter, useCache, scrapeConcurrency)
+		entries, err = pipeline.FetchSpecList(ctx, client, filter.Series, useCache, scrapeConcurrency)
 		var partial *pipeline.PartialSpecListError
 		if errors.As(err, &partial) {
 			// Proceeding would silently drop every spec under the failed
@@ -522,12 +533,14 @@ func resolveSpecs(ctx context.Context, client *http.Client, specList, specFlag, 
 	}
 	fmt.Printf("Parsed %d spec entries\n", len(specs))
 
-	return pipeline.FilterSpecs(specs, release, seriesFilter, specFlag, true)
+	filter.LatestOnly = true
+	return pipeline.FilterSpecs(specs, filter)
 }
 
 func cmdDownload(args []string) {
 	fs := flag.NewFlagSet("download", flag.ExitOnError)
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
+	maxRelease := fs.Int("max-release", 0, "Cap selection at this release: take each spec at its newest version at or below it (e.g., 19)")
 	latest := fs.Bool("latest", false, "Select every spec at its latest version (use when no other selector is given)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
@@ -540,12 +553,12 @@ func cmdDownload(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	requireSelector(*release, *latest, *specFlag, *seriesFlag)
+	filter := specFilterFromFlags(*release, *maxRelease, *latest, *specFlag, *seriesFlag)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, !*noCache, *scrapeWorkers)
+	filtered := resolveSpecs(ctx, client, *specList, filter, !*noCache, *scrapeWorkers)
 
 	if len(filtered) == 0 {
 		fmt.Println("No specs matched the filters.")
@@ -571,6 +584,7 @@ func cmdPipeline(args []string) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "Output SQLite database path")
 	release := fs.Int("release", 0, "Download specs for specific release (e.g., 19)")
+	maxRelease := fs.Int("max-release", 0, "Cap selection at this release: take each spec at its newest version at or below it (e.g., 19)")
 	latest := fs.Bool("latest", false, "Select every spec at its latest version (use when no other selector is given)")
 	seriesFlag := fs.String("series", "", "Filter by series, comma-separated (e.g., 23,29)")
 	specFlag := fs.String("spec", "", "Download specific spec (e.g., 23.501)")
@@ -583,14 +597,14 @@ func cmdPipeline(args []string) {
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
 
-	requireSelector(*release, *latest, *specFlag, *seriesFlag)
+	filter := specFilterFromFlags(*release, *maxRelease, *latest, *specFlag, *seriesFlag)
 
 	// Resolve specs before opening the database: resolveSpecs exits via
 	// log.Fatalf on failure, which must not strand an open WAL-mode database.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	client := &http.Client{Timeout: *timeout}
-	filtered := resolveSpecs(ctx, client, *specList, *specFlag, *seriesFlag, *release, !*noCache, *scrapeWorkers)
+	filtered := resolveSpecs(ctx, client, *specList, filter, !*noCache, *scrapeWorkers)
 
 	if err := runPipeline(ctx, *dbPath, client, filtered, *workers, *convertDoc, *convertImage, *timeout); err != nil {
 		log.Printf("Pipeline failed: %v", err)
@@ -781,6 +795,7 @@ func replaceDatabase(newPath, dbPath string) error {
 func cmdUpdate(args []string) {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 	dbPath := fs.String("db", "3gpp.db", "SQLite database path")
+	maxRelease := fs.Int("max-release", 0, "Cap updates at this release: update each spec to its newest version at or below it (e.g., 19)")
 	workers := fs.Int("workers", runtime.NumCPU(), "Number of parallel workers")
 	convertDoc := fs.Bool("convert-doc", false, "Convert .doc to .docx using LibreOffice")
 	convertImage := fs.Bool("convert-image", false, "Convert EMF/WMF images to PNG using LibreOffice (requires soffice)")
@@ -789,6 +804,12 @@ func cmdUpdate(args []string) {
 	scrapeWorkers := fs.Int("scrape-workers", 0, "Concurrency for scraping spec listings (0 = auto)")
 	timeout := fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	_ = fs.Parse(args)
+
+	if *maxRelease < 0 {
+		fmt.Fprintln(os.Stderr, "--max-release must not be negative")
+		exit(1)
+		return
+	}
 
 	newPath := *dbPath + ".new"
 	// Clear any copy left by a previous failed run. Its sidecars have to go
@@ -857,7 +878,9 @@ func cmdUpdate(args []string) {
 		}
 	}
 
-	latestSpecs := pipeline.FilterSpecs(allSpecs, 0, nil, "", true)
+	// A database built with --max-release must be updated with the same cap,
+	// otherwise every spec is dragged up to the newest release on the archive.
+	latestSpecs := pipeline.FilterSpecs(allSpecs, pipeline.SpecFilter{MaxRelease: *maxRelease, LatestOnly: true})
 
 	// Find specs that need updating
 	normalizeID := func(id string) string {
@@ -881,7 +904,15 @@ func cmdUpdate(args []string) {
 		if !ok {
 			continue
 		}
-		if specver.Compare(newVer, oldVer) > 0 {
+		// A cap makes the target version the newest one at or below it, which
+		// can be older than what is stored — a database built without the cap
+		// holds versions above it. Move to the target in either direction then,
+		// or applying a cap to an existing database would be a no-op.
+		changed := specver.Compare(newVer, oldVer) > 0
+		if *maxRelease > 0 {
+			changed = specver.Compare(newVer, oldVer) != 0
+		}
+		if changed {
 			fmt.Printf("  %s: %s -> %s\n", sv.SpecID, oldVer, newVer)
 			updates = append(updates, sv)
 		}

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -891,6 +891,31 @@ func cmdUpdate(args []string) {
 		dbVersions[normalizeID(s.ID)] = s.Version
 	}
 
+	// Specs the cap excludes entirely: the archive has the spec, but every
+	// version of it is above the cap. Leaving them would keep the database
+	// above --max-release however often it is updated, so they go. Only specs
+	// the listing actually carried are considered — one missing from a partial
+	// listing is skipped, like everywhere else in this command, rather than
+	// deleted on the strength of a failed fetch.
+	var removals []string
+	if *maxRelease > 0 {
+		inArchive := make(map[string]bool, len(allSpecs))
+		for _, sv := range allSpecs {
+			inArchive[normalizeID(sv.SpecID)] = true
+		}
+		underCap := make(map[string]bool, len(latestSpecs))
+		for _, sv := range latestSpecs {
+			underCap[normalizeID(sv.SpecID)] = true
+		}
+		for _, s := range currentResult.Specs {
+			normID := normalizeID(s.ID)
+			if inArchive[normID] && !underCap[normID] {
+				fmt.Printf("  %s: %s -> removed (no version at or below release %d)\n", s.ID, s.Version, *maxRelease)
+				removals = append(removals, s.ID)
+			}
+		}
+	}
+
 	var updates []*pipeline.SpecVersion
 	for _, sv := range latestSpecs {
 		normID := normalizeID(sv.SpecID)
@@ -918,13 +943,17 @@ func cmdUpdate(args []string) {
 		}
 	}
 
-	if len(updates) == 0 {
+	if len(updates) == 0 && len(removals) == 0 {
 		fmt.Println("All specs are up to date.")
 		discardWorkingCopy(newPath)
 		return
 	}
 
-	fmt.Printf("\n%d specs to update\n", len(updates))
+	fmt.Printf("\n%d specs to update", len(updates))
+	if len(removals) > 0 {
+		fmt.Printf(", %d to remove", len(removals))
+	}
+	fmt.Println()
 
 	d, err := db.OpenReadWrite(newPath)
 	if err != nil {
@@ -939,19 +968,29 @@ func cmdUpdate(args []string) {
 		log.Fatalf("Failed to initialize working copy schema: %v", err)
 	}
 
-	p := &pipeline.Pipeline{
-		DB:           d,
-		Client:       client,
-		Workers:      *workers,
-		ConvertDoc:   *convertDoc,
-		ConvertImage: *convertImage,
-		Timeout:      *timeout,
+	for _, id := range removals {
+		if err := d.DeleteSpec(id); err != nil {
+			_ = d.Close()
+			discardWorkingCopy(newPath)
+			log.Fatalf("Update failed: %v", err)
+		}
 	}
 
-	if err := p.Run(ctx, updates); err != nil {
-		_ = d.Close()
-		discardWorkingCopy(newPath)
-		log.Fatalf("Update failed: %v", err)
+	if len(updates) > 0 {
+		p := &pipeline.Pipeline{
+			DB:           d,
+			Client:       client,
+			Workers:      *workers,
+			ConvertDoc:   *convertDoc,
+			ConvertImage: *convertImage,
+			Timeout:      *timeout,
+		}
+
+		if err := p.Run(ctx, updates); err != nil {
+			_ = d.Close()
+			discardWorkingCopy(newPath)
+			log.Fatalf("Update failed: %v", err)
+		}
 	}
 
 	// Checkpoint WAL into the main file so the renamed DB is self-contained.

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -811,6 +811,69 @@ func TestCmdUpdate_MaxReleaseMovesDown(t *testing.T) {
 	}
 }
 
+// TestCmdUpdate_MaxReleaseRemovesAboveCap covers a spec the cap excludes
+// outright: the archive has no version at or below it, so leaving the stored
+// rows would keep the database above --max-release no matter how often it is
+// updated. A spec missing from the listing altogether must survive, since that
+// is indistinguishable from a listing that failed to fetch.
+func TestCmdUpdate_MaxReleaseRemovesAboveCap(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update.db")
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.InitSchema(); err != nil {
+		t.Fatalf("init schema: %v", err)
+	}
+	// Introduced in Rel-20, so nothing at or below the cap exists.
+	if err := d.InsertSpecWithSections(db.Spec{
+		ID: "TS 23.999", Title: "Brand new", Version: "20.0.0", VersionToken: "k00", Release: "20", Series: "23",
+	}, []db.Section{
+		{SpecID: "TS 23.999", Version: "20.0.0", Number: "1", Title: "Scope", Level: 1, Content: "# 1 Scope\nBrand new spec."},
+	}); err != nil {
+		t.Fatalf("insert spec: %v", err)
+	}
+	// Absent from the spec list below, so the cap must leave it alone.
+	if err := d.UpsertSpec(db.Spec{
+		ID: "TS 34.108", Title: "Common test environments", Version: "18.4.0", VersionToken: "i40", Release: "18", Series: "34",
+	}); err != nil {
+		t.Fatalf("upsert spec: %v", err)
+	}
+	d.Close()
+
+	listPath := filepath.Join(t.TempDir(), "list.txt")
+	if err := os.WriteFile(listPath, []byte("23_series/23.999/23999-k00.zip\n"), 0o644); err != nil {
+		t.Fatalf("write list: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		cmdUpdate([]string{"-db", dbPath, "-max-release", "19", "-spec-list", listPath, "-no-cache"})
+	})
+	if !strings.Contains(out, "TS 23.999: 20.0.0 -> removed") {
+		t.Errorf("output = %q, want TS 23.999 reported as removed", out)
+	}
+
+	d, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	result, err := d.ListSpecs(context.Background(), "", "", -1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].ID != "TS 34.108" {
+		t.Fatalf("specs after update = %+v, want only TS 34.108", result.Specs)
+	}
+	sections, err := d.AllSections(context.Background(), "TS 23.999", "20.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sections) != 0 {
+		t.Errorf("sections of the removed spec survived: %d", len(sections))
+	}
+}
+
 // partialArchive serves a mock archive where 23.501 lists one zip and 23.502
 // fails, so a full scrape assembles a partial spec list.
 func partialArchive(t *testing.T, healthyZip string) *httptest.Server {

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"syscall"
@@ -278,9 +279,7 @@ func TestResolveSpecs_FromSpecList(t *testing.T) {
 			context.Background(),
 			&http.Client{},
 			listPath,
-			"",    // specFlag
-			"",    // seriesFlag
-			0,     // release
+			pipeline.SpecFilter{},
 			false, // useCache
 			0,     // scrapeConcurrency
 		)
@@ -319,12 +318,10 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 		specs := resolveSpecs(
 			context.Background(),
 			client,
-			"",       // specList
-			"23.501", // specFlag
-			"",       // seriesFlag
-			0,        // release
-			false,    // useCache
-			0,        // scrapeConcurrency
+			"", // specList
+			pipeline.SpecFilter{SpecID: "23.501"},
+			false, // useCache
+			0,     // scrapeConcurrency
 		)
 		if len(specs) != 1 {
 			t.Fatalf("expected 1 spec, got %d", len(specs))
@@ -338,23 +335,36 @@ func TestResolveSpecs_FetchBySpecFlag(t *testing.T) {
 	}
 }
 
-// TestRequireSelector covers the selector guard shared by cmdDownload and
-// cmdPipeline, including --series as a valid sole selector and the exit path
-// taken when no selector is given.
-func TestRequireSelector(t *testing.T) {
+// TestSpecFilterFromFlags covers the selector guard shared by cmdDownload and
+// cmdPipeline, including --series as a valid sole selector, the exit path taken
+// when no selector is given, and the release flags that contradict each other.
+func TestSpecFilterFromFlags(t *testing.T) {
 	tests := []struct {
-		name     string
-		release  int
-		latest   bool
-		spec     string
-		series   string
-		wantExit bool
+		name       string
+		release    int
+		maxRelease int
+		latest     bool
+		spec       string
+		series     string
+		wantExit   bool
+		wantErr    string
+		wantFilter pipeline.SpecFilter
 	}{
-		{"none", 0, false, "", "", true},
-		{"release", 19, false, "", "", false},
-		{"latest", 0, true, "", "", false},
-		{"spec", 0, false, "23.501", "", false},
-		{"series alone", 0, false, "", "23,29", false},
+		{name: "none", wantExit: true, wantErr: "Specify --release, --max-release, --latest, --series, or --spec"},
+		{name: "release", release: 19, wantFilter: pipeline.SpecFilter{Release: 19}},
+		{name: "max release", maxRelease: 19, wantFilter: pipeline.SpecFilter{MaxRelease: 19}},
+		{name: "latest", latest: true},
+		{name: "latest with max release", latest: true, maxRelease: 19, wantFilter: pipeline.SpecFilter{MaxRelease: 19}},
+		{name: "spec", spec: "23.501", wantFilter: pipeline.SpecFilter{SpecID: "23.501"}},
+		{name: "series alone", series: "23,29", wantFilter: pipeline.SpecFilter{Series: []string{"23", "29"}}},
+		{
+			name: "release and max release", release: 19, maxRelease: 18,
+			wantExit: true, wantErr: "Specify only one of --release and --max-release",
+		},
+		{
+			name: "negative max release", maxRelease: -1,
+			wantExit: true, wantErr: "--release and --max-release must not be negative",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -363,19 +373,25 @@ func TestRequireSelector(t *testing.T) {
 			exit = func(code int) { exitCode = code }
 			t.Cleanup(func() { exit = orig })
 
+			var got pipeline.SpecFilter
 			stderr := captureStderr(t, func() {
-				requireSelector(tt.release, tt.latest, tt.spec, tt.series)
+				got = specFilterFromFlags(tt.release, tt.maxRelease, tt.latest, tt.spec, tt.series)
 			})
 
 			if tt.wantExit {
 				if exitCode != 1 {
 					t.Errorf("exit code = %d, want 1", exitCode)
 				}
-				if !strings.Contains(stderr, "Specify --release, --latest, --series, or --spec") {
-					t.Errorf("stderr = %q, want selector message", stderr)
+				if !strings.Contains(stderr, tt.wantErr) {
+					t.Errorf("stderr = %q, want %q", stderr, tt.wantErr)
 				}
-			} else if exitCode != -1 {
+				return
+			}
+			if exitCode != -1 {
 				t.Errorf("exit(%d) called, want no exit", exitCode)
+			}
+			if !reflect.DeepEqual(got, tt.wantFilter) {
+				t.Errorf("filter = %+v, want %+v", got, tt.wantFilter)
 			}
 		})
 	}
@@ -704,10 +720,8 @@ func TestResolveSpecs_FetchAllSeries(t *testing.T) {
 		specs := resolveSpecs(
 			context.Background(),
 			client,
-			"",    // specList
-			"",    // specFlag
-			"23",  // seriesFlag
-			0,     // release
+			"", // specList
+			pipeline.SpecFilter{Series: []string{"23"}},
 			false, // useCache
 			0,     // scrapeConcurrency
 		)
@@ -761,6 +775,42 @@ func TestCmdUpdate_AllUpToDate(t *testing.T) {
 	}
 }
 
+// TestCmdUpdate_MaxReleaseMovesDown covers applying a cap to a database built
+// without one: the target version is older than the stored version, so an
+// update that only ever moves forward would report nothing to do and silently
+// leave the database above the cap.
+func TestCmdUpdate_MaxReleaseMovesDown(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update.db")
+	seedUpdatableDB(t, dbPath) // 23.501 at v20.1.0
+
+	ts := specArchive(t, "23501-j60.zip")
+	origClient := newHTTPClient
+	newHTTPClient = func(timeout time.Duration) *http.Client {
+		return &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+	}
+	t.Cleanup(func() { newHTTPClient = origClient })
+
+	out := captureStdout(t, func() {
+		cmdUpdate([]string{"-db", dbPath, "-max-release", "19", "-no-cache", "-workers", "1", "-timeout", "5s"})
+	})
+	if !strings.Contains(out, "23.501: 20.1.0 -> 19.6.0") {
+		t.Errorf("output = %q, want 23.501 moved down to the capped version", out)
+	}
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	result, err := d.ListSpecs(context.Background(), "", "", -1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Specs) != 1 || result.Specs[0].Version != "19.6.0" {
+		t.Errorf("specs after update = %+v, want a single spec at 19.6.0", result.Specs)
+	}
+}
+
 // partialArchive serves a mock archive where 23.501 lists one zip and 23.502
 // fails, so a full scrape assembles a partial spec list.
 func partialArchive(t *testing.T, healthyZip string) *httptest.Server {
@@ -811,7 +861,7 @@ func TestResolveSpecs_PartialSpecListAborts(t *testing.T) {
 
 	logged := captureLog(t, func() {
 		_ = captureStdout(t, func() {
-			specs := resolveSpecs(context.Background(), client, "", "", "23", 0, false, 0)
+			specs := resolveSpecs(context.Background(), client, "", pipeline.SpecFilter{Series: []string{"23"}}, false, 0)
 			if specs != nil {
 				t.Errorf("expected nil specs after an abort, got %d", len(specs))
 			}

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -407,19 +407,39 @@ func LoadSpecList(path string) ([]string, error) {
 	return entries, scanner.Err()
 }
 
+// SpecFilter selects which archive entries a build or download processes.
+// The zero value selects everything.
+type SpecFilter struct {
+	// Release keeps only that release; 0 keeps every release.
+	Release int
+	// MaxRelease keeps releases at or below it; 0 leaves the selection
+	// uncapped. Unlike Release it does not drop a spec that has no version in
+	// the named release — combined with LatestOnly the spec falls back to its
+	// newest version below the cap.
+	MaxRelease int
+	Series     []string
+	SpecID     string
+	// LatestOnly keeps a single version per spec: the newest one that passed
+	// the filters above.
+	LatestOnly bool
+}
+
 // FilterSpecs filters specs by release/series/spec_id and optionally keeps only the latest version.
-func FilterSpecs(specs []*SpecVersion, release int, series []string, specID string, latestOnly bool) []*SpecVersion {
+func FilterSpecs(specs []*SpecVersion, f SpecFilter) []*SpecVersion {
 	var filtered []*SpecVersion
 
 	for _, s := range specs {
-		if release > 0 && s.Release != release {
+		if f.Release > 0 && s.Release != f.Release {
 			continue
 		}
-		if len(series) > 0 && !contains(series, s.Series) {
+		if f.MaxRelease > 0 && s.Release > f.MaxRelease {
 			continue
 		}
-		if specID != "" {
-			normalized := strings.ReplaceAll(specID, ".", "")
+		if len(f.Series) > 0 && !contains(f.Series, s.Series) {
+			continue
+		}
+		if f.SpecID != "" {
+			normalized := strings.ReplaceAll(f.SpecID, ".", "")
 			if strings.ReplaceAll(s.SpecID, ".", "") != normalized {
 				continue
 			}
@@ -427,7 +447,7 @@ func FilterSpecs(specs []*SpecVersion, release int, series []string, specID stri
 		filtered = append(filtered, s)
 	}
 
-	if latestOnly {
+	if f.LatestOnly {
 		best := make(map[string]*SpecVersion)
 		for _, s := range filtered {
 			key := s.SpecID

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -97,28 +97,28 @@ func TestFilterSpecs(t *testing.T) {
 	}
 
 	t.Run("filter by release", func(t *testing.T) {
-		got := FilterSpecs(specs, 19, nil, "", false)
+		got := FilterSpecs(specs, SpecFilter{Release: 19})
 		if len(got) != 2 {
 			t.Fatalf("expected 2, got %d", len(got))
 		}
 	})
 
 	t.Run("filter by series", func(t *testing.T) {
-		got := FilterSpecs(specs, 0, []string{"29"}, "", false)
+		got := FilterSpecs(specs, SpecFilter{Series: []string{"29"}})
 		if len(got) != 2 {
 			t.Fatalf("expected 2, got %d", len(got))
 		}
 	})
 
 	t.Run("filter by spec ID", func(t *testing.T) {
-		got := FilterSpecs(specs, 0, nil, "23.501", false)
+		got := FilterSpecs(specs, SpecFilter{SpecID: "23.501"})
 		if len(got) != 2 {
 			t.Fatalf("expected 2, got %d", len(got))
 		}
 	})
 
 	t.Run("latest only", func(t *testing.T) {
-		got := FilterSpecs(specs, 0, nil, "", true)
+		got := FilterSpecs(specs, SpecFilter{LatestOnly: true})
 		if len(got) != 2 {
 			t.Fatalf("expected 2 (one per spec), got %d", len(got))
 		}
@@ -129,15 +129,74 @@ func TestFilterSpecs(t *testing.T) {
 		}
 	})
 
+	t.Run("max release caps the latest version", func(t *testing.T) {
+		got := FilterSpecs(specs, SpecFilter{MaxRelease: 19, LatestOnly: true})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 (one per spec), got %d", len(got))
+		}
+		for _, s := range got {
+			if s.Release != 19 {
+				t.Errorf("expected release 19 for %s, got %d", s.SpecID, s.Release)
+			}
+		}
+	})
+
+	// The difference from Release: a spec with no version in the capped
+	// release stays in the selection at its newest older version, instead of
+	// dropping out of the build entirely.
+	t.Run("max release keeps specs older than the cap", func(t *testing.T) {
+		withOldSpec := append([]*SpecVersion{
+			{Series: "34", SpecID: "34.108", Release: 18, VersionMinor: 40, VersionLetter: "i"},
+		}, specs...)
+
+		got := FilterSpecs(withOldSpec, SpecFilter{MaxRelease: 19, LatestOnly: true})
+		if len(got) != 3 {
+			t.Fatalf("expected 3 (one per spec), got %d", len(got))
+		}
+		var found *SpecVersion
+		for _, s := range got {
+			if s.SpecID == "34.108" {
+				found = s
+			}
+		}
+		if found == nil {
+			t.Fatal("34.108 dropped by the cap; expected its release 18 version")
+		}
+		if found.Release != 18 {
+			t.Errorf("expected release 18 for 34.108, got %d", found.Release)
+		}
+
+		// Same input, exact-release filter: 34.108 has no release 19 version.
+		exact := FilterSpecs(withOldSpec, SpecFilter{Release: 19, LatestOnly: true})
+		if len(exact) != 2 {
+			t.Fatalf("expected 2 with Release: 19, got %d", len(exact))
+		}
+	})
+
+	t.Run("max release below every version", func(t *testing.T) {
+		got := FilterSpecs(specs, SpecFilter{MaxRelease: 18, LatestOnly: true})
+		if len(got) != 0 {
+			t.Fatalf("expected 0, got %d", len(got))
+		}
+	})
+
+	// The CLI rejects the combination, but as a filter the two are ANDed.
+	t.Run("release and max release combined", func(t *testing.T) {
+		got := FilterSpecs(specs, SpecFilter{Release: 20, MaxRelease: 19})
+		if len(got) != 0 {
+			t.Fatalf("expected 0, got %d", len(got))
+		}
+	})
+
 	t.Run("no match", func(t *testing.T) {
-		got := FilterSpecs(specs, 99, nil, "", false)
+		got := FilterSpecs(specs, SpecFilter{Release: 99})
 		if len(got) != 0 {
 			t.Fatalf("expected 0, got %d", len(got))
 		}
 	})
 
 	t.Run("nil input", func(t *testing.T) {
-		got := FilterSpecs(nil, 0, nil, "", false)
+		got := FilterSpecs(nil, SpecFilter{})
 		if len(got) != 0 {
 			t.Fatalf("expected 0, got %d", len(got))
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -393,6 +393,32 @@ func (d *DB) UpsertSpec(spec Spec) error {
 	return err
 }
 
+// DeleteSpec removes a specification and everything keyed to it: its sections
+// (the FTS index follows through the sections triggers), images, OpenAPI
+// definitions and outgoing references. References that merely *target* the spec
+// are left alone — they are part of the referencing spec's text, not of this
+// one.
+func (d *DB) DeleteSpec(id string) error {
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
+	for _, q := range []string{
+		"DELETE FROM sections WHERE spec_id = ?",
+		"DELETE FROM images WHERE spec_id = ?",
+		"DELETE FROM openapi_specs WHERE spec_id = ?",
+		"DELETE FROM spec_references WHERE source_spec_id = ?",
+		"DELETE FROM specs WHERE id = ?",
+	} {
+		if _, err = tx.Exec(q, id); err != nil {
+			return fmt.Errorf("delete spec %s: %w", id, err)
+		}
+	}
+	return tx.Commit()
+}
+
 // UpsertSection deletes then re-inserts a section to trigger FTS update.
 func (d *DB) UpsertSection(section Section) error {
 	tx, err := d.conn.Begin()

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1814,6 +1814,78 @@ func TestUpsertSpec_Replaces(t *testing.T) {
 	}
 }
 
+// TestDeleteSpec verifies a removed spec takes its sections, search index
+// entries, OpenAPI definitions and outgoing references with it, while
+// references that merely target it stay with the spec that made them.
+func TestDeleteSpec(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Seed data has TS 24.229 referencing TS 33.203, so deleting the target
+	// must not touch the referencing spec's rows.
+	if err := d.DeleteSpec("TS 29.510"); err != nil {
+		t.Fatalf("DeleteSpec: %v", err)
+	}
+
+	result, err := d.ListSpecs(t.Context(), "", "", -1, 0)
+	if err != nil {
+		t.Fatalf("ListSpecs: %v", err)
+	}
+	for _, s := range result.Specs {
+		if s.ID == "TS 29.510" {
+			t.Errorf("TS 29.510 still listed after delete")
+		}
+	}
+
+	sections, err := d.AllSections(t.Context(), "TS 29.510", "18.5.0")
+	if err != nil {
+		t.Fatalf("AllSections: %v", err)
+	}
+	if len(sections) != 0 {
+		t.Errorf("sections after delete = %d, want 0", len(sections))
+	}
+
+	// The FTS index is external-content, so it only stays in step through the
+	// sections triggers.
+	hits, err := d.Search(t.Context(), "NRF services", nil, 10, 0)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	for _, r := range hits.Results {
+		if r.SpecID == "TS 29.510" {
+			t.Errorf("deleted spec still in the search index: %+v", r)
+		}
+	}
+
+	apis, err := d.ListOpenAPI(t.Context(), "TS 29.510")
+	if err != nil {
+		t.Fatalf("ListOpenAPI: %v", err)
+	}
+	if len(apis) != 0 {
+		t.Errorf("openapi definitions after delete = %d, want 0", len(apis))
+	}
+
+	// TS 24.229's outgoing references survive: it was not the spec deleted.
+	refs, err := d.GetReferences(t.Context(), "TS 24.229", "18.4.0", "5.1", "outgoing", false)
+	if err != nil {
+		t.Fatalf("GetReferences: %v", err)
+	}
+	if len(refs) == 0 {
+		t.Error("deleting one spec dropped another spec's references")
+	}
+
+	// ...and go when that spec is the one deleted.
+	if err := d.DeleteSpec("TS 24.229"); err != nil {
+		t.Fatalf("DeleteSpec: %v", err)
+	}
+	refs, err = d.GetReferences(t.Context(), "TS 24.229", "18.4.0", "5.1", "outgoing", false)
+	if err != nil {
+		t.Fatalf("GetReferences: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("outgoing references after delete = %d, want 0", len(refs))
+	}
+}
+
 // TestUpsertSection_ReplacesContent verifies UpsertSection deletes and
 // re-inserts a section, and that the FTS index is updated accordingly.
 func TestUpsertSection_ReplacesContent(t *testing.T) {


### PR DESCRIPTION
## Problem

Version selection had only two modes, with nothing in between:

- `--latest` takes the newest version of every spec across all releases.
- `--release 19` is an exact-match filter, so a spec that has no Release-19
  version (TS 34.108, for example) drops out of the database entirely.

There was no way to say "build everything as of Release 19" — pin the newest
release without losing specs frozen in an earlier one.

## Change

`--max-release N` caps the selection: every spec is taken at its newest version
at or below release N. Available on `build`, `download` and `update`; exclusive
with `--release`.

Selection compared on real archive entries:

| Selector | 23.501 (k10/j60/i80) | 34.108 (i20 only) | New spec (k00 only) |
|---|---|---|---|
| `--latest` | k10 (Rel-20) | i20 | k00 |
| `--max-release 19` | **j60 (Rel-19)** | **i20 (kept at Rel-18)** | dropped |
| `--release 19` | j60 | **dropped** | dropped |

Implementation notes:

- `FilterSpecs` now takes a `SpecFilter` struct instead of five positional
  arguments — two adjacent `int` release parameters would have been easy to
  swap. The release number is already `SpecVersion.Release` (base-36 value of
  the archive token's first character), so the filter itself is one comparison.
- `update` takes the cap too, and with a cap it moves a spec in **either**
  direction. The cap is not stored in the database, so the target version can be
  older than what is stored; without this, applying a cap to an existing
  database would report "All specs are up to date" and silently leave it above
  the cap. A spec whose every archive version is above the cap is removed
  outright (new `db.DeleteSpec`), but only when the listing actually carried it
  — one missing from a partial listing is still skipped rather than deleted.
- `MAX_RELEASE` is wired through the Makefile, Dockerfile and `cloudbuild.yaml`.
  The Cloud Build image tag became `rel${_RELEASE}${_MAX_RELEASE}` (default
  `rellatest` unchanged, capped builds tag `rellatest19`) so the scheduled
  uncapped build cannot overwrite and redeploy a capped image.

## Testing

- `TestFilterSpecs` covers the cap, the fallback to an older release that
  `--release` drops, and a cap below every available version.
- `TestSpecFilterFromFlags` covers the selector guard and the `--release` /
  `--max-release` exclusivity.
- `TestCmdUpdate_MaxReleaseMovesDown` builds a database at v20.1.0 and checks
  that `update --max-release 19` brings it down to v19.6.0.
- `TestCmdUpdate_MaxReleaseRemovesAboveCap` checks a Rel-20-only spec is removed
  while a spec absent from the listing survives; `TestDeleteSpec` checks the
  deletion clears sections, the FTS index, OpenAPI rows and outgoing references
  while keeping references that target the spec.
- `gofmt`, `go vet` and `go test -short ./...` pass locally; `golangci-lint`
  could not run in the dev environment (its binary is built against an older Go
  than this module targets), so CI is the first real lint check.