### PR TITLE
feat: add search_openapi with a dedicated OpenAPI FTS5 index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,19 @@ make web                  # HTTP server with web viewer at :8080
   entries are evicted LRU, and a version's text and images evict as one unit.
   Images are fetched lazily on the first `get_image`/`list_images` call.
   OpenAPI YAML and cross-references are prebuilt-only.
+- **OpenAPI search is a second FTS index.** `openapi_chunks` / `openapi_chunks_fts`
+  (`db.OpenAPIIndexSchema`) hold one row per schema and per operation, derived
+  from `openapi_specs` by `internal/openapiindex` and **rebuilt wholesale** —
+  never incrementally, because most `$ref`s cross into another file, so
+  importing one document changes the chunks of documents imported before it.
+  Every importing CLI command ends in `rebuildOpenAPIIndex`. The tokenizer is
+  plain `unicode61`, no porter: these rows are identifiers, not prose, and
+  `-`/`.`/`_` split so a partial name matches. A schema chunk expands `$ref`
+  exactly one level. Like the rest of the OpenAPI features it is prebuilt-only
+  and absent from `versionstore`. Databases built before this existed have no
+  index at all — `serve` opens read-only and cannot create it, so
+  `SearchOpenAPI` returns `db.ErrNoOpenAPIIndex` and the tool points at
+  `build-openapi-index`.
 - **Image references are format-independent**: `image://NAME?w=&h=` in body
   text, `<img src="image://...">` in table cells. `structdiff.NormalizeImageRefs`
   keeps conversion-pair extension changes (`.emf`/`.wmf`/`.pcz`/`.png`) from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,12 @@ make web                  # HTTP server with web viewer at :8080
   and absent from `versionstore`. Databases built before this existed have no
   index at all — `serve` opens read-only and cannot create it, so
   `SearchOpenAPI` returns `db.ErrNoOpenAPIIndex` and the tool points at
-  `build-openapi-index`.
+  `build-openapi-index`. **The index is never allowed to be stale**: a rebuild
+  that fails drops it (`DropOpenAPIIndex`) rather than leaving chunks that
+  describe the previous corpus, so the honest "missing" state is the only
+  failure mode. `update` keeps its working copy on such a failure — the spec
+  import costs hours, the index seconds — but only after confirming the drop
+  took.
 - **Image references are format-independent**: `image://NAME?w=&h=` in body
   text, `<img src="image://...">` in table cells. `structdiff.NormalizeImageRefs`
   keeps conversion-pair extension changes (`.emf`/`.wmf`/`.pcz`/`.png`) from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,14 @@ make web                  # HTTP server with web viewer at :8080
   from `openapi_specs` by `internal/openapiindex` and **rebuilt wholesale** —
   never incrementally, because most `$ref`s cross into another file, so
   importing one document changes the chunks of documents imported before it.
-  Every importing CLI command ends in `rebuildOpenAPIIndex`. The tokenizer is
+  `build` and `update` end in `rebuildOpenAPIIndex`; `import` and `import-dir`
+  deliberately do not, because the YAML arrives in the archive zip and a
+  `.docx` import cannot touch `openapi_specs`. The tokenizer is
   plain `unicode61`, no porter: these rows are identifiers, not prose, and
   `-`/`.`/`_` split so a partial name matches. A schema chunk expands `$ref`
-  exactly one level. Like the rest of the OpenAPI features it is prebuilt-only
+  one level, through `items` and `additionalProperties` as well as directly —
+  that is how the 5G SBI definitions state most of their relationships. Like
+  the rest of the OpenAPI features it is prebuilt-only
   and absent from `versionstore`. Databases built before this existed have no
   index at all — `serve` opens read-only and cannot create it, so
   `SearchOpenAPI` returns `db.ErrNoOpenAPIIndex` and the tool points at

--- a/README.md
+++ b/README.md
@@ -314,6 +314,28 @@ and `offset` pages past the cap.
 |------|-------------|----------------|
 | `list_openapi` | List available OpenAPI definitions | `spec_id` (optional): filter by spec, e.g. `"TS 29.510"` |
 | `get_openapi` | Get OpenAPI definition (paginated) | `spec_id`, `api_name` (required), `path`, `schema`, `offset`, `max_lines` |
+| `search_openapi` | Full-text search across OpenAPI definitions | `query` (required), `spec_ids`, `api_name`, `kind` (`"schema"` or `"operation"`), `include_body`, `limit`, `offset` |
+
+`search_openapi` uses its own FTS5 index, separate from the one `search` uses:
+`search` covers specification clause text and never returns OpenAPI content,
+`search_openapi` covers OpenAPI content only. One hit is one definition rather
+than one document — a schema from `components.schemas`, or one HTTP method of
+one path (named like `PUT /nf-instances/{nfInstanceID}`) — so you can find a
+data type or an endpoint without knowing which API document defines it, then
+read it in full with `get_openapi`. A query that is a single bare term ranks a
+definition of exactly that name first, so `NFProfile` returns the `NFProfile`
+schema ahead of the schemas that only reference it.
+
+A schema's indexed text carries one level of `$ref` expansion, which makes the
+fields of a referenced type searchable from the schema that uses it; a type two
+hops away is not in that text. Unlike `search`, this index applies no stemming
+— identifiers are matched as written — and `-`, `.` and `_` split tokens, so
+`Nnrf_NFManagement` is also found by `NFManagement` and `/nf-instances` by
+`instances`. camelCase is not split.
+
+The index is built at the end of `build`, `import`, `import-dir` and `update`.
+A database built before this tool existed has no index; add it in place with
+[`build-openapi-index`](#build-openapi-index).
 
 ### Embedded images
 
@@ -678,6 +700,34 @@ Usage: `3gpp-mcp get-openapi [flags] <spec-id> <api-name>`
 |------|-------------|---------|
 | `--path` | Filter by API path (e.g. `/nf-instances`) | |
 | `--schema` | Filter by schema name (e.g. `NFProfile`) | |
+
+### `search-openapi`
+
+Full-text search across OpenAPI definitions; results print as JSON. One hit is
+one schema or one operation. As with `search`, everything after the flags is
+joined into one query: `3gpp-mcp search-openapi NFProfile AND heartbeat`.
+
+Usage: `3gpp-mcp search-openapi [flags] <query>`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--specs` | Limit search to specific specs, comma-separated (e.g. `"TS 29.510,TS 29.518"`) | |
+| `--api` | Limit search to a single API document (e.g. `Nnrf_NFManagement`) | |
+| `--kind` | Limit search to `schema` or `operation` | both |
+| `--body` | Include the full text of each matching definition | `false` |
+| `--limit` | Maximum number of results per page (max 200) | `10` |
+| `--offset` | Number of results to skip | `0` |
+
+### `build-openapi-index`
+
+Rebuild the OpenAPI search index of an existing database. `build`, `import`,
+`import-dir` and `update` all do this themselves, so this command is for
+adding the index to a database built before `search_openapi` existed — the
+server opens the database read-only and cannot create it on the fly.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--db` | SQLite database path | `3gpp.db` |
 
 ### `get-references`
 

--- a/README.md
+++ b/README.md
@@ -326,15 +326,19 @@ read it in full with `get_openapi`. A query that is a single bare term ranks a
 definition of exactly that name first, so `NFProfile` returns the `NFProfile`
 schema ahead of the schemas that only reference it.
 
-A schema's indexed text carries one level of `$ref` expansion, which makes the
-fields of a referenced type searchable from the schema that uses it; a type two
-hops away is not in that text. Unlike `search`, this index applies no stemming
+A schema's indexed text carries one level of `$ref` expansion — through `items`
+and `additionalProperties` as well as directly, which is how the 5G SBI
+definitions state most of their relationships — so the fields of a referenced
+type are searchable from the schema that uses it; a type two hops away is not
+in that text. Unlike `search`, this index applies no stemming
 — identifiers are matched as written — and `-`, `.` and `_` split tokens, so
 `Nnrf_NFManagement` is also found by `NFManagement` and `/nf-instances` by
 `instances`. camelCase is not split.
 
-The index is built at the end of `build`, `import`, `import-dir` and `update`.
-A database built before this tool existed has no index; add it in place with
+The index is built at the end of `build` and `update`. `import` and `import-dir`
+leave it alone: the YAML files ship in the archive zip, so importing a `.docx`
+cannot change what there is to index. A database built before this tool existed
+has no index; add it in place with
 [`build-openapi-index`](#build-openapi-index).
 
 ### Embedded images
@@ -720,10 +724,10 @@ Usage: `3gpp-mcp search-openapi [flags] <query>`
 
 ### `build-openapi-index`
 
-Rebuild the OpenAPI search index of an existing database. `build`, `import`,
-`import-dir` and `update` all do this themselves, so this command is for
-adding the index to a database built before `search_openapi` existed — the
-server opens the database read-only and cannot create it on the fly.
+Rebuild the OpenAPI search index of an existing database. `build` and `update`
+do this themselves, so this command is for adding the index to a database built
+before `search_openapi` existed — the server opens the database read-only and
+cannot create it on the fly.
 
 | Flag | Description | Default |
 |------|-------------|---------|

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/openapiindex"
 	"github.com/higebu/3gpp-mcp/internal/specver"
 	"github.com/higebu/3gpp-mcp/tools"
 	"github.com/higebu/3gpp-mcp/versionstore"
@@ -109,6 +110,7 @@ func init() {
 		{name: "import", aliases: []string{"convert"}, desc: "Import a single DOCX file into database", run: cmdConvert},
 		{name: "import-dir", aliases: []string{"convert-dir"}, desc: "Import a directory of DOCX files into database", run: cmdConvertDir},
 		{name: "update", desc: "Update database to latest spec versions", run: cmdUpdate},
+		{name: "build-openapi-index", desc: "Rebuild the OpenAPI search index", run: cmdBuildOpenAPIIndex},
 		{name: "list-specs", desc: "List specifications in the database", run: cmdListSpecs},
 		{name: "list-versions", desc: "List versions of a specification", run: cmdListVersions},
 		{name: "get-toc", desc: "Print a specification's table of contents", run: cmdGetTOC},
@@ -117,6 +119,7 @@ func init() {
 		{name: "search", desc: "Full-text search across specifications", run: cmdSearch},
 		{name: "list-openapi", desc: "List OpenAPI definitions", run: cmdListOpenAPI},
 		{name: "get-openapi", desc: "Print an OpenAPI definition", run: cmdGetOpenAPI},
+		{name: "search-openapi", desc: "Full-text search across OpenAPI definitions", run: cmdSearchOpenAPI},
 		{name: "get-references", desc: "Print cross-references as JSON", run: cmdGetReferences},
 		{name: "list-images", desc: "List embedded images in a specification", run: cmdListImages},
 		{name: "get-image", desc: "Write an embedded image to a file or stdout", run: cmdGetImage},
@@ -195,7 +198,7 @@ func newMCPServer(d *db.DB, src *tools.Source) *mcp.Server {
 		Name:    "3gpp-mcp",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions.\n\n" +
+		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions, and search_openapi when you know the data type or endpoint but not which API document defines it. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions.\n\n" +
 			"Notation: section text is Markdown. Figures are `![...](image://NAME)` links. Formulas are LaTeX — a standalone equation is a ```latex code block whose equation number is kept as `\\tag{7.3-1}`, and a formula inside a sentence or a table cell is delimited with `$...$` or `$$...$$`.\n\n" +
 			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then use compare_versions: without section_number it summarizes which sections were added, removed or changed between two versions, and with section_number it returns a line-level diff of that section's text. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. get_image and list_images also accept a version: an archived version's images are downloaded on their own first use, again taking up to a few minutes before a retry succeeds. search and get_references only have data for the version in the database.",
 	})
@@ -208,6 +211,7 @@ func newMCPServer(d *db.DB, src *tools.Source) *mcp.Server {
 	mcp.AddTool(s, tools.SearchTool, tools.HandleSearch(d))
 	mcp.AddTool(s, tools.ListOpenAPITool, tools.HandleListOpenAPI(d))
 	mcp.AddTool(s, tools.GetOpenAPITool, tools.HandleGetOpenAPI(d))
+	mcp.AddTool(s, tools.SearchOpenAPITool, tools.HandleSearchOpenAPI(d))
 	mcp.AddTool(s, tools.GetReferencesTool, tools.HandleGetReferences(d))
 	mcp.AddTool(s, tools.ListImagesTool, tools.HandleListImages(src))
 	mcp.AddTool(s, tools.GetImageTool, tools.HandleGetImage(src))
@@ -404,6 +408,9 @@ func runConvert(ctx context.Context, dbPath, docxPath string, convertImage bool)
 	if err := pipeline.ConvertSingleFile(ctx, d, docxPath, convertImage); err != nil {
 		return err
 	}
+	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
+		return err
+	}
 	fmt.Printf("Written to %s\n", dbPath)
 	return nil
 }
@@ -453,7 +460,7 @@ func runConvertDir(ctx context.Context, dbPath, dirPath string, workers int, con
 	if err := pipeline.ConvertDir(ctx, d, dirPath, workers, convertDoc, convertImage); err != nil {
 		return fmt.Errorf("import %s: %w", dirPath, err)
 	}
-	return nil
+	return rebuildOpenAPIIndex(ctx, d)
 }
 
 // exit is swapped in tests to cover fatal error paths without terminating
@@ -645,7 +652,60 @@ func runPipeline(ctx context.Context, dbPath string, client *http.Client, specs 
 	// Run's errors are self-describing ("all N specs failed", ctx.Err()), and
 	// cmdPipeline prefixes "Pipeline failed:" — wrapping here would only
 	// repeat that context.
-	return p.Run(ctx, specs)
+	if err := p.Run(ctx, specs); err != nil {
+		return err
+	}
+
+	return rebuildOpenAPIIndex(ctx, d)
+}
+
+// rebuildOpenAPIIndex refreshes the search_openapi index and reports what it
+// wrote. Every command that imports into a database ends with this: an
+// OpenAPI $ref usually points into another document, so a chunk cannot be
+// rendered until the whole table is in place, and importing one document can
+// change the chunks of documents imported long before it.
+func rebuildOpenAPIIndex(ctx context.Context, d *db.DB) error {
+	stats, err := openapiindex.Build(ctx, d)
+	if err != nil {
+		return fmt.Errorf("build openapi index: %w", err)
+	}
+	if stats.Unparsable > 0 {
+		log.Printf("warning: %d OpenAPI documents could not be parsed and are not searchable", stats.Unparsable)
+	}
+	fmt.Printf("OpenAPI index: %s\n", stats)
+	return nil
+}
+
+func cmdBuildOpenAPIIndex(args []string) {
+	fs := flag.NewFlagSet("build-openapi-index", flag.ExitOnError)
+	dbPath := fs.String("db", "3gpp.db", "SQLite database path")
+	_ = fs.Parse(args)
+	requireArgs(fs, 0, "3gpp-mcp build-openapi-index [options]")
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	if err := runBuildOpenAPIIndex(ctx, *dbPath); err != nil {
+		log.Printf("Build openapi index failed: %v", err)
+		exit(1)
+	}
+}
+
+// runBuildOpenAPIIndex rebuilds the index in an existing database. It is the
+// way to add the index to a database built before search_openapi existed:
+// serve opens read-only and so cannot create the tables itself.
+func runBuildOpenAPIIndex(ctx context.Context, dbPath string) error {
+	d, err := db.OpenReadWrite(dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer d.Close()
+
+	if err := d.InitSchema(); err != nil {
+		return fmt.Errorf("init schema: %w", err)
+	}
+
+	return rebuildOpenAPIIndex(ctx, d)
 }
 
 func cmdCompletion(args []string) {
@@ -991,6 +1051,15 @@ func cmdUpdate(args []string) {
 			discardWorkingCopy(newPath)
 			log.Fatalf("Update failed: %v", err)
 		}
+	}
+
+	// The working copy carries the old index, and a removed or re-imported
+	// spec can invalidate chunks anywhere in it, so rebuild before the copy
+	// becomes the live database.
+	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
+		_ = d.Close()
+		discardWorkingCopy(newPath)
+		log.Fatalf("Update failed: %v", err)
 	}
 
 	// Checkpoint WAL into the main file so the renamed DB is self-contained.

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -405,10 +405,10 @@ func runConvert(ctx context.Context, dbPath, docxPath string, convertImage bool)
 	// ConvertSingleFile's errors already name the stage and the file
 	// ("parse %s: ..."), and cmdConvert prefixes "Convert failed:" — wrapping
 	// here again would only repeat that context.
+	// No OpenAPI rebuild here: the YAML files live in the archive zip, not in
+	// a .docx, so importing documents never changes openapi_specs and a
+	// rebuild could only rewrite every chunk to what it already was.
 	if err := pipeline.ConvertSingleFile(ctx, d, docxPath, convertImage); err != nil {
-		return err
-	}
-	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
 		return err
 	}
 	fmt.Printf("Written to %s\n", dbPath)
@@ -457,10 +457,12 @@ func runConvertDir(ctx context.Context, dbPath, dirPath string, workers int, con
 
 	// ConvertDir's errors do not all carry the directory (e.g. "all N files
 	// failed to parse"), so name it here.
+	// As in runConvert, a .docx import cannot change openapi_specs, so there
+	// is nothing for an OpenAPI rebuild to do.
 	if err := pipeline.ConvertDir(ctx, d, dirPath, workers, convertDoc, convertImage); err != nil {
 		return fmt.Errorf("import %s: %w", dirPath, err)
 	}
-	return rebuildOpenAPIIndex(ctx, d)
+	return nil
 }
 
 // exit is swapped in tests to cover fatal error paths without terminating
@@ -660,17 +662,15 @@ func runPipeline(ctx context.Context, dbPath string, client *http.Client, specs 
 }
 
 // rebuildOpenAPIIndex refreshes the search_openapi index and reports what it
-// wrote. Every command that imports into a database ends with this: an
-// OpenAPI $ref usually points into another document, so a chunk cannot be
-// rendered until the whole table is in place, and importing one document can
-// change the chunks of documents imported long before it.
+// wrote. Every command that writes openapi_specs ends with this: an OpenAPI
+// $ref usually points into another document, so a chunk cannot be rendered
+// until the whole table is in place, and importing one document can change the
+// chunks of documents imported long before it. Build names each unparsable
+// document as it goes.
 func rebuildOpenAPIIndex(ctx context.Context, d *db.DB) error {
 	stats, err := openapiindex.Build(ctx, d)
 	if err != nil {
 		return fmt.Errorf("build openapi index: %w", err)
-	}
-	if stats.Unparsable > 0 {
-		log.Printf("warning: %d OpenAPI documents could not be parsed and are not searchable", stats.Unparsable)
 	}
 	fmt.Printf("OpenAPI index: %s\n", stats)
 	return nil
@@ -1056,10 +1056,14 @@ func cmdUpdate(args []string) {
 	// The working copy carries the old index, and a removed or re-imported
 	// spec can invalidate chunks anywhere in it, so rebuild before the copy
 	// becomes the live database.
+	//
+	// A failure here is not worth throwing the update away over: the chunks
+	// are derived data, ReplaceOpenAPIChunks is transactional so the previous
+	// index survives intact, and build-openapi-index regenerates it in
+	// seconds. Discarding the working copy would instead cost the whole spec
+	// import that just ran, which takes hours to redo.
 	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
-		_ = d.Close()
-		discardWorkingCopy(newPath)
-		log.Fatalf("Update failed: %v", err)
+		log.Printf("warning: %v; the database keeps its previous OpenAPI index — run '3gpp-mcp build-openapi-index --db %s' to refresh it", err, *dbPath)
 	}
 
 	// Checkpoint WAL into the main file so the renamed DB is self-contained.

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -658,7 +658,7 @@ func runPipeline(ctx context.Context, dbPath string, client *http.Client, specs 
 		return err
 	}
 
-	return rebuildOpenAPIIndex(ctx, d)
+	return refreshOpenAPIIndexAfterImport(ctx, d)
 }
 
 // rebuildOpenAPIIndex refreshes the search_openapi index and reports what it
@@ -667,22 +667,36 @@ func runPipeline(ctx context.Context, dbPath string, client *http.Client, specs 
 // until the whole table is in place, and importing one document can change the
 // chunks of documents imported long before it. Build names each unparsable
 // document as it goes.
+// A failure leaves any existing index in place. ReplaceOpenAPIChunks is a
+// single transaction, so a rebuild that does not finish changes nothing, and
+// on its own that leaves the index describing exactly the openapi_specs it was
+// built from — still correct. Callers that have just rewritten openapi_specs
+// need refreshOpenAPIIndexAfterImport instead.
 func rebuildOpenAPIIndex(ctx context.Context, d *db.DB) error {
 	stats, err := openapiindex.Build(ctx, d)
 	if err != nil {
-		// A half-done rebuild must not be left behind as a working index. The
-		// chunks still in the database describe the corpus as it was before
-		// this run, so search_openapi would answer with definitions that no
-		// longer exist — wrong in a way no caller can detect. Dropping the
-		// index puts the database in the state serve already handles: the tool
-		// reports it as missing and names build-openapi-index.
-		if dropErr := d.DropOpenAPIIndex(); dropErr != nil {
-			return fmt.Errorf("build openapi index: %w (dropping the stale index also failed: %v)", err, dropErr)
-		}
-		return fmt.Errorf("build openapi index: %w; the stale index was dropped, so run 'build-openapi-index' before serving search_openapi", err)
+		return fmt.Errorf("build openapi index: %w", err)
 	}
 	fmt.Printf("OpenAPI index: %s\n", stats)
 	return nil
+}
+
+// refreshOpenAPIIndexAfterImport is rebuildOpenAPIIndex for a caller that has
+// already written openapi_specs. That is what makes a failure different here:
+// the surviving index describes the corpus as it was before the import, so
+// leaving it would have search_openapi answer with definitions that no longer
+// exist — wrong in a way no caller can detect. Dropping it puts the database
+// in the state serve already handles, where the tool reports the index as
+// missing and names build-openapi-index.
+func refreshOpenAPIIndexAfterImport(ctx context.Context, d *db.DB) error {
+	err := rebuildOpenAPIIndex(ctx, d)
+	if err == nil {
+		return nil
+	}
+	if dropErr := d.DropOpenAPIIndex(); dropErr != nil {
+		return fmt.Errorf("%w (dropping the now-stale index also failed: %v)", err, dropErr)
+	}
+	return fmt.Errorf("%w; the now-stale index was dropped, so run 'build-openapi-index' before serving search_openapi", err)
 }
 
 func cmdBuildOpenAPIIndex(args []string) {
@@ -1070,12 +1084,17 @@ func cmdUpdate(args []string) {
 	// are derived data that build-openapi-index regenerates in seconds, while
 	// discarding the working copy costs the whole spec import that just ran —
 	// but the database must not go live carrying an index that disagrees with
-	// its openapi_specs. rebuildOpenAPIIndex drops the stale index on failure
-	// for exactly that reason, so the update is only kept once the database is
-	// honestly index-less; if the drop did not take, correctness wins over the
-	// import and the working copy goes.
-	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
-		stale, checkErr := d.HasOpenAPIIndex(ctx)
+	// its openapi_specs. refreshOpenAPIIndexAfterImport drops the stale index
+	// on failure for exactly that reason, so the update is only kept once the
+	// database is honestly index-less; if the drop did not take, correctness
+	// wins over the import and the working copy goes.
+	//
+	// The check runs on a context stripped of cancellation: the most likely
+	// way to get here is a Ctrl-C during the rebuild, and reusing the
+	// cancelled ctx would fail the check for that same reason and discard an
+	// import that is otherwise complete and correct.
+	if err := refreshOpenAPIIndexAfterImport(ctx, d); err != nil {
+		stale, checkErr := d.HasOpenAPIIndex(context.WithoutCancel(ctx))
 		if checkErr != nil || stale {
 			_ = d.Close()
 			discardWorkingCopy(newPath)

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -670,7 +670,16 @@ func runPipeline(ctx context.Context, dbPath string, client *http.Client, specs 
 func rebuildOpenAPIIndex(ctx context.Context, d *db.DB) error {
 	stats, err := openapiindex.Build(ctx, d)
 	if err != nil {
-		return fmt.Errorf("build openapi index: %w", err)
+		// A half-done rebuild must not be left behind as a working index. The
+		// chunks still in the database describe the corpus as it was before
+		// this run, so search_openapi would answer with definitions that no
+		// longer exist — wrong in a way no caller can detect. Dropping the
+		// index puts the database in the state serve already handles: the tool
+		// reports it as missing and names build-openapi-index.
+		if dropErr := d.DropOpenAPIIndex(); dropErr != nil {
+			return fmt.Errorf("build openapi index: %w (dropping the stale index also failed: %v)", err, dropErr)
+		}
+		return fmt.Errorf("build openapi index: %w; the stale index was dropped, so run 'build-openapi-index' before serving search_openapi", err)
 	}
 	fmt.Printf("OpenAPI index: %s\n", stats)
 	return nil
@@ -1057,13 +1066,22 @@ func cmdUpdate(args []string) {
 	// spec can invalidate chunks anywhere in it, so rebuild before the copy
 	// becomes the live database.
 	//
-	// A failure here is not worth throwing the update away over: the chunks
-	// are derived data, ReplaceOpenAPIChunks is transactional so the previous
-	// index survives intact, and build-openapi-index regenerates it in
-	// seconds. Discarding the working copy would instead cost the whole spec
-	// import that just ran, which takes hours to redo.
+	// A failure here is not worth throwing the update away over — the chunks
+	// are derived data that build-openapi-index regenerates in seconds, while
+	// discarding the working copy costs the whole spec import that just ran —
+	// but the database must not go live carrying an index that disagrees with
+	// its openapi_specs. rebuildOpenAPIIndex drops the stale index on failure
+	// for exactly that reason, so the update is only kept once the database is
+	// honestly index-less; if the drop did not take, correctness wins over the
+	// import and the working copy goes.
 	if err := rebuildOpenAPIIndex(ctx, d); err != nil {
-		log.Printf("warning: %v; the database keeps its previous OpenAPI index — run '3gpp-mcp build-openapi-index --db %s' to refresh it", err, *dbPath)
+		stale, checkErr := d.HasOpenAPIIndex(ctx)
+		if checkErr != nil || stale {
+			_ = d.Close()
+			discardWorkingCopy(newPath)
+			log.Fatalf("Update failed: %v", err)
+		}
+		log.Printf("warning: %v; run '3gpp-mcp build-openapi-index --db %s'", err, *dbPath)
 	}
 
 	// Checkpoint WAL into the main file so the renamed DB is self-contained.

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1051,8 +1051,8 @@ func TestStreamableHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	if len(toolsRes.Tools) != 11 {
-		t.Errorf("got %d tools, want 11", len(toolsRes.Tools))
+	if len(toolsRes.Tools) != 12 {
+		t.Errorf("got %d tools, want 12", len(toolsRes.Tools))
 	}
 
 	res, err := session.CallTool(ctx, &mcp.CallToolParams{

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -594,6 +594,58 @@ func runGetOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID, apiName
 	return err
 }
 
+// search-openapi
+
+func cmdSearchOpenAPI(args []string) {
+	fs := flag.NewFlagSet("search-openapi", flag.ExitOnError)
+	qf := addQueryFlags(fs, false)
+	specs := fs.String("specs", "", "Limit search to specific specs, comma-separated (e.g. \"TS 29.510,TS 29.518\")")
+	api := fs.String("api", "", "Limit search to a single API document (e.g. Nnrf_NFManagement)")
+	kind := fs.String("kind", "", "Limit search to one kind of definition: schema or operation")
+	body := fs.Bool("body", false, "Include the full text of each matching definition")
+	limit := fs.Int("limit", 0, "Maximum number of results per page (default: 10, max: 200)")
+	offset := fs.Int("offset", 0, "Number of results to skip")
+	_ = fs.Parse(args)
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "Usage: 3gpp-mcp search-openapi [options] <query>")
+		fmt.Fprintln(os.Stderr, "Options must come before the query.")
+		os.Exit(1)
+	}
+
+	runQuery("search-openapi", func(ctx context.Context) error {
+		src, cleanup, err := qf.openSource(false)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		// Joining the remaining arguments lets multi-term FTS queries go
+		// unquoted, as in search.
+		return runSearchOpenAPI(ctx, os.Stdout, src.DB, strings.Join(fs.Args(), " "), *specs, *api, *kind, *body, *limit, *offset)
+	})
+}
+
+func runSearchOpenAPI(ctx context.Context, out io.Writer, d *db.DB, query, specs, api, kind string, includeBody bool, limit, offset int) error {
+	var specIDs []string
+	if specs != "" {
+		for _, s := range strings.Split(specs, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				specIDs = append(specIDs, s)
+			}
+		}
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	results, err := d.SearchOpenAPI(ctx, query, specIDs, api, kind, includeBody, limit, offset)
+	if err != nil {
+		if errors.Is(err, db.ErrNoOpenAPIIndex) {
+			return fmt.Errorf("%w; run '3gpp-mcp build-openapi-index' to add it", err)
+		}
+		return err
+	}
+	return printJSON(out, results)
+}
+
 // get-references
 
 func cmdGetReferences(args []string) {

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -351,31 +351,37 @@ func TestRunSearchOpenAPIWithoutIndex(t *testing.T) {
 	}
 }
 
-// TestRebuildOpenAPIIndexDropsStaleIndexOnFailure covers the guarantee update
-// relies on: a rebuild that cannot finish leaves no index at all, so
-// search_openapi reports it as missing instead of answering from the corpus as
-// it was before.
-func TestRebuildOpenAPIIndexDropsStaleIndexOnFailure(t *testing.T) {
+// cancelledContext is the most likely way a rebuild fails in practice: a
+// Ctrl-C partway through.
+func cancelledContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	return ctx
+}
+
+// TestRefreshOpenAPIIndexAfterImportDropsStaleIndex covers the guarantee update
+// relies on: after openapi_specs has been rewritten, a rebuild that cannot
+// finish leaves no index at all, so search_openapi reports it as missing
+// instead of answering from the corpus as it was before.
+func TestRefreshOpenAPIIndexAfterImportDropsStaleIndex(t *testing.T) {
 	path := seedDBPath(t)
 	d, err := db.OpenReadWrite(path)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	// Break the FTS side while the chunk rows stay: the triggers now write to
-	// a table that is not there, so the rebuild fails partway.
-	if err := d.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
-		t.Fatalf("break index: %v", err)
-	}
 
-	err = rebuildOpenAPIIndex(t.Context(), d)
+	err = refreshOpenAPIIndexAfterImport(cancelledContext(t), d)
 	if err == nil {
 		t.Fatal("expected the rebuild to fail")
 	}
 	if !strings.Contains(err.Error(), "build-openapi-index") {
 		t.Errorf("error should name the recovery: %v", err)
 	}
+	// The check has to run on a live context: update makes the same call, and
+	// reusing the cancelled one would report a failure of its own.
 	if ok, checkErr := d.HasOpenAPIIndex(t.Context()); checkErr != nil || ok {
-		t.Errorf("stale index survived a failed rebuild: %v, %v", ok, checkErr)
+		t.Errorf("stale index survived a failed refresh: %v, %v", ok, checkErr)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -389,6 +395,34 @@ func TestRebuildOpenAPIIndexDropsStaleIndexOnFailure(t *testing.T) {
 	})
 	if !strings.Contains(out, "OpenAPI index:") {
 		t.Errorf("unexpected output: %s", out)
+	}
+}
+
+// TestRebuildOpenAPIIndexKeepsIndexOnFailure is the other half: when nothing
+// has rewritten openapi_specs, a failed rebuild changes nothing and the index
+// still describes the corpus it was built from. Dropping it there would turn a
+// Ctrl-C on build-openapi-index into an outage for a running serve.
+func TestRebuildOpenAPIIndexKeepsIndexOnFailure(t *testing.T) {
+	path := seedDBPath(t)
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	if err := rebuildOpenAPIIndex(cancelledContext(t), d); err == nil {
+		t.Fatal("expected the rebuild to fail")
+	}
+
+	if ok, checkErr := d.HasOpenAPIIndex(t.Context()); checkErr != nil || !ok {
+		t.Fatalf("HasOpenAPIIndex = %v, %v; want true, nil", ok, checkErr)
+	}
+	got, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if len(got.Results) == 0 {
+		t.Error("a failed rebuild emptied an index that was still correct")
 	}
 }
 

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -426,6 +426,16 @@ func TestRebuildOpenAPIIndexKeepsIndexOnFailure(t *testing.T) {
 	}
 }
 
+// TestCmdBuildOpenAPIIndex drives the command through its flag parsing, the
+// way a shell invocation would.
+func TestCmdBuildOpenAPIIndex(t *testing.T) {
+	path := seedDBPath(t)
+	out := captureStdout(t, func() { cmdBuildOpenAPIIndex([]string{"-db", path}) })
+	if !strings.Contains(out, "OpenAPI index:") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
 func TestRunBuildOpenAPIIndex(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "old.db")
 	d, err := db.OpenReadWrite(path)

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/higebu/3gpp-mcp/converter/pipeline"
 	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/openapiindex"
 	"github.com/higebu/3gpp-mcp/internal/testutil"
 	"github.com/higebu/3gpp-mcp/tools"
 	"github.com/higebu/3gpp-mcp/versionstore"
@@ -294,6 +295,105 @@ func TestRunListOpenAPI(t *testing.T) {
 	}
 	if strings.TrimSpace(out.String()) != "[]" {
 		t.Errorf("expected [] for a spec without OpenAPI, got:\n%s", out.String())
+	}
+}
+
+func TestRunSearchOpenAPI(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	if _, err := openapiindex.Build(t.Context(), d); err != nil {
+		t.Fatalf("build openapi index: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runSearchOpenAPI(t.Context(), &out, d, "NFProfile", "", "", "", false, 0, 0); err != nil {
+		t.Fatalf("runSearchOpenAPI: %v", err)
+	}
+	var results db.OpenAPISearchResults
+	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if len(results.Results) == 0 || results.Results[0].Name != "NFProfile" {
+		t.Fatalf("unexpected results: %+v", results.Results)
+	}
+	if results.Results[0].Body != "" {
+		t.Errorf("body should be omitted without -body: %q", results.Results[0].Body)
+	}
+
+	out.Reset()
+	if err := runSearchOpenAPI(t.Context(), &out, d, "NFProfile", "TS 23.501, TS 29.510", "", "schema", true, 0, 0); err != nil {
+		t.Fatalf("runSearchOpenAPI filtered: %v", err)
+	}
+	if !strings.Contains(out.String(), "nfInstanceId") {
+		t.Errorf("-body should return the full chunk:\n%s", out.String())
+	}
+
+	out.Reset()
+	if err := runSearchOpenAPI(t.Context(), &out, d, "NFProfile", "TS 23.501", "", "", false, 0, 0); err != nil {
+		t.Fatalf("runSearchOpenAPI spec filter: %v", err)
+	}
+	if !strings.Contains(out.String(), `"total_count": 0`) {
+		t.Errorf("spec filter not applied:\n%s", out.String())
+	}
+}
+
+// TestRunSearchOpenAPIWithoutIndex covers a database built before
+// search_openapi existed: the CLI names the command that fixes it.
+func TestRunSearchOpenAPIWithoutIndex(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	if err := d.Exec("DROP TABLE openapi_chunks"); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+
+	var out bytes.Buffer
+	err := runSearchOpenAPI(t.Context(), &out, d, "NFProfile", "", "", "", false, 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "build-openapi-index") {
+		t.Fatalf("err = %v, want a build-openapi-index hint", err)
+	}
+}
+
+func TestRunBuildOpenAPIIndex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// A database with the spec tables but no index, as an older build left it.
+	if err := d.ExecScript(db.SpecTablesSchema + db.ImagesTableSchema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	if err := d.Exec(`CREATE TABLE openapi_specs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT, spec_id TEXT NOT NULL, api_name TEXT NOT NULL,
+		version TEXT, filename TEXT, content TEXT NOT NULL, UNIQUE(spec_id, api_name))`); err != nil {
+		t.Fatalf("openapi_specs: %v", err)
+	}
+	if err := d.UpsertOpenAPI("TS 29.510", "Nnrf_NFManagement", "v1.3.0", "TS29510_Nnrf_NFManagement.yaml",
+		"components:\n  schemas:\n    NFProfile:\n      type: object\n"); err != nil {
+		t.Fatalf("seed openapi: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runBuildOpenAPIIndex(t.Context(), path); err != nil {
+			t.Fatalf("runBuildOpenAPIIndex: %v", err)
+		}
+	})
+	if !strings.Contains(out, "OpenAPI index: 1 chunks") {
+		t.Errorf("unexpected output: %s", out)
+	}
+
+	reopened, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	results, err := reopened.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if len(results.Results) != 1 {
+		t.Errorf("index not usable after rebuild: %+v", results)
 	}
 }
 
@@ -575,6 +675,11 @@ func seedDBPath(t *testing.T) string {
 	if err := d.ExecScript(testutil.SeedData); err != nil {
 		t.Fatalf("seed data: %v", err)
 	}
+	// A real database gets its OpenAPI index built at the end of every import,
+	// so the seed does too.
+	if _, err := openapiindex.Build(t.Context(), d); err != nil {
+		t.Fatalf("build openapi index: %v", err)
+	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close seed db: %v", err)
 	}
@@ -604,6 +709,8 @@ func TestCmdQueryCommands(t *testing.T) {
 		{"get-references", func() { cmdGetReferences([]string{"-db", path, "TS 24.229", "5.1"}) }, []string{"TS 23.228"}},
 		{"list-openapi", func() { cmdListOpenAPI([]string{"-db", path}) }, []string{"Nnrf_NFManagement"}},
 		{"get-openapi", func() { cmdGetOpenAPI([]string{"-db", path, "-schema", "NFProfile", "TS 29.510", "Nnrf_NFManagement"}) }, []string{"NFProfile"}},
+		{"search-openapi", func() { cmdSearchOpenAPI([]string{"-db", path, "-limit", "2", "NFProfile"}) }, []string{"NFProfile", "total_count"}},
+		{"search-openapi multi-arg", func() { cmdSearchOpenAPI([]string{"-db", path, "-kind", "operation", "nf-instances"}) }, []string{`"operation"`}},
 		{"list-images", func() { cmdListImages([]string{"-db", path, "TS 23.501"}) }, []string{`"count"`}},
 	}
 	for _, tt := range tests {

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -351,6 +351,47 @@ func TestRunSearchOpenAPIWithoutIndex(t *testing.T) {
 	}
 }
 
+// TestRebuildOpenAPIIndexDropsStaleIndexOnFailure covers the guarantee update
+// relies on: a rebuild that cannot finish leaves no index at all, so
+// search_openapi reports it as missing instead of answering from the corpus as
+// it was before.
+func TestRebuildOpenAPIIndexDropsStaleIndexOnFailure(t *testing.T) {
+	path := seedDBPath(t)
+	d, err := db.OpenReadWrite(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// Break the FTS side while the chunk rows stay: the triggers now write to
+	// a table that is not there, so the rebuild fails partway.
+	if err := d.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
+		t.Fatalf("break index: %v", err)
+	}
+
+	err = rebuildOpenAPIIndex(t.Context(), d)
+	if err == nil {
+		t.Fatal("expected the rebuild to fail")
+	}
+	if !strings.Contains(err.Error(), "build-openapi-index") {
+		t.Errorf("error should name the recovery: %v", err)
+	}
+	if ok, checkErr := d.HasOpenAPIIndex(t.Context()); checkErr != nil || ok {
+		t.Errorf("stale index survived a failed rebuild: %v, %v", ok, checkErr)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// And the database is recoverable exactly the way the error says.
+	out := captureStdout(t, func() {
+		if err := runBuildOpenAPIIndex(t.Context(), path); err != nil {
+			t.Fatalf("runBuildOpenAPIIndex: %v", err)
+		}
+	})
+	if !strings.Contains(out, "OpenAPI index:") {
+		t.Errorf("unexpected output: %s", out)
+	}
+}
+
 func TestRunBuildOpenAPIIndex(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "old.db")
 	d, err := db.OpenReadWrite(path)

--- a/db/db.go
+++ b/db/db.go
@@ -301,6 +301,61 @@ CREATE TABLE IF NOT EXISTS spec_references (
 
 CREATE INDEX IF NOT EXISTS idx_ref_source ON spec_references(source_spec_id, source_version, source_section);
 CREATE INDEX IF NOT EXISTS idx_ref_target ON spec_references(target_spec);
+` + OpenAPIIndexSchema
+
+// OpenAPIIndexSchema defines the OpenAPI search index: one row per schema and
+// per operation, derived from openapi_specs by internal/openapiindex and
+// rebuilt wholesale, never written by the importer.
+//
+// It is a second FTS index, separate from sections_fts on purpose. The rows
+// are YAML fragments rather than prose, and search must not have to rank the
+// two kinds of text against each other.
+//
+// The tokenizer is plain unicode61, without porter: these rows are identifiers
+// (NFProfile, supportedFeatures), not English, and stemming only mangles them.
+// Leaving '-', '.' and '_' as separators is what makes a partial name work —
+// Nnrf_NFManagement indexes as "nnrf" and "nfmanagement", /nf-instances as
+// "nf" and "instances".
+const OpenAPIIndexSchema = `
+CREATE TABLE IF NOT EXISTS openapi_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    spec_id TEXT NOT NULL,
+    api_name TEXT NOT NULL,
+    filename TEXT NOT NULL DEFAULT '',
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    body TEXT NOT NULL,
+    UNIQUE(spec_id, api_name, kind, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_openapi_chunks_spec ON openapi_chunks(spec_id, api_name);
+CREATE INDEX IF NOT EXISTS idx_openapi_chunks_name ON openapi_chunks(name);
+
+-- kind is not an FTS column: it is a two-value filter applied to the backing
+-- table, and indexing it would let the words "schema" and "operation" score.
+CREATE VIRTUAL TABLE IF NOT EXISTS openapi_chunks_fts USING fts5(
+    api_name, name, body,
+    content=openapi_chunks,
+    content_rowid=id,
+    tokenize="unicode61"
+);
+
+CREATE TRIGGER IF NOT EXISTS openapi_chunks_ai AFTER INSERT ON openapi_chunks BEGIN
+    INSERT INTO openapi_chunks_fts(rowid, api_name, name, body)
+    VALUES (new.id, new.api_name, new.name, new.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS openapi_chunks_ad AFTER DELETE ON openapi_chunks BEGIN
+    INSERT INTO openapi_chunks_fts(openapi_chunks_fts, rowid, api_name, name, body)
+    VALUES ('delete', old.id, old.api_name, old.name, old.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS openapi_chunks_au AFTER UPDATE ON openapi_chunks BEGIN
+    INSERT INTO openapi_chunks_fts(openapi_chunks_fts, rowid, api_name, name, body)
+    VALUES ('delete', old.id, old.api_name, old.name, old.body);
+    INSERT INTO openapi_chunks_fts(rowid, api_name, name, body)
+    VALUES (new.id, new.api_name, new.name, new.body);
+END;
 `
 
 // InitSchema creates the database tables and indexes.
@@ -1022,6 +1077,14 @@ var fts5Columns = map[string]bool{
 	"spec_id": true, "number": true, "title": true, "content": true,
 }
 
+// openapiFTS5Columns is the same set for the openapi_chunks_fts table. The two
+// indexes have no column in common, so the sanitizer has to be told which one
+// a query is headed for: "name:NFProfile" is a column filter against one and a
+// literal term against the other.
+var openapiFTS5Columns = map[string]bool{
+	"api_name": true, "name": true, "body": true,
+}
+
 // fts5Operators are FTS5 keywords that must not be quoted.
 var fts5Operators = map[string]bool{
 	"AND": true, "OR": true, "NOT": true,
@@ -1065,16 +1128,16 @@ func quoteFTS5Term(s string) string {
 
 // classifyToken quotes a bareword or "col:val" column-filter token if it
 // contains a character FTS5 cannot parse in an unquoted bareword. Only a
-// prefix naming a real column of sections_fts is treated as a column filter
-// (FTS5 matches column names case-insensitively, so the lookup does too);
-// anything else before the colon is ordinary query text and is quoted along
-// with the rest of the token, because FTS5 answers an unknown column with a
-// hard "no such column" error that fails the entire search.
-func classifyToken(token string) string {
+// prefix naming a real column of the target index is treated as a column
+// filter (FTS5 matches column names case-insensitively, so the lookup does
+// too); anything else before the colon is ordinary query text and is quoted
+// along with the rest of the token, because FTS5 answers an unknown column
+// with a hard "no such column" error that fails the entire search.
+func classifyToken(token string, cols map[string]bool) string {
 	if colIdx := strings.IndexByte(token, ':'); colIdx > 0 {
 		col := token[:colIdx]
 		val := token[colIdx+1:]
-		if fts5Columns[strings.ToLower(col)] {
+		if cols[strings.ToLower(col)] {
 			if val == "" {
 				// "content:" with no value is a syntax error; treat the
 				// whole token as a literal search term instead.
@@ -1199,6 +1262,13 @@ func sanitizeNEARGroup(run string) string {
 // means something other than exclusion), so passing the hyphen through
 // unchanged never actually excludes anything.
 func sanitizeFTS5Query(query string) string {
+	return sanitizeFTS5QueryCols(query, fts5Columns)
+}
+
+// sanitizeFTS5QueryCols is sanitizeFTS5Query against an index whose columns
+// are cols, so a "col:val" token is only kept as a column filter when col is
+// one of that index's own columns.
+func sanitizeFTS5QueryCols(query string, cols map[string]bool) string {
 	var result []string
 	i := 0
 	n := len(query)
@@ -1316,14 +1386,14 @@ func sanitizeFTS5Query(query string) string {
 			// even without any other special character in the token).
 			canNegate := len(result) > 0 && !fts5Operators[result[len(result)-1]]
 			if canNegate {
-				result = append(result, "NOT", classifyToken(token[1:]))
+				result = append(result, "NOT", classifyToken(token[1:], cols))
 			} else {
 				result = append(result, quoteFTS5String(token))
 			}
 			continue
 		}
 
-		result = append(result, classifyToken(token))
+		result = append(result, classifyToken(token, cols))
 	}
 
 	// An operator keyword at the end of the query has no right operand, which

--- a/db/openapi_search.go
+++ b/db/openapi_search.go
@@ -220,7 +220,10 @@ func (d *DB) SearchOpenAPI(ctx context.Context, query string, specIDs []string, 
 		fromWhere += " AND (" + strings.Join(conds, " OR ") + ")"
 	}
 	if apiName != "" {
-		fromWhere += " AND c.api_name = ?"
+		// Case-insensitive, because an API name is copied out of prose as
+		// often as out of list_openapi and "nnrf_nfmanagement" would
+		// otherwise return an empty result indistinguishable from no matches.
+		fromWhere += " AND LOWER(c.api_name) = LOWER(?)"
 		filterArgs = append(filterArgs, apiName)
 	}
 	if kind != "" {

--- a/db/openapi_search.go
+++ b/db/openapi_search.go
@@ -134,17 +134,35 @@ func (d *DB) ReplaceOpenAPIChunks(chunks []OpenAPIChunk) error {
 // ErrNoOpenAPIIndex — visibly missing and rebuildable, rather than silently
 // wrong. InitSchema recreates the tables.
 func (d *DB) DropOpenAPIIndex() error {
+	// One transaction, because half a drop is worse than either end of it: the
+	// content table left without its FTS twin still answers HasOpenAPIIndex
+	// with "absent" (it counts both), so the database would pass for
+	// index-less while carrying rows that the next rebuild's DELETE would fire
+	// delete triggers for against an index that never held them — the "missing
+	// row" corruption ReplaceOpenAPIChunks exists to avoid. SQLite makes DDL
+	// transactional, so this is all or nothing.
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("drop openapi index: begin transaction: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
 	// Triggers first: they write to openapi_chunks_fts, so leaving one behind
 	// a dropped table would break the next write to openapi_chunks.
-	_, err := d.conn.Exec(`
-DROP TRIGGER IF EXISTS openapi_chunks_ai;
-DROP TRIGGER IF EXISTS openapi_chunks_ad;
-DROP TRIGGER IF EXISTS openapi_chunks_au;
-DROP TABLE IF EXISTS openapi_chunks_fts;
-DROP TABLE IF EXISTS openapi_chunks;
-`)
-	if err != nil {
-		return fmt.Errorf("drop openapi index: %w", err)
+	for _, stmt := range []string{
+		"DROP TRIGGER IF EXISTS openapi_chunks_ai",
+		"DROP TRIGGER IF EXISTS openapi_chunks_ad",
+		"DROP TRIGGER IF EXISTS openapi_chunks_au",
+		"DROP TABLE IF EXISTS openapi_chunks_fts",
+		"DROP TABLE IF EXISTS openapi_chunks",
+	} {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("drop openapi index (%s): %w", stmt, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("drop openapi index: commit: %w", err)
 	}
 	return nil
 }

--- a/db/openapi_search.go
+++ b/db/openapi_search.go
@@ -1,0 +1,275 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Chunk kinds stored in openapi_chunks.kind.
+const (
+	// OpenAPIKindSchema is one entry of components.schemas.
+	OpenAPIKindSchema = "schema"
+	// OpenAPIKindOperation is one method of one path, named "METHOD /path".
+	OpenAPIKindOperation = "operation"
+)
+
+// ErrNoOpenAPIIndex reports that this database predates the OpenAPI search
+// index. The tables are created by InitSchema, but serve opens the database
+// read-only, so a database built by an older version cannot grow them on the
+// fly — it has to be rebuilt with build-openapi-index.
+var ErrNoOpenAPIIndex = errors.New("openapi search index not built in this database")
+
+// OpenAPIDoc is one row of openapi_specs, as the index builder reads it.
+type OpenAPIDoc struct {
+	SpecID   string
+	APIName  string
+	Filename string
+	Content  string
+}
+
+// OpenAPIChunk is one indexed unit of an OpenAPI definition: a schema, or an
+// operation. Body is the rendered text that gets searched.
+type OpenAPIChunk struct {
+	SpecID   string
+	APIName  string
+	Filename string
+	Kind     string
+	Name     string
+	Body     string
+}
+
+// OpenAPISearchResult is one hit of SearchOpenAPI. Body is only filled when
+// the caller asks for it, because a chunk body is far longer than a snippet.
+type OpenAPISearchResult struct {
+	SpecID  string `json:"spec_id"`
+	APIName string `json:"api_name"`
+	Kind    string `json:"kind"`
+	Name    string `json:"name"`
+	Snippet string `json:"snippet"`
+	Body    string `json:"body,omitempty"`
+}
+
+// OpenAPISearchResults mirrors SearchResults so both search tools page the
+// same way.
+type OpenAPISearchResults struct {
+	Results    []OpenAPISearchResult `json:"results"`
+	TotalCount int                   `json:"total_count"`
+	Limit      int                   `json:"limit"`
+	Offset     int                   `json:"offset"`
+}
+
+// AllOpenAPIDocs returns every stored OpenAPI document. The index builder
+// needs all of them at once: most $refs in the 5G SBI definitions point into
+// another file, so a chunk cannot be rendered from its own document alone.
+// Ordering by filename makes a rebuild reproducible.
+func (d *DB) AllOpenAPIDocs(ctx context.Context) ([]OpenAPIDoc, error) {
+	rows, err := d.conn.QueryContext(ctx,
+		"SELECT spec_id, api_name, COALESCE(filename, ''), content FROM openapi_specs ORDER BY filename, spec_id, api_name",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list openapi documents: %w", err)
+	}
+	defer rows.Close()
+
+	var docs []OpenAPIDoc
+	for rows.Next() {
+		var doc OpenAPIDoc
+		if err := rows.Scan(&doc.SpecID, &doc.APIName, &doc.Filename, &doc.Content); err != nil {
+			return nil, fmt.Errorf("scan openapi document: %w", err)
+		}
+		docs = append(docs, doc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list openapi documents: iterate: %w", err)
+	}
+	return docs, nil
+}
+
+// ReplaceOpenAPIChunks swaps the whole index for chunks in one transaction.
+// The index is derived data with no incremental story — a $ref that starts
+// resolving because another document arrived changes chunks in files that
+// were not themselves re-imported — so it is always rebuilt wholesale.
+func (d *DB) ReplaceOpenAPIChunks(chunks []OpenAPIChunk) error {
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit per database/sql docs
+
+	// An explicit DELETE keeps the FTS5 delete triggers firing, which
+	// INSERT OR REPLACE would skip without recursive_triggers, leaving stale
+	// index entries behind that fail later searches with "missing row".
+	if _, err := tx.Exec("DELETE FROM openapi_chunks"); err != nil {
+		return fmt.Errorf("clear openapi chunks: %w", err)
+	}
+
+	stmt, err := tx.Prepare(
+		"INSERT INTO openapi_chunks (spec_id, api_name, filename, kind, name, body) VALUES (?, ?, ?, ?, ?, ?)",
+	)
+	if err != nil {
+		return fmt.Errorf("prepare openapi chunk insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, c := range chunks {
+		if _, err := stmt.Exec(c.SpecID, c.APIName, c.Filename, c.Kind, c.Name, c.Body); err != nil {
+			return fmt.Errorf("insert openapi chunk %s %s: %w", c.APIName, c.Name, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit openapi chunks: %w", err)
+	}
+	return nil
+}
+
+// HasOpenAPIIndex reports whether this database carries the OpenAPI search
+// index tables at all.
+func (d *DB) HasOpenAPIIndex(ctx context.Context) (bool, error) {
+	var n int
+	err := d.conn.QueryRowContext(ctx,
+		"SELECT count(*) FROM sqlite_master WHERE name IN ('openapi_chunks', 'openapi_chunks_fts')",
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("check openapi index: %w", err)
+	}
+	return n == 2, nil
+}
+
+// openapiBM25Weights orders OpenAPI hits: a name match dominates, because the
+// question that reaches this index almost always names the thing it wants
+// (NFProfile, POST /nf-instances), and api_name barely counts so that querying
+// an API's own name does not float every chunk of it above better body
+// matches. Column order is api_name, name, body. bm25() returns negative
+// scores, smaller = better, so ORDER BY stays ascending. Weighting must happen
+// in the query: setting the table's rank option needs a write, and serve opens
+// read-only.
+const openapiBM25Weights = "bm25(openapi_chunks_fts, 0.5, 5.0, 1.0)"
+
+// openapiNameRank sorts a hit whose name is what the query asked for ahead of
+// everything else, before bm25 gets a say.
+//
+// bm25 alone cannot do this here. It normalizes by document length, and these
+// chunks differ in size by three orders of magnitude — the NFProfile schema of
+// TS 29.510 renders to ~39 KB once its properties are expanded, while the
+// schemas that merely mention NFProfile in a description are a few hundred
+// bytes. Weighting the name column does not close that gap, so a search for
+// NFProfile returned NFProfile eighth. Whatever else it ranks, this index has
+// to answer "the thing called X" with X.
+const openapiNameRank = "CASE WHEN lower(c.name) = lower(?) THEN 0 WHEN instr(lower(c.name), lower(?)) > 0 THEN 1 ELSE 2 END, "
+
+// nameHint returns the part of a query that can be compared against a chunk
+// name: the query itself when it is one bare term, and nothing when it carries
+// FTS5 syntax. A query with operators, phrases or column filters is not a name
+// anybody typed, so ranking by name equality against it would be noise.
+func nameHint(query string) string {
+	q := strings.TrimSpace(query)
+	if q == "" || strings.ContainsAny(q, " \t\n\"()*:") {
+		return ""
+	}
+	return q
+}
+
+// SearchOpenAPI runs a full-text search over the OpenAPI index. One hit is one
+// schema or one operation, never a whole document. kind, when set, must be
+// OpenAPIKindSchema or OpenAPIKindOperation.
+func (d *DB) SearchOpenAPI(ctx context.Context, query string, specIDs []string, apiName, kind string, includeBody bool, limit, offset int) (*OpenAPISearchResults, error) {
+	if limit <= 0 {
+		limit = DefaultSearchLimit
+	}
+	if limit > MaxSearchLimit {
+		limit = MaxSearchLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	if kind != "" && kind != OpenAPIKindSchema && kind != OpenAPIKindOperation {
+		return nil, fmt.Errorf("invalid kind %q: want %q or %q", kind, OpenAPIKindSchema, OpenAPIKindOperation)
+	}
+
+	// Reported before the query runs, so an old database gets the actionable
+	// "rebuild the index" message instead of a bare "no such table".
+	ok, err := d.HasOpenAPIIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoOpenAPIIndex
+	}
+
+	hint := nameHint(query)
+	query = sanitizeFTS5QueryCols(query, openapiFTS5Columns)
+
+	// spec_id and kind live on the backing table only, so every filter is
+	// applied through the join rather than as an FTS column.
+	fromWhere := "FROM openapi_chunks_fts JOIN openapi_chunks c ON c.id = openapi_chunks_fts.rowid WHERE openapi_chunks_fts MATCH ?"
+	filterArgs := []any{query}
+
+	if len(specIDs) > 0 {
+		// Each spec ID also matches its split multi-file parts, exactly as in
+		// Search: "TS 29.510" covers "TS 29.510-1" and friends.
+		conds := make([]string, len(specIDs))
+		for i, id := range specIDs {
+			conds[i] = "c.spec_id = ? OR c.spec_id LIKE ? ESCAPE '\\'"
+			filterArgs = append(filterArgs, id, EscapeLikePattern(id)+"-%")
+		}
+		fromWhere += " AND (" + strings.Join(conds, " OR ") + ")"
+	}
+	if apiName != "" {
+		fromWhere += " AND c.api_name = ?"
+		filterArgs = append(filterArgs, apiName)
+	}
+	if kind != "" {
+		fromWhere += " AND c.kind = ?"
+		filterArgs = append(filterArgs, kind)
+	}
+
+	// As in Search, the total comes from its own query sharing the filter, so
+	// an offset past the last row still reports how many matches there are.
+	var totalCount int
+	if err := d.conn.QueryRowContext(ctx, "SELECT count(*) "+fromWhere, filterArgs...).Scan(&totalCount); err != nil {
+		return nil, fmt.Errorf("invalid search query %q: %w", query, err)
+	}
+
+	// Column -1 lets FTS5 pick the best-matching column for the snippet, so a
+	// name-only hit shows the marked name. The rowid tie-breaker keeps equal
+	// scoring rows in a stable order, so paging never duplicates or drops one.
+	body := "''"
+	if includeBody {
+		body = "c.body"
+	}
+	// The name rank is dropped entirely rather than passed an empty hint, so a
+	// query that is not a name leaves the ordering to bm25 alone.
+	rank, rankArgs := "", []any(nil)
+	if hint != "" {
+		rank, rankArgs = openapiNameRank, []any{hint, hint}
+	}
+	sqlQuery := "SELECT c.spec_id, c.api_name, c.kind, c.name, " +
+		"snippet(openapi_chunks_fts, -1, '<mark>', '</mark>', '...', 32), " + body + " " +
+		fromWhere + " ORDER BY " + rank + openapiBM25Weights + ", openapi_chunks_fts.rowid LIMIT ? OFFSET ?"
+	args := append(append([]any{}, filterArgs...), rankArgs...)
+	args = append(args, limit, offset)
+
+	rows, err := d.conn.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid search query %q: %w", query, err)
+	}
+	defer rows.Close()
+
+	results := []OpenAPISearchResult{}
+	for rows.Next() {
+		var r OpenAPISearchResult
+		if err := rows.Scan(&r.SpecID, &r.APIName, &r.Kind, &r.Name, &r.Snippet, &r.Body); err != nil {
+			return nil, fmt.Errorf("scan openapi search result: %w", err)
+		}
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search openapi: iterate: %w", err)
+	}
+	return &OpenAPISearchResults{Results: results, TotalCount: totalCount, Limit: limit, Offset: offset}, nil
+}

--- a/db/openapi_search.go
+++ b/db/openapi_search.go
@@ -125,6 +125,30 @@ func (d *DB) ReplaceOpenAPIChunks(chunks []OpenAPIChunk) error {
 	return nil
 }
 
+// DropOpenAPIIndex removes the index tables and their triggers.
+//
+// It is the recovery for a rebuild that failed partway: the chunks still in
+// the database describe the corpus as it was before, and a stale index answers
+// with definitions that no longer exist. Dropping it leaves the database in the
+// state a pre-index build produces, which SearchOpenAPI already reports as
+// ErrNoOpenAPIIndex — visibly missing and rebuildable, rather than silently
+// wrong. InitSchema recreates the tables.
+func (d *DB) DropOpenAPIIndex() error {
+	// Triggers first: they write to openapi_chunks_fts, so leaving one behind
+	// a dropped table would break the next write to openapi_chunks.
+	_, err := d.conn.Exec(`
+DROP TRIGGER IF EXISTS openapi_chunks_ai;
+DROP TRIGGER IF EXISTS openapi_chunks_ad;
+DROP TRIGGER IF EXISTS openapi_chunks_au;
+DROP TABLE IF EXISTS openapi_chunks_fts;
+DROP TABLE IF EXISTS openapi_chunks;
+`)
+	if err != nil {
+		return fmt.Errorf("drop openapi index: %w", err)
+	}
+	return nil
+}
+
 // HasOpenAPIIndex reports whether this database carries the OpenAPI search
 // index tables at all.
 func (d *DB) HasOpenAPIIndex(ctx context.Context) (bool, error) {

--- a/db/openapi_search_test.go
+++ b/db/openapi_search_test.go
@@ -267,6 +267,40 @@ func TestSearchOpenAPIWithoutIndex(t *testing.T) {
 	}
 }
 
+// TestDropOpenAPIIndex covers the recovery from a rebuild that failed partway:
+// the database has to end up visibly index-less rather than quietly serving
+// the previous corpus.
+func TestDropOpenAPIIndex(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	if err := d.DropOpenAPIIndex(); err != nil {
+		t.Fatalf("DropOpenAPIIndex: %v", err)
+	}
+
+	if ok, err := d.HasOpenAPIIndex(t.Context()); err != nil || ok {
+		t.Fatalf("HasOpenAPIIndex = %v, %v; want false, nil", ok, err)
+	}
+	if _, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0); !errors.Is(err, ErrNoOpenAPIIndex) {
+		t.Fatalf("err = %v, want ErrNoOpenAPIIndex", err)
+	}
+
+	// Dropping is recoverable: the schema recreates the tables, triggers and
+	// all, and the index works again.
+	if err := d.ExecScript(OpenAPIIndexSchema); err != nil {
+		t.Fatalf("recreate schema: %v", err)
+	}
+	if err := d.ReplaceOpenAPIChunks(testChunks); err != nil {
+		t.Fatalf("ReplaceOpenAPIChunks: %v", err)
+	}
+	got, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI after rebuild: %v", err)
+	}
+	if len(got.Results) == 0 {
+		t.Error("index did not come back after being dropped and rebuilt")
+	}
+}
+
 func TestReplaceOpenAPIChunksClearsStaleRows(t *testing.T) {
 	d := setupOpenAPIIndexDB(t)
 

--- a/db/openapi_search_test.go
+++ b/db/openapi_search_test.go
@@ -376,6 +376,77 @@ func TestDropOpenAPIIndex(t *testing.T) {
 	}
 }
 
+// TestReplaceOpenAPIChunksRejectsDuplicates covers the rollback: a chunk set
+// that violates the (spec, api, kind, name) key must leave the previous index
+// intact rather than half-written.
+func TestReplaceOpenAPIChunksRejectsDuplicates(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	dup := append(append([]OpenAPIChunk{}, testChunks...), testChunks[0])
+	err := d.ReplaceOpenAPIChunks(dup)
+	if err == nil {
+		t.Fatal("expected a duplicate chunk to be rejected")
+	}
+	if !strings.Contains(err.Error(), "NFProfile") {
+		t.Errorf("error should name the offending chunk: %v", err)
+	}
+
+	// The transaction rolled back, so the index is still the one it was.
+	got, searchErr := d.SearchOpenAPI(t.Context(), "name:NFProfile", nil, "", "", false, 0, 0)
+	if searchErr != nil {
+		t.Fatalf("SearchOpenAPI: %v", searchErr)
+	}
+	if len(got.Results) != 1 {
+		t.Errorf("results = %v, want the pre-existing index intact", names(got.Results))
+	}
+}
+
+// TestReplaceOpenAPIChunksNeedsTheFTSTable covers the half-dropped index: the
+// delete triggers write to openapi_chunks_fts, so a rebuild against a database
+// missing it has to fail rather than quietly desynchronize the two.
+func TestReplaceOpenAPIChunksNeedsTheFTSTable(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	if err := d.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
+		t.Fatalf("drop fts table: %v", err)
+	}
+	if err := d.ReplaceOpenAPIChunks(testChunks); err == nil {
+		t.Fatal("expected the rebuild to fail without the FTS table")
+	}
+}
+
+// TestOpenAPIIndexOnClosedDatabase checks that every entry point reports a
+// database it cannot reach, rather than panicking or returning empty results
+// that read as "nothing indexed".
+func TestOpenAPIIndexOnClosedDatabase(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := d.AllOpenAPIDocs(t.Context()); err == nil {
+		t.Error("AllOpenAPIDocs succeeded on a closed database")
+	}
+	if err := d.ReplaceOpenAPIChunks(testChunks); err == nil {
+		t.Error("ReplaceOpenAPIChunks succeeded on a closed database")
+	}
+	if err := d.DropOpenAPIIndex(); err == nil {
+		t.Error("DropOpenAPIIndex succeeded on a closed database")
+	}
+	if _, err := d.HasOpenAPIIndex(t.Context()); err == nil {
+		t.Error("HasOpenAPIIndex succeeded on a closed database")
+	}
+	// The search must not mistake an unreachable database for one that simply
+	// has no index, or the tool would tell the caller to rebuild it.
+	_, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err == nil {
+		t.Fatal("SearchOpenAPI succeeded on a closed database")
+	}
+	if errors.Is(err, ErrNoOpenAPIIndex) {
+		t.Errorf("an unreachable database reported as a missing index: %v", err)
+	}
+}
+
 func TestReplaceOpenAPIChunksClearsStaleRows(t *testing.T) {
 	d := setupOpenAPIIndexDB(t)
 

--- a/db/openapi_search_test.go
+++ b/db/openapi_search_test.go
@@ -267,6 +267,81 @@ func TestSearchOpenAPIWithoutIndex(t *testing.T) {
 	}
 }
 
+func TestAllOpenAPIDocs(t *testing.T) {
+	d := setupTestDB(t)
+
+	docs, err := d.AllOpenAPIDocs(t.Context())
+	if err != nil {
+		t.Fatalf("AllOpenAPIDocs: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d documents, want 1", len(docs))
+	}
+	// The builder needs the file name to resolve cross-file $refs, so it has
+	// to survive the round trip along with the content.
+	got := docs[0]
+	if got.SpecID != "TS 29.510" || got.APIName != "Nnrf_NFManagement" {
+		t.Errorf("document = %s %s, want TS 29.510 Nnrf_NFManagement", got.SpecID, got.APIName)
+	}
+	if got.Filename != "TS29510_Nnrf_NFManagement.yaml" {
+		t.Errorf("filename = %q", got.Filename)
+	}
+	if !strings.Contains(got.Content, "NFProfile") {
+		t.Errorf("content = %q, want the stored YAML", got.Content)
+	}
+}
+
+func TestSearchOpenAPIClampsLimitAndOffset(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	tests := []struct {
+		name       string
+		limit      int
+		offset     int
+		wantLimit  int
+		wantOffset int
+	}{
+		{"zero limit falls back to the default", 0, 0, DefaultSearchLimit, 0},
+		{"negative limit falls back to the default", -5, 0, DefaultSearchLimit, 0},
+		{"limit above the cap is clamped", MaxSearchLimit + 100, 0, MaxSearchLimit, 0},
+		{"negative offset starts at the beginning", 0, -3, DefaultSearchLimit, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.SearchOpenAPI(t.Context(), "type", nil, "", "", false, tt.limit, tt.offset)
+			if err != nil {
+				t.Fatalf("SearchOpenAPI: %v", err)
+			}
+			if got.Limit != tt.wantLimit || got.Offset != tt.wantOffset {
+				t.Errorf("limit, offset = %d, %d; want %d, %d", got.Limit, got.Offset, tt.wantLimit, tt.wantOffset)
+			}
+		})
+	}
+}
+
+// TestSearchOpenAPISanitizesQuery checks that the syntax FTS5 would reject
+// outright reaches it quoted instead of failing the search.
+func TestSearchOpenAPISanitizesQuery(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	for _, query := range []string{
+		"nf-instances",            // a bare hyphen is the column-filter operator
+		"29.510",                  // a bare period is a syntax error
+		`"unterminated`,           // an unterminated phrase
+		"AND",                     // an operator with no operands
+		"NFProfile -UeContext",    // a trailing exclusion
+		"NEAR(NFProfile type, 5)", // a NEAR group
+		"name:",                   // a column filter with no value
+		"*",                       // a bare prefix operator
+	} {
+		t.Run(query, func(t *testing.T) {
+			if _, err := d.SearchOpenAPI(t.Context(), query, nil, "", "", false, 0, 0); err != nil {
+				t.Errorf("SearchOpenAPI(%q): %v", query, err)
+			}
+		})
+	}
+}
+
 // TestDropOpenAPIIndex covers the recovery from a rebuild that failed partway:
 // the database has to end up visibly index-less rather than quietly serving
 // the previous corpus.

--- a/db/openapi_search_test.go
+++ b/db/openapi_search_test.go
@@ -1,0 +1,286 @@
+package db
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testChunks is a small stand-in for what internal/openapiindex renders, with
+// enough shape to exercise ranking and every filter.
+var testChunks = []OpenAPIChunk{
+	{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml",
+		Kind: OpenAPIKindSchema, Name: "NFProfile",
+		Body: "NFProfile:\n  type: object\n  properties:\n    nfInstanceId:\n      type: string\n",
+	},
+	{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml",
+		Kind: OpenAPIKindSchema, Name: "NFService",
+		Body: "NFService:\n  type: object\n  description: mentions NFProfile in prose only\n",
+	},
+	{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml",
+		Kind: OpenAPIKindOperation, Name: "PUT /nf-instances/{nfInstanceID}",
+		Body: "PUT /nf-instances/{nfInstanceID}\n  summary: Register NF Instance\n",
+	},
+	{
+		SpecID: "TS 29.518", APIName: "Namf_Communication", Filename: "TS29518_Namf_Communication.yaml",
+		Kind: OpenAPIKindSchema, Name: "UeContext",
+		Body: "UeContext:\n  type: object\n  properties:\n    supi:\n      type: string\n",
+	},
+}
+
+func setupOpenAPIIndexDB(t *testing.T) *DB {
+	t.Helper()
+	d := setupTestDB(t)
+	if err := d.ReplaceOpenAPIChunks(testChunks); err != nil {
+		t.Fatalf("ReplaceOpenAPIChunks: %v", err)
+	}
+	return d
+}
+
+func names(results []OpenAPISearchResult) []string {
+	out := make([]string, len(results))
+	for i, r := range results {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func TestSearchOpenAPI(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	tests := []struct {
+		name    string
+		query   string
+		specIDs []string
+		apiName string
+		kind    string
+		want    []string
+	}{
+		{
+			// The name column outweighs body, so the schema that is named
+			// NFProfile beats the one that only mentions it.
+			name:  "name outranks body",
+			query: "NFProfile",
+			want:  []string{"NFProfile", "NFService"},
+		},
+		{
+			// '-' and '.' split tokens rather than breaking the query.
+			name:  "hyphenated term",
+			query: "nf-instances",
+			want:  []string{"PUT /nf-instances/{nfInstanceID}"},
+		},
+		{
+			name:  "kind filter",
+			query: "NFProfile OR nf-instances",
+			kind:  OpenAPIKindOperation,
+			want:  []string{"PUT /nf-instances/{nfInstanceID}"},
+		},
+		{
+			name:    "spec filter",
+			query:   "type",
+			specIDs: []string{"TS 29.518"},
+			want:    []string{"UeContext"},
+		},
+		{
+			name:    "api filter",
+			query:   "type",
+			apiName: "Namf_Communication",
+			want:    []string{"UeContext"},
+		},
+		{
+			name:  "column filter",
+			query: "name:NFProfile",
+			want:  []string{"NFProfile"},
+		},
+		{
+			// No stemming: the index stores identifiers, not English.
+			name:  "no stemming",
+			query: "properties",
+			want:  []string{"NFProfile", "UeContext"},
+		},
+		{
+			name:  "no match",
+			query: "SmContextCreateData",
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.SearchOpenAPI(t.Context(), tt.query, tt.specIDs, tt.apiName, tt.kind, false, 0, 0)
+			if err != nil {
+				t.Fatalf("SearchOpenAPI: %v", err)
+			}
+			if diff := strings.Join(names(got.Results), "|"); diff != strings.Join(tt.want, "|") {
+				t.Errorf("results = %v, want %v", names(got.Results), tt.want)
+			}
+			if got.TotalCount != len(tt.want) {
+				t.Errorf("total_count = %d, want %d", got.TotalCount, len(tt.want))
+			}
+		})
+	}
+}
+
+// TestSearchOpenAPIRanksNameFirst pins the case bm25 gets wrong on its own:
+// the real NFProfile schema renders to tens of kilobytes once its properties
+// are expanded, and length normalization pushes it below the small schemas
+// that only mention it in a description.
+func TestSearchOpenAPIRanksNameFirst(t *testing.T) {
+	d := setupTestDB(t)
+
+	long := "NFProfile:\n  type: object\n  properties:\n" +
+		strings.Repeat("    filler:\n      description: padding to make this chunk long\n", 400)
+	chunks := []OpenAPIChunk{
+		{
+			SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Kind: OpenAPIKindSchema,
+			Name: "NotificationData", Body: "NotificationData:\n  description: carries an NFProfile\n",
+		},
+		{
+			SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Kind: OpenAPIKindSchema,
+			Name: "NFProfile", Body: long,
+		},
+		{
+			SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Kind: OpenAPIKindSchema,
+			Name: "NFProfileList", Body: "NFProfileList:\n  type: array\n  items:\n    $ref: '#/components/schemas/NFProfile'\n",
+		},
+	}
+	if err := d.ReplaceOpenAPIChunks(chunks); err != nil {
+		t.Fatalf("ReplaceOpenAPIChunks: %v", err)
+	}
+
+	got, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	// Exact name first, then the name that contains it, then the rest.
+	want := []string{"NFProfile", "NFProfileList", "NotificationData"}
+	if strings.Join(names(got.Results), "|") != strings.Join(want, "|") {
+		t.Errorf("results = %v, want %v", names(got.Results), want)
+	}
+
+	// A query carrying FTS5 syntax is not a name anybody typed, so the name
+	// rank stays out of it and every hit is still returned.
+	got, err = d.SearchOpenAPI(t.Context(), "NFProfile OR NotificationData", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI operator query: %v", err)
+	}
+	if got.TotalCount != 3 {
+		t.Errorf("total_count = %d, want 3", got.TotalCount)
+	}
+}
+
+func TestSearchOpenAPIIncludeBody(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	got, err := d.SearchOpenAPI(t.Context(), "name:NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Body != "" {
+		t.Fatalf("body should be omitted by default, got %q", got.Results[0].Body)
+	}
+	if !strings.Contains(got.Results[0].Snippet, "<mark>") {
+		t.Errorf("snippet should mark the match, got %q", got.Results[0].Snippet)
+	}
+
+	got, err = d.SearchOpenAPI(t.Context(), "name:NFProfile", nil, "", "", true, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI with body: %v", err)
+	}
+	if !strings.Contains(got.Results[0].Body, "nfInstanceId") {
+		t.Errorf("body = %q, want the full chunk", got.Results[0].Body)
+	}
+}
+
+func TestSearchOpenAPIPagination(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	var seen []string
+	for offset := 0; offset < 4; offset++ {
+		got, err := d.SearchOpenAPI(t.Context(), "type OR summary", nil, "", "", false, 1, offset)
+		if err != nil {
+			t.Fatalf("SearchOpenAPI offset %d: %v", offset, err)
+		}
+		if got.TotalCount != 4 {
+			t.Fatalf("total_count = %d, want 4", got.TotalCount)
+		}
+		if len(got.Results) != 1 {
+			t.Fatalf("offset %d returned %d results, want 1", offset, len(got.Results))
+		}
+		seen = append(seen, got.Results[0].Name)
+	}
+	// Paging must neither repeat nor drop a hit.
+	unique := map[string]bool{}
+	for _, n := range seen {
+		if unique[n] {
+			t.Fatalf("name %q returned twice across pages: %v", n, seen)
+		}
+		unique[n] = true
+	}
+
+	// An offset past the last hit still reports the full count.
+	got, err := d.SearchOpenAPI(t.Context(), "type OR summary", nil, "", "", false, 10, 99)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI past end: %v", err)
+	}
+	if got.TotalCount != 4 || len(got.Results) != 0 {
+		t.Errorf("past end: got %d results, total %d; want 0 and 4", len(got.Results), got.TotalCount)
+	}
+}
+
+func TestSearchOpenAPIInvalidKind(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	if _, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "component", false, 0, 0); err == nil {
+		t.Fatal("expected an error for an unknown kind")
+	}
+}
+
+func TestSearchOpenAPIWithoutIndex(t *testing.T) {
+	// A database built before search_openapi existed: the spec tables are
+	// there, the index tables are not, and serve cannot create them because it
+	// opens read-only.
+	dbPath := filepath.Join(t.TempDir(), "old.db")
+	d, err := OpenReadWrite(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	if err := d.ExecScript(SpecTablesSchema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+
+	if _, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0); !errors.Is(err, ErrNoOpenAPIIndex) {
+		t.Fatalf("err = %v, want ErrNoOpenAPIIndex", err)
+	}
+}
+
+func TestReplaceOpenAPIChunksClearsStaleRows(t *testing.T) {
+	d := setupOpenAPIIndexDB(t)
+
+	// A rebuild replaces the index wholesale; the FTS side has to follow, or
+	// the old rows keep matching and searches fail on a missing backing row.
+	if err := d.ReplaceOpenAPIChunks(testChunks[3:]); err != nil {
+		t.Fatalf("ReplaceOpenAPIChunks: %v", err)
+	}
+
+	got, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if got.TotalCount != 0 {
+		t.Errorf("stale chunks survived the rebuild: %v", names(got.Results))
+	}
+
+	got, err = d.SearchOpenAPI(t.Context(), "UeContext", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Errorf("kept chunk missing after rebuild: %v", names(got.Results))
+	}
+}

--- a/db/openapi_search_test.go
+++ b/db/openapi_search_test.go
@@ -92,6 +92,14 @@ func TestSearchOpenAPI(t *testing.T) {
 			want:    []string{"UeContext"},
 		},
 		{
+			// An API name is copied out of prose as often as out of
+			// list_openapi, so the filter ignores case.
+			name:    "api filter ignores case",
+			query:   "type",
+			apiName: "namf_communication",
+			want:    []string{"UeContext"},
+		},
+		{
 			name:  "column filter",
 			query: "name:NFProfile",
 			want:  []string{"NFProfile"},

--- a/internal/openapiindex/build.go
+++ b/internal/openapiindex/build.go
@@ -1,0 +1,110 @@
+package openapiindex
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/higebu/3gpp-mcp/db"
+)
+
+// Stats summarizes a rebuild, for the line the CLI logs afterwards.
+type Stats struct {
+	Documents  int `json:"documents"`
+	Unparsable int `json:"unparsable"`
+	Chunks     int `json:"chunks"`
+	Schemas    int `json:"schemas"`
+	Operations int `json:"operations"`
+	Bytes      int `json:"bytes"`
+}
+
+// String renders the stats as the one line a build prints.
+func (s Stats) String() string {
+	return fmt.Sprintf("%d chunks (%d schemas, %d operations) from %d OpenAPI documents",
+		s.Chunks, s.Schemas, s.Operations, s.Documents)
+}
+
+// Chunks renders every schema and operation in the store, in store order.
+func Chunks(store *Store) []db.OpenAPIChunk {
+	var chunks []db.OpenAPIChunk
+	for _, doc := range store.Docs {
+		schemas := store.Schemas(doc)
+		for _, name := range sortedKeys(schemas) {
+			schema, ok := schemas[name].(map[string]any)
+			if !ok {
+				continue
+			}
+			chunks = append(chunks, db.OpenAPIChunk{
+				SpecID:   doc.SpecID,
+				APIName:  doc.APIName,
+				Filename: doc.Filename,
+				Kind:     db.OpenAPIKindSchema,
+				Name:     name,
+				Body:     store.RenderSchema(doc, name, schema, 0),
+			})
+		}
+
+		for _, op := range store.Operations(doc) {
+			name := strings.ToUpper(op.Method) + " " + op.Path
+			body := []string{name}
+			if summary, ok := op.Op["summary"].(string); ok {
+				body = append(body, "  summary: "+summary)
+			}
+			params, _ := op.Op["parameters"].([]any)
+			for _, p := range params {
+				param, _ := p.(map[string]any)
+				if param == nil {
+					continue
+				}
+				if pname, ok := param["name"].(string); ok {
+					body = append(body, "  parameter: "+pname)
+				}
+			}
+			if target, tName, tSchema, ok := store.RequestSchema(doc, op.Op); ok {
+				body = append(body, "  requestBody:")
+				body = append(body, indent(store.RenderSchema(target, tName, tSchema, 0), "    ")...)
+			}
+			chunks = append(chunks, db.OpenAPIChunk{
+				SpecID:   doc.SpecID,
+				APIName:  doc.APIName,
+				Filename: doc.Filename,
+				Kind:     db.OpenAPIKindOperation,
+				Name:     name,
+				Body:     strings.Join(body, "\n"),
+			})
+		}
+	}
+	return chunks
+}
+
+// Build rebuilds the whole OpenAPI search index from openapi_specs. It is
+// always a full rebuild: a $ref only resolves once the file it points at is in
+// the database, so importing one document can change the chunks of documents
+// that were imported long before it.
+//
+// The database must be open read-write and carry the index schema, so callers
+// run InitSchema first.
+func Build(ctx context.Context, d *db.DB) (Stats, error) {
+	docs, err := d.AllOpenAPIDocs(ctx)
+	if err != nil {
+		return Stats{}, fmt.Errorf("read openapi documents: %w", err)
+	}
+
+	store, unparsable := NewStore(docs)
+	chunks := Chunks(store)
+
+	if err := d.ReplaceOpenAPIChunks(chunks); err != nil {
+		return Stats{}, fmt.Errorf("write openapi index: %w", err)
+	}
+
+	stats := Stats{Documents: len(store.Docs), Unparsable: unparsable, Chunks: len(chunks)}
+	for _, c := range chunks {
+		if c.Kind == db.OpenAPIKindSchema {
+			stats.Schemas++
+		} else {
+			stats.Operations++
+		}
+		stats.Bytes += len(c.Body)
+	}
+	return stats, nil
+}

--- a/internal/openapiindex/build.go
+++ b/internal/openapiindex/build.go
@@ -3,6 +3,7 @@ package openapiindex
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
@@ -90,14 +91,19 @@ func Build(ctx context.Context, d *db.DB) (Stats, error) {
 		return Stats{}, fmt.Errorf("read openapi documents: %w", err)
 	}
 
-	store, unparsable := NewStore(docs)
+	store, parseErrs := NewStore(docs)
+	// Named one by one: a document missing from search is only actionable if
+	// the operator can see which one it was and why.
+	for _, err := range parseErrs {
+		log.Printf("warning: openapi index: %v", err)
+	}
 	chunks := Chunks(store)
 
 	if err := d.ReplaceOpenAPIChunks(chunks); err != nil {
 		return Stats{}, fmt.Errorf("write openapi index: %w", err)
 	}
 
-	stats := Stats{Documents: len(store.Docs), Unparsable: unparsable, Chunks: len(chunks)}
+	stats := Stats{Documents: len(store.Docs), Unparsable: len(parseErrs), Chunks: len(chunks)}
 	for _, c := range chunks {
 		if c.Kind == db.OpenAPIKindSchema {
 			stats.Schemas++

--- a/internal/openapiindex/openapiindex_test.go
+++ b/internal/openapiindex/openapiindex_test.go
@@ -1,0 +1,226 @@
+package openapiindex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/testutil"
+)
+
+// Two documents that reference each other the way the 5G SBI definitions do:
+// the operation's request body is a $ref into this file, and one of that
+// schema's properties is a $ref into the other file.
+var crossFileDocs = []db.OpenAPIDoc{
+	{
+		SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml",
+		Content: `openapi: 3.0.0
+paths:
+  /nf-instances/{nfInstanceID}:
+    put:
+      summary: Register NF Instance
+      parameters:
+        - name: nfInstanceID
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NFProfile'
+    get:
+      summary: Read NF Instance
+components:
+  schemas:
+    NFProfile:
+      type: object
+      description: Information of an NF Instance
+      properties:
+        nfInstanceId:
+          type: string
+        nfType:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/NFType'
+        offRef:
+          $ref: 'TS29999_Missing.yaml#/components/schemas/Nowhere'
+`,
+	},
+	{
+		SpecID: "TS 29.571", APIName: "CommonData", Filename: "TS29571_CommonData.yaml",
+		Content: `openapi: 3.0.0
+components:
+  schemas:
+    NFType:
+      type: string
+      description: NF types known to the NRF
+    PlmnId:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NFType'
+      properties:
+        mcc:
+          type: string
+`,
+	},
+}
+
+func chunkByName(t *testing.T, chunks []db.OpenAPIChunk, kind, name string) db.OpenAPIChunk {
+	t.Helper()
+	for _, c := range chunks {
+		if c.Kind == kind && c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no %s chunk named %q in %d chunks", kind, name, len(chunks))
+	return db.OpenAPIChunk{}
+}
+
+func TestChunks(t *testing.T) {
+	store, unparsable := NewStore(crossFileDocs)
+	if unparsable != 0 {
+		t.Fatalf("unparsable = %d, want 0", unparsable)
+	}
+	chunks := Chunks(store)
+
+	var gotNames []string
+	for _, c := range chunks {
+		gotNames = append(gotNames, c.Kind+" "+c.Name)
+	}
+	want := []string{
+		"schema NFProfile",
+		"operation GET /nf-instances/{nfInstanceID}",
+		"operation PUT /nf-instances/{nfInstanceID}",
+		"schema NFType",
+		"schema PlmnId",
+	}
+	if strings.Join(gotNames, "|") != strings.Join(want, "|") {
+		t.Errorf("chunks = %v, want %v", gotNames, want)
+	}
+
+	// A chunk carries the document it came from, so a hit can be handed
+	// straight to get_openapi.
+	nfProfile := chunkByName(t, chunks, db.OpenAPIKindSchema, "NFProfile")
+	if nfProfile.SpecID != "TS 29.510" || nfProfile.APIName != "Nnrf_NFManagement" {
+		t.Errorf("NFProfile came from %s %s, want TS 29.510 Nnrf_NFManagement", nfProfile.SpecID, nfProfile.APIName)
+	}
+}
+
+func TestChunksExpandsOneLevel(t *testing.T) {
+	store, _ := NewStore(crossFileDocs)
+	chunks := Chunks(store)
+
+	body := chunkByName(t, chunks, db.OpenAPIKindSchema, "NFProfile").Body
+
+	// A cross-file $ref is expanded, which is what makes the referenced type
+	// searchable from the schema that uses it.
+	for _, want := range []string{"nfInstanceId", "nfType", "# expanded:", "NF types known to the NRF"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("NFProfile body missing %q:\n%s", want, body)
+		}
+	}
+	// A $ref into a document the database does not hold stays a bare ref
+	// rather than failing the render.
+	if !strings.Contains(body, "$ref: TS29999_Missing.yaml#/components/schemas/Nowhere") {
+		t.Errorf("unresolvable ref should survive as text:\n%s", body)
+	}
+
+	// One level is the limit: PlmnId's own allOf expansion must not drag in a
+	// third level.
+	plmn := chunkByName(t, chunks, db.OpenAPIKindSchema, "PlmnId").Body
+	if strings.Count(plmn, "# expanded:") != 1 {
+		t.Errorf("PlmnId expanded more than one level:\n%s", plmn)
+	}
+}
+
+func TestChunksOperationBody(t *testing.T) {
+	store, _ := NewStore(crossFileDocs)
+	chunks := Chunks(store)
+
+	body := chunkByName(t, chunks, db.OpenAPIKindOperation, "PUT /nf-instances/{nfInstanceID}").Body
+	for _, want := range []string{
+		"PUT /nf-instances/{nfInstanceID}",
+		"summary: Register NF Instance",
+		"parameter: nfInstanceID",
+		"requestBody:",
+		"nfInstanceId",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("operation body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestChunksDeterministic(t *testing.T) {
+	// Go map iteration is random, so a rebuild that walked the parsed YAML
+	// directly would churn the index on every run.
+	store, _ := NewStore(crossFileDocs)
+	first := Chunks(store)
+	for i := 0; i < 5; i++ {
+		store, _ := NewStore(crossFileDocs)
+		got := Chunks(store)
+		if len(got) != len(first) {
+			t.Fatalf("chunk count changed between runs: %d vs %d", len(got), len(first))
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("chunk %d changed between runs:\n%+v\nvs\n%+v", j, got[j], first[j])
+			}
+		}
+	}
+}
+
+func TestNewStoreSkipsUnparsable(t *testing.T) {
+	docs := append([]db.OpenAPIDoc{{
+		SpecID: "TS 29.500", APIName: "Broken", Filename: "broken.yaml",
+		Content: "\topenapi: [unclosed\n",
+	}}, crossFileDocs...)
+
+	store, unparsable := NewStore(docs)
+	if unparsable != 1 {
+		t.Errorf("unparsable = %d, want 1", unparsable)
+	}
+	if len(store.Docs) != len(crossFileDocs) {
+		t.Errorf("kept %d documents, want %d", len(store.Docs), len(crossFileDocs))
+	}
+}
+
+func TestBuild(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+
+	stats, err := Build(t.Context(), d)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if stats.Documents != 1 {
+		t.Errorf("documents = %d, want 1", stats.Documents)
+	}
+	if stats.Schemas != 2 || stats.Operations != 2 {
+		t.Errorf("stats = %+v, want 2 schemas and 2 operations", stats)
+	}
+	if stats.Chunks != stats.Schemas+stats.Operations || stats.Bytes == 0 {
+		t.Errorf("stats = %+v, want consistent chunk count and non-zero bytes", stats)
+	}
+
+	// The chunks are searchable straight after the build.
+	got, err := d.SearchOpenAPI(t.Context(), "NFProfile", nil, "", "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("SearchOpenAPI: %v", err)
+	}
+	if len(got.Results) == 0 || got.Results[0].Name != "NFProfile" {
+		t.Errorf("search after build returned %+v", got.Results)
+	}
+}
+
+func TestBuildIsIdempotent(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+
+	first, err := Build(t.Context(), d)
+	if err != nil {
+		t.Fatalf("first Build: %v", err)
+	}
+	second, err := Build(t.Context(), d)
+	if err != nil {
+		t.Fatalf("second Build: %v", err)
+	}
+	if first != second {
+		t.Errorf("rebuild changed the index: %+v vs %+v", first, second)
+	}
+}

--- a/internal/openapiindex/openapiindex_test.go
+++ b/internal/openapiindex/openapiindex_test.go
@@ -274,9 +274,12 @@ components:
 // it cannot make sense of: it skips what it cannot read and keeps going,
 // rather than dropping the document or panicking.
 func TestChunksHandlesDegenerateDocuments(t *testing.T) {
-	store, parseErrs := NewStore([]db.OpenAPIDoc{{
-		SpecID: "TS 29.500", APIName: "Degenerate", Filename: "degenerate.yaml", Content: degenerateDoc,
-	}})
+	store, parseErrs := NewStore([]db.OpenAPIDoc{
+		{SpecID: "TS 29.500", APIName: "Degenerate", Filename: "degenerate.yaml", Content: degenerateDoc},
+		// A document with neither components nor paths contributes nothing,
+		// and a missing file name keeps it out of the cross-file lookup.
+		{SpecID: "TS 29.501", APIName: "Empty", Content: "openapi: 3.0.0\n"},
+	})
 	if len(parseErrs) != 0 {
 		t.Fatalf("parse errors = %v, want none", parseErrs)
 	}
@@ -456,6 +459,38 @@ func TestBuild(t *testing.T) {
 	}
 	if len(got.Results) == 0 || got.Results[0].Name != "NFProfile" {
 		t.Errorf("search after build returned %+v", got.Results)
+	}
+}
+
+// TestBuildReportsUnparsableDocuments checks that one bad document costs its
+// own chunks and nothing else: the rest of the corpus is still indexed, and
+// the count comes back so the caller can report it.
+func TestBuildReportsUnparsableDocuments(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	if err := d.UpsertOpenAPI("TS 29.500", "Broken", "v1", "broken.yaml", "\topenapi: [unclosed\n"); err != nil {
+		t.Fatalf("seed broken document: %v", err)
+	}
+
+	stats, err := Build(t.Context(), d)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if stats.Unparsable != 1 {
+		t.Errorf("unparsable = %d, want 1", stats.Unparsable)
+	}
+	if stats.Documents != 1 || stats.Chunks == 0 {
+		t.Errorf("stats = %+v, want the good document still indexed", stats)
+	}
+}
+
+func TestBuildOnUnreachableDatabase(t *testing.T) {
+	d := testutil.SetupTestDB(t)
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := Build(t.Context(), d); err == nil {
+		t.Error("Build succeeded on a closed database")
 	}
 }
 

--- a/internal/openapiindex/openapiindex_test.go
+++ b/internal/openapiindex/openapiindex_test.go
@@ -29,11 +29,16 @@ paths:
               $ref: '#/components/schemas/NFProfile'
     get:
       summary: Read NF Instance
+    options:
+      summary: Discover communication options
 components:
   schemas:
     NFProfile:
       type: object
       description: Information of an NF Instance
+      required:
+        - nfInstanceId
+        - nfType
       properties:
         nfInstanceId:
           type: string
@@ -41,6 +46,16 @@ components:
           $ref: 'TS29571_CommonData.yaml#/components/schemas/NFType'
         offRef:
           $ref: 'TS29999_Missing.yaml#/components/schemas/Nowhere'
+        nfServices:
+          type: array
+          items:
+            $ref: 'TS29571_CommonData.yaml#/components/schemas/NFService'
+        plmnIdList:
+          type: object
+          additionalProperties:
+            $ref: 'TS29571_CommonData.yaml#/components/schemas/PlmnId'
+    SupportedFeatures:
+      $ref: 'TS29571_CommonData.yaml#/components/schemas/NFType'
 `,
 	},
 	{
@@ -51,6 +66,15 @@ components:
     NFType:
       type: string
       description: NF types known to the NRF
+      enum:
+        - NRF
+        - AMF
+        - SMF
+    NFService:
+      type: object
+      properties:
+        serviceInstanceId:
+          type: string
     PlmnId:
       type: object
       allOf:
@@ -74,9 +98,9 @@ func chunkByName(t *testing.T, chunks []db.OpenAPIChunk, kind, name string) db.O
 }
 
 func TestChunks(t *testing.T) {
-	store, unparsable := NewStore(crossFileDocs)
-	if unparsable != 0 {
-		t.Fatalf("unparsable = %d, want 0", unparsable)
+	store, parseErrs := NewStore(crossFileDocs)
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse errors = %v, want none", parseErrs)
 	}
 	chunks := Chunks(store)
 
@@ -86,8 +110,11 @@ func TestChunks(t *testing.T) {
 	}
 	want := []string{
 		"schema NFProfile",
+		"schema SupportedFeatures",
 		"operation GET /nf-instances/{nfInstanceID}",
 		"operation PUT /nf-instances/{nfInstanceID}",
+		"operation OPTIONS /nf-instances/{nfInstanceID}",
+		"schema NFService",
 		"schema NFType",
 		"schema PlmnId",
 	}
@@ -128,6 +155,68 @@ func TestChunksExpandsOneLevel(t *testing.T) {
 	if strings.Count(plmn, "# expanded:") != 1 {
 		t.Errorf("PlmnId expanded more than one level:\n%s", plmn)
 	}
+}
+
+// TestChunksExpandsContainerRefs covers the shape most 5G SBI relationships
+// actually take: the type is behind items or additionalProperties, not behind
+// the property's own $ref.
+func TestChunksExpandsContainerRefs(t *testing.T) {
+	store, _ := NewStore(crossFileDocs)
+	body := chunkByName(t, Chunks(store), db.OpenAPIKindSchema, "NFProfile").Body
+
+	for _, want := range []string{
+		// items: the referenced type is named and its fields are expanded, so
+		// NFProfile is reachable from a search for NFService.
+		"items:", "NFService", "serviceInstanceId",
+		// additionalProperties: the map's value type, likewise.
+		"additionalProperties:", "PlmnId", "mcc",
+		// The property's own scalars survive alongside the container ref.
+		"type: array",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("NFProfile body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestChunksIndexesScalarLists covers enum and required, which are the text a
+// question quotes most directly.
+func TestChunksIndexesScalarLists(t *testing.T) {
+	chunks := Chunks(mustStore(t))
+
+	nfType := chunkByName(t, chunks, db.OpenAPIKindSchema, "NFType").Body
+	if !strings.Contains(nfType, "enum: NRF, AMF, SMF") {
+		t.Errorf("NFType body missing its enum:\n%s", nfType)
+	}
+	nfProfile := chunkByName(t, chunks, db.OpenAPIKindSchema, "NFProfile").Body
+	if !strings.Contains(nfProfile, "required: nfInstanceId, nfType") {
+		t.Errorf("NFProfile body missing its required list:\n%s", nfProfile)
+	}
+	// A list of mappings is structure, not text, and stays out.
+	if strings.Contains(nfProfile, "allOf: map[") {
+		t.Errorf("a composite list leaked into the body:\n%s", nfProfile)
+	}
+}
+
+// TestChunksRendersAliasSchema covers a schema that is nothing but a $ref,
+// which would otherwise index as its own name and no content at all.
+func TestChunksRendersAliasSchema(t *testing.T) {
+	body := chunkByName(t, Chunks(mustStore(t)), db.OpenAPIKindSchema, "SupportedFeatures").Body
+
+	for _, want := range []string{"$ref: TS29571_CommonData.yaml", "# expanded:", "NF types known to the NRF"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SupportedFeatures body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func mustStore(t *testing.T) *Store {
+	t.Helper()
+	store, parseErrs := NewStore(crossFileDocs)
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse errors = %v, want none", parseErrs)
+	}
+	return store
 }
 
 func TestChunksOperationBody(t *testing.T) {
@@ -173,9 +262,13 @@ func TestNewStoreSkipsUnparsable(t *testing.T) {
 		Content: "\topenapi: [unclosed\n",
 	}}, crossFileDocs...)
 
-	store, unparsable := NewStore(docs)
-	if unparsable != 1 {
-		t.Errorf("unparsable = %d, want 1", unparsable)
+	store, parseErrs := NewStore(docs)
+	if len(parseErrs) != 1 {
+		t.Fatalf("parse errors = %v, want 1", parseErrs)
+	}
+	// The error has to name the file, or an operator cannot act on it.
+	if !strings.Contains(parseErrs[0].Error(), "broken.yaml") {
+		t.Errorf("error does not name the document: %v", parseErrs[0])
 	}
 	if len(store.Docs) != len(crossFileDocs) {
 		t.Errorf("kept %d documents, want %d", len(store.Docs), len(crossFileDocs))

--- a/internal/openapiindex/openapiindex_test.go
+++ b/internal/openapiindex/openapiindex_test.go
@@ -210,6 +210,163 @@ func TestChunksRendersAliasSchema(t *testing.T) {
 	}
 }
 
+// degenerateDoc exercises the shapes a hand-written 3GPP YAML can take that
+// the renderer has to walk past rather than trip over.
+const degenerateDoc = `openapi: 3.0.0
+paths:
+  # A path item that is not a mapping, and a method that is not an operation.
+  /not-a-mapping: "nope"
+  /partial:
+    get: "also not a mapping"
+    post:
+      summary: Mixed scalars
+      parameters:
+        - "not a mapping"
+        - notAName: 1
+        - name: valid
+      requestBody:
+        $ref: '#/components/requestBodies/Shared'
+    put:
+      requestBody:
+        content:
+          text/plain: null
+          application/json:
+            schema:
+              type: object
+components:
+  schemas:
+    NotAMapping: "scalar schema"
+    Leaves:
+      type: object
+      deprecated: true
+      properties:
+        count:
+          type: integer
+          minimum: 1
+          multipleOf: 0.5
+          deprecated: false
+        notAMapping: "scalar property"
+        nested:
+          type: object
+          properties:
+            deeper:
+              type: string
+        offRef:
+          $ref: 'not a components pointer'
+        emptyList:
+          enum: []
+        listOfMappings:
+          oneOf:
+            - type: string
+    Composed:
+      allOf:
+        - "not a mapping"
+        - type: object
+          required:
+            - a
+          properties:
+            a:
+              type: string
+        - $ref: '#/components/schemas/NotAMapping'
+`
+
+// TestChunksHandlesDegenerateDocuments pins the renderer's behaviour on input
+// it cannot make sense of: it skips what it cannot read and keeps going,
+// rather than dropping the document or panicking.
+func TestChunksHandlesDegenerateDocuments(t *testing.T) {
+	store, parseErrs := NewStore([]db.OpenAPIDoc{{
+		SpecID: "TS 29.500", APIName: "Degenerate", Filename: "degenerate.yaml", Content: degenerateDoc,
+	}})
+	if len(parseErrs) != 0 {
+		t.Fatalf("parse errors = %v, want none", parseErrs)
+	}
+	chunks := Chunks(store)
+
+	var got []string
+	for _, c := range chunks {
+		got = append(got, c.Kind+" "+c.Name)
+	}
+	want := []string{
+		// NotAMapping is not a schema object and produces no chunk, and the
+		// operations come out in httpMethods order rather than document order.
+		"schema Composed",
+		"schema Leaves",
+		"operation PUT /partial",
+		"operation POST /partial",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("chunks = %v, want %v", got, want)
+	}
+
+	leaves := chunkByName(t, chunks, db.OpenAPIKindSchema, "Leaves").Body
+	for _, want := range []string{
+		"deprecated: false",              // bool leaf
+		"minimum: 1",                     // int leaf
+		"multipleOf: 0.5",                // float leaf
+		"$ref: not a components pointer", // an unrecognized ref stays as text
+	} {
+		if !strings.Contains(leaves, want) {
+			t.Errorf("Leaves body missing %q:\n%s", want, leaves)
+		}
+	}
+	// An empty list and a list of mappings are not leaf text.
+	if strings.Contains(leaves, "enum:") || strings.Contains(leaves, "map[") {
+		t.Errorf("a non-leaf list leaked into the body:\n%s", leaves)
+	}
+
+	composed := chunkByName(t, chunks, db.OpenAPIKindSchema, "Composed").Body
+	for _, want := range []string{"required: a", "property: a", "$ref: #/components/schemas/NotAMapping"} {
+		if !strings.Contains(composed, want) {
+			t.Errorf("Composed body missing %q:\n%s", want, composed)
+		}
+	}
+
+	post := chunkByName(t, chunks, db.OpenAPIKindOperation, "POST /partial").Body
+	if !strings.Contains(post, "parameter: valid") {
+		t.Errorf("POST body missing its one usable parameter:\n%s", post)
+	}
+	// A requestBody that is itself a $ref names a shared requestBody object,
+	// not a schema, so nothing is expanded for it.
+	if strings.Contains(post, "requestBody:") {
+		t.Errorf("a $ref requestBody should not be expanded:\n%s", post)
+	}
+	// An inline schema with no $ref has nothing to resolve either.
+	if put := chunkByName(t, chunks, db.OpenAPIKindOperation, "PUT /partial").Body; strings.Contains(put, "requestBody:") {
+		t.Errorf("an inline request schema should not be expanded:\n%s", put)
+	}
+}
+
+// TestResolveRejectsUnknownTargets covers the refs that lead out of the store.
+func TestResolveRejectsUnknownTargets(t *testing.T) {
+	store := mustStore(t)
+	doc := store.Docs[0]
+
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{"not a schema pointer", "#/components/parameters/Foo"},
+		{"empty", ""},
+		{"file not in the store", "TS29999_Missing.yaml#/components/schemas/Nowhere"},
+		{"schema not in the file", "#/components/schemas/Nowhere"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, _, ok := store.Resolve(doc, tt.ref); ok {
+				t.Errorf("Resolve(%q) resolved, want not found", tt.ref)
+			}
+		})
+	}
+}
+
+func TestStatsString(t *testing.T) {
+	got := Stats{Documents: 4, Chunks: 214, Schemas: 191, Operations: 23}.String()
+	want := "214 chunks (191 schemas, 23 operations) from 4 OpenAPI documents"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
 func mustStore(t *testing.T) *Store {
 	t.Helper()
 	store, parseErrs := NewStore(crossFileDocs)

--- a/internal/openapiindex/render.go
+++ b/internal/openapiindex/render.go
@@ -6,8 +6,10 @@ import (
 )
 
 // httpMethods are the operation keys read out of a path item, in the order
-// their chunks are emitted.
-var httpMethods = []string{"get", "put", "post", "patch", "delete"}
+// their chunks are emitted. It is the full OpenAPI set rather than the four
+// verbs the SBI APIs mostly use, so a rarer one (TS 29.510 defines an OPTIONS
+// operation) still gets a chunk.
+var httpMethods = []string{"get", "put", "post", "patch", "delete", "head", "options", "trace"}
 
 // Operation is one method of one path.
 type Operation struct {
@@ -77,9 +79,28 @@ func (s *Store) RequestSchema(doc *Doc, op map[string]any) (*Doc, string, map[st
 func (s *Store) RenderSchema(doc *Doc, name string, schema map[string]any, depth int) string {
 	out := []string{name + ":"}
 
+	// A schema that is nothing but a $ref is an alias for another type. Without
+	// this the chunk would be its own name and nothing else.
+	if ref, _ := schema["$ref"].(string); ref != "" {
+		out = append(out, "  $ref: "+ref)
+		if target, tName, tSchema, ok := s.expand(doc, ref, depth); ok {
+			out = append(out, "  # expanded:")
+			out = append(out, indent(s.RenderSchema(target, tName, tSchema, depth+1), "  ")...)
+		}
+	}
+
 	for _, key := range []string{"type", "description"} {
 		if v, ok := schema[key].(string); ok {
 			out = append(out, "  "+key+": "+v)
+		}
+	}
+
+	// enum and required are lists of leaves, and they are the text a question
+	// often quotes — a status value like REGISTERED, or the field a request is
+	// rejected for missing.
+	for _, key := range []string{"enum", "required"} {
+		if line, ok := scalarLine("  "+key, schema[key]); ok {
+			out = append(out, line)
 		}
 	}
 
@@ -105,8 +126,8 @@ func (s *Store) RenderSchema(doc *Doc, name string, schema map[string]any, depth
 				continue
 			}
 			for _, k := range sortedKeys(m) {
-				if v, ok := scalar(m[k]); ok {
-					out = append(out, "    - "+k+": "+v)
+				if line, ok := scalarLine("    - "+k, m[k]); ok {
+					out = append(out, line)
 				}
 			}
 			if props, ok := m["properties"].(map[string]any); ok {
@@ -133,14 +154,44 @@ func (s *Store) RenderSchema(doc *Doc, name string, schema map[string]any, depth
 				}
 			}
 			for _, k := range sortedKeys(v) {
-				if sv, ok := scalar(v[k]); ok {
-					out = append(out, "      "+k+": "+sv)
+				if line, ok := scalarLine("      "+k, v[k]); ok {
+					out = append(out, line)
 				}
 			}
+			out = append(out, s.renderContainerRefs(doc, v, depth)...)
 		}
 	}
 
 	return strings.Join(out, "\n")
+}
+
+// containerKeys are the wrappers a property puts between itself and the type it
+// actually holds.
+var containerKeys = []string{"items", "additionalProperties"}
+
+// renderContainerRefs renders the $ref a property holds through a container.
+// The 5G SBI definitions state most of their relationships this way — a list is
+// `items: {$ref: NFService}` and a map is `additionalProperties: {$ref:
+// AmfInfo}` — so reading only a property's direct $ref drops the majority of
+// them, and with them every occurrence of the referenced type's name.
+func (s *Store) renderContainerRefs(doc *Doc, prop map[string]any, depth int) []string {
+	var out []string
+	for _, key := range containerKeys {
+		inner, _ := prop[key].(map[string]any)
+		if inner == nil {
+			continue
+		}
+		ref, _ := inner["$ref"].(string)
+		if ref == "" {
+			continue
+		}
+		out = append(out, "      "+key+":", "        $ref: "+ref)
+		if target, tName, tSchema, ok := s.expand(doc, ref, depth); ok {
+			out = append(out, "        # expanded:")
+			out = append(out, indent(s.RenderSchema(target, tName, tSchema, depth+1), "        ")...)
+		}
+	}
+	return out
 }
 
 // expand resolves ref only at the top level of a chunk, which is what keeps
@@ -164,6 +215,29 @@ func scalar(v any) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// scalarLine renders "key: value" for a leaf, or for a list of leaves as a
+// comma-separated run. key carries its own indentation.
+func scalarLine(key string, v any) (string, bool) {
+	if s, ok := scalar(v); ok {
+		return key + ": " + s, true
+	}
+	items, ok := v.([]any)
+	if !ok || len(items) == 0 {
+		return "", false
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := scalar(item)
+		if !ok {
+			// A list of mappings is structure, not text; it belongs to a
+			// deeper level than this rendering goes.
+			return "", false
+		}
+		parts = append(parts, s)
+	}
+	return key + ": " + strings.Join(parts, ", "), true
 }
 
 // indent prefixes every line of text.

--- a/internal/openapiindex/render.go
+++ b/internal/openapiindex/render.go
@@ -1,0 +1,176 @@
+package openapiindex
+
+import (
+	"fmt"
+	"strings"
+)
+
+// httpMethods are the operation keys read out of a path item, in the order
+// their chunks are emitted.
+var httpMethods = []string{"get", "put", "post", "patch", "delete"}
+
+// Operation is one method of one path.
+type Operation struct {
+	Path   string
+	Method string
+	Op     map[string]any
+}
+
+// Operations returns doc's operations, ordered by path then by method.
+func (s *Store) Operations(doc *Doc) []Operation {
+	paths, _ := doc.Root["paths"].(map[string]any)
+	if paths == nil {
+		return nil
+	}
+	var ops []Operation
+	for _, p := range sortedKeys(paths) {
+		item, _ := paths[p].(map[string]any)
+		if item == nil {
+			continue
+		}
+		for _, method := range httpMethods {
+			if op, ok := item[method].(map[string]any); ok {
+				ops = append(ops, Operation{Path: p, Method: method, Op: op})
+			}
+		}
+	}
+	return ops
+}
+
+// RequestSchema resolves the schema an operation's request body carries. A
+// requestBody that is itself a $ref names a shared requestBody object rather
+// than a schema, and is left alone.
+func (s *Store) RequestSchema(doc *Doc, op map[string]any) (*Doc, string, map[string]any, bool) {
+	body, _ := op["requestBody"].(map[string]any)
+	if body == nil {
+		return nil, "", nil, false
+	}
+	if _, isRef := body["$ref"]; isRef {
+		return nil, "", nil, false
+	}
+	content, _ := body["content"].(map[string]any)
+	for _, mediaType := range sortedKeys(content) {
+		media, _ := content[mediaType].(map[string]any)
+		if media == nil {
+			continue
+		}
+		schema, _ := media["schema"].(map[string]any)
+		if schema == nil {
+			continue
+		}
+		if ref, _ := schema["$ref"].(string); ref != "" {
+			return s.Resolve(doc, ref)
+		}
+	}
+	return nil, "", nil, false
+}
+
+// RenderSchema renders a schema as YAML-ish text with one level of $ref
+// expanded.
+//
+// One level is what makes a chunk self-contained enough to answer "what fields
+// does this have" without the reader resolving the whole reference graph, and
+// it is also the limit: an answer sitting two hops away is not in any single
+// chunk. Expanding further would multiply the index size — these schemas
+// reference each other densely — for text that is already reachable through
+// get_openapi.
+func (s *Store) RenderSchema(doc *Doc, name string, schema map[string]any, depth int) string {
+	out := []string{name + ":"}
+
+	for _, key := range []string{"type", "description"} {
+		if v, ok := schema[key].(string); ok {
+			out = append(out, "  "+key+": "+v)
+		}
+	}
+
+	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+		members, ok := schema[key].([]any)
+		if !ok {
+			continue
+		}
+		out = append(out, "  "+key+":")
+		for _, member := range members {
+			m, ok := member.(map[string]any)
+			if !ok {
+				continue
+			}
+			ref, _ := m["$ref"].(string)
+			if ref != "" {
+				if target, tName, tSchema, ok := s.expand(doc, ref, depth); ok {
+					out = append(out, "    - $ref: "+ref, "      # expanded:")
+					out = append(out, indent(s.RenderSchema(target, tName, tSchema, depth+1), "      ")...)
+				} else {
+					out = append(out, "    - $ref: "+ref)
+				}
+				continue
+			}
+			for _, k := range sortedKeys(m) {
+				if v, ok := scalar(m[k]); ok {
+					out = append(out, "    - "+k+": "+v)
+				}
+			}
+			if props, ok := m["properties"].(map[string]any); ok {
+				for _, p := range sortedKeys(props) {
+					out = append(out, "      property: "+p)
+				}
+			}
+		}
+	}
+
+	if props, ok := schema["properties"].(map[string]any); ok {
+		out = append(out, "  properties:")
+		for _, p := range sortedKeys(props) {
+			out = append(out, "    "+p+":")
+			v, ok := props[p].(map[string]any)
+			if !ok {
+				continue
+			}
+			if ref, _ := v["$ref"].(string); ref != "" {
+				if target, tName, tSchema, ok := s.expand(doc, ref, depth); ok {
+					out = append(out, "      $ref: "+ref, "      # expanded:")
+					out = append(out, indent(s.RenderSchema(target, tName, tSchema, depth+1), "      ")...)
+					continue
+				}
+			}
+			for _, k := range sortedKeys(v) {
+				if sv, ok := scalar(v[k]); ok {
+					out = append(out, "      "+k+": "+sv)
+				}
+			}
+		}
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// expand resolves ref only at the top level of a chunk, which is what keeps
+// the expansion one level deep.
+func (s *Store) expand(doc *Doc, ref string, depth int) (*Doc, string, map[string]any, bool) {
+	if depth != 0 {
+		return nil, "", nil, false
+	}
+	return s.Resolve(doc, ref)
+}
+
+// scalar formats a leaf value for the rendered text, reporting false for
+// anything composite: a nested mapping or list belongs to a deeper level than
+// this rendering goes.
+func scalar(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool, int, int64, uint64, float64:
+		return fmt.Sprintf("%v", t), true
+	default:
+		return "", false
+	}
+}
+
+// indent prefixes every line of text.
+func indent(text, prefix string) []string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return lines
+}

--- a/internal/openapiindex/store.go
+++ b/internal/openapiindex/store.go
@@ -14,6 +14,7 @@
 package openapiindex
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 
@@ -40,16 +41,20 @@ type Store struct {
 // followed by a pointer into components.schemas.
 var refRE = regexp.MustCompile(`^([^#]*)#/components/schemas/([\w.-]+)$`)
 
-// NewStore parses docs, skipping any that are not a YAML mapping. Documents
-// that fail to parse are reported by count so a build can surface them without
-// failing over one bad file.
-func NewStore(docs []db.OpenAPIDoc) (*Store, int) {
+// NewStore parses docs, skipping any that are not a YAML mapping. A bad file
+// is returned as an error naming it rather than failing the whole build, so
+// one unparsable document costs its own chunks and nothing else.
+func NewStore(docs []db.OpenAPIDoc) (*Store, []error) {
 	s := &Store{byFile: make(map[string]*Doc, len(docs))}
-	skipped := 0
+	var errs []error
 	for _, d := range docs {
 		var root map[string]any
-		if err := yaml.Unmarshal([]byte(d.Content), &root); err != nil || root == nil {
-			skipped++
+		if err := yaml.Unmarshal([]byte(d.Content), &root); err != nil {
+			errs = append(errs, fmt.Errorf("parse %s (%s %s): %w", d.Filename, d.SpecID, d.APIName, err))
+			continue
+		}
+		if root == nil {
+			errs = append(errs, fmt.Errorf("parse %s (%s %s): not a YAML mapping", d.Filename, d.SpecID, d.APIName))
 			continue
 		}
 		doc := &Doc{SpecID: d.SpecID, APIName: d.APIName, Filename: d.Filename, Root: root}
@@ -61,7 +66,7 @@ func NewStore(docs []db.OpenAPIDoc) (*Store, int) {
 			s.byFile[d.Filename] = doc
 		}
 	}
-	return s, skipped
+	return s, errs
 }
 
 // Schemas returns doc's components.schemas mapping, or nil.

--- a/internal/openapiindex/store.go
+++ b/internal/openapiindex/store.go
@@ -1,0 +1,110 @@
+// Package openapiindex turns the OpenAPI YAML documents stored in
+// openapi_specs into the search index behind the search_openapi tool: one row
+// per schema and one per operation, rather than one per document.
+//
+// The unit matters. A 5G SBI document is tens of thousands of lines and names
+// hundreds of data types, so a document-level hit says little more than
+// list_openapi already says. A schema or an operation is the thing a question
+// is actually about ("what does NFProfile carry", "what does PUT
+// /nf-instances/{id} take"), and it is small enough to read.
+//
+// Chunks are rebuilt from the whole table at once, never per document: in the
+// 5G SBI definitions most $refs point into another file, so a document's own
+// chunks depend on documents that were not necessarily imported with it.
+package openapiindex
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"gopkg.in/yaml.v3"
+)
+
+// Doc is one parsed OpenAPI document.
+type Doc struct {
+	SpecID   string
+	APIName  string
+	Filename string
+	Root     map[string]any
+}
+
+// Store holds every parsed document, cross-linked by file name so a $ref can
+// be followed out of the document that wrote it.
+type Store struct {
+	Docs   []*Doc
+	byFile map[string]*Doc
+}
+
+// refRE matches the only $ref form these documents use: an optional file name
+// followed by a pointer into components.schemas.
+var refRE = regexp.MustCompile(`^([^#]*)#/components/schemas/([\w.-]+)$`)
+
+// NewStore parses docs, skipping any that are not a YAML mapping. Documents
+// that fail to parse are reported by count so a build can surface them without
+// failing over one bad file.
+func NewStore(docs []db.OpenAPIDoc) (*Store, int) {
+	s := &Store{byFile: make(map[string]*Doc, len(docs))}
+	skipped := 0
+	for _, d := range docs {
+		var root map[string]any
+		if err := yaml.Unmarshal([]byte(d.Content), &root); err != nil || root == nil {
+			skipped++
+			continue
+		}
+		doc := &Doc{SpecID: d.SpecID, APIName: d.APIName, Filename: d.Filename, Root: root}
+		s.Docs = append(s.Docs, doc)
+		// A document with no file name cannot be the target of a cross-file
+		// $ref, and indexing it under "" would make every such document
+		// collide with the others.
+		if d.Filename != "" {
+			s.byFile[d.Filename] = doc
+		}
+	}
+	return s, skipped
+}
+
+// Schemas returns doc's components.schemas mapping, or nil.
+func (s *Store) Schemas(doc *Doc) map[string]any {
+	comp, _ := doc.Root["components"].(map[string]any)
+	if comp == nil {
+		return nil
+	}
+	schemas, _ := comp["schemas"].(map[string]any)
+	return schemas
+}
+
+// Resolve follows a $ref to the schema it names. It reports false when the ref
+// is not a components.schemas pointer, or names a file this store does not
+// hold — 3GPP documents also reference schemas from specifications outside the
+// database, and those simply stay unexpanded.
+func (s *Store) Resolve(doc *Doc, ref string) (*Doc, string, map[string]any, bool) {
+	m := refRE.FindStringSubmatch(ref)
+	if m == nil {
+		return nil, "", nil, false
+	}
+	target := doc
+	if m[1] != "" {
+		target = s.byFile[m[1]]
+		if target == nil {
+			return nil, "", nil, false
+		}
+	}
+	schema, _ := s.Schemas(target)[m[2]].(map[string]any)
+	if schema == nil {
+		return nil, "", nil, false
+	}
+	return target, m[2], schema, true
+}
+
+// sortedKeys returns m's keys in a fixed order. Go map iteration is random and
+// yaml.Unmarshal into a map drops document order, so every rendering loop goes
+// through here to keep a rebuild byte-identical to the last one.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,16 +59,30 @@ paths:
   /nf-instances:
     get:
       summary: List NF Instances
+      parameters:
+        - name: target-nf-type
+          in: query
   /nf-instances/{nfInstanceID}:
     put:
       summary: Register NF Instance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ''#/components/schemas/NFProfile''
 components:
   schemas:
     NFProfile:
       type: object
+      description: Information of an NF Instance registered in the NRF
       properties:
         nfInstanceId:
-          type: string');
+          type: string
+        nfType:
+          $ref: ''#/components/schemas/NFType''
+    NFType:
+      type: string
+      description: NF types known to the NRF');
 `
 
 // SetupTestDB creates a temporary SQLite database with the standard schema and seed data.

--- a/tools/search_openapi.go
+++ b/tools/search_openapi.go
@@ -1,0 +1,80 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type SearchOpenAPIInput struct {
+	Query       string   `json:"query" jsonschema:"required,FTS5 query string. Hyphenated or dotted terms like nf-instances and 29.510 are auto-quoted. Use AND/OR/NOT operators and double-quoted phrases for exact matches."`
+	SpecIDs     []string `json:"spec_ids,omitempty" jsonschema:"Limit the search to one or more specifications (e.g. [\"TS 29.510\", \"TS 29.518\"])."`
+	APIName     string   `json:"api_name,omitempty" jsonschema:"Limit the search to a single API document (e.g. Nnrf_NFManagement). Use list_openapi to see the available names."`
+	Kind        string   `json:"kind,omitempty" jsonschema:"Limit the search to one kind of definition: \"schema\" for data types or \"operation\" for endpoints. Both are searched when omitted."`
+	IncludeBody bool     `json:"include_body,omitempty" jsonschema:"Return the full text of each matching definition instead of a snippet (default: false). Costs many more tokens; prefer the default and follow up with get_openapi."`
+	Limit       int      `json:"limit,omitempty" jsonschema:"Maximum number of results per page (default: 10, max: 200)"`
+	Offset      int      `json:"offset,omitempty" jsonschema:"Number of results to skip for pagination (default: 0). Combine with total_count in the response to page through all matches."`
+}
+
+var SearchOpenAPITool = &mcp.Tool{
+	Name: "search_openapi",
+	Description: `Full-text search across the OpenAPI definitions of the 5G service-based interface APIs (TS 29.xxx series), using SQLite FTS5 syntax.
+
+Use this when you need an API detail but do not know which API document holds it — searching for a data type (NFProfile, SmContextCreateData) or an endpoint (/nf-instances, subscriptions) finds it without guessing an api_name first. When you already know the document, get_openapi reads it directly.
+
+This is a separate index from the search tool: search covers specification clause text and never returns OpenAPI content, and this tool covers OpenAPI content only.
+
+Results:
+- One hit is one definition, not one document: either a schema (a data type from components.schemas) or an operation (one HTTP method of one path, named like "PUT /nf-instances/{nfInstanceID}").
+- A query that is a single bare term ranks a definition of exactly that name first, so searching NFProfile returns the NFProfile schema itself ahead of the schemas that merely reference it.
+- Each hit reports spec_id, api_name, kind, name and a snippet. Pass those to get_openapi (with its schema or path parameter) to read the full definition.
+- A schema's text carries one level of $ref expansion, so referenced field names are searchable, but a type two hops away is not. Follow it up with get_openapi.
+- Set include_body to get the matched definition's full text inline. It is much larger than a snippet.
+
+Query syntax:
+- AND/OR/NOT:    NFProfile AND heartbeat
+- Phrase:        "nf instances"
+- Prefix:        subscri*
+- Column filter: name:NFProfile  or  body:nfInstanceId  or  api_name:Nnrf_NFManagement
+- Hyphenated, dotted or underscored terms (e.g. nf-instances, 29.510, Nnrf_NFManagement) are auto-quoted to avoid FTS5 syntax errors.
+
+Tokenization:
+- Unlike search, this index applies no stemming: identifiers are matched as written, and inflected English forms do not fold together.
+- '-', '.' and '_' split tokens, so Nnrf_NFManagement is indexed as "nnrf" and "nfmanagement" and /nf-instances as "nf" and "instances" — a partial name matches, but camelCase is not split (supportedFeatures is one token).
+
+Pagination:
+- Results come as {results, total_count, limit, offset}; total_count is the full match count.
+- Use limit (default 10, max 200) and offset to page through matches beyond the first page.`,
+}
+
+func HandleSearchOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input SearchOpenAPIInput) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchOpenAPIInput) (*mcp.CallToolResult, any, error) {
+		if input.Query == "" {
+			return errorResult("query is required"), nil, nil
+		}
+
+		offset := input.Offset
+		if offset < 0 {
+			offset = 0
+		}
+
+		results, err := d.SearchOpenAPI(ctx, input.Query, input.SpecIDs, input.APIName, input.Kind, input.IncludeBody, input.Limit, offset)
+		if err != nil {
+			if errors.Is(err, db.ErrNoOpenAPIIndex) {
+				return errorResult("This database has no OpenAPI search index. It was built before search_openapi existed; rebuild it with \"3gpp-mcp build-openapi-index --db <path>\", or use list_openapi and get_openapi instead."), nil, nil
+			}
+			return errorResult(fmt.Sprintf("search failed: %v", err)), nil, nil
+		}
+
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to marshal: %v", err)), nil, nil
+		}
+
+		return textResult(string(data)), nil, nil
+	}
+}

--- a/tools/search_openapi_test.go
+++ b/tools/search_openapi_test.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/openapiindex"
+	"github.com/higebu/3gpp-mcp/internal/testutil"
+)
+
+func setupOpenAPISearchDB(t *testing.T) *db.DB {
+	t.Helper()
+	d := testutil.SetupTestDB(t)
+	if _, err := openapiindex.Build(context.Background(), d); err != nil {
+		t.Fatalf("build openapi index: %v", err)
+	}
+	return d
+}
+
+func TestHandleSearchOpenAPI(t *testing.T) {
+	d := setupOpenAPISearchDB(t)
+	handler := HandleSearchOpenAPI(d)
+
+	tests := []struct {
+		name  string
+		input SearchOpenAPIInput
+		want  []string
+		none  bool
+	}{
+		{
+			name:  "schema by name",
+			input: SearchOpenAPIInput{Query: "NFProfile"},
+			want:  []string{"NFProfile", "\"kind\": \"schema\"", "TS 29.510", "Nnrf_NFManagement"},
+		},
+		{
+			name:  "operation by path",
+			input: SearchOpenAPIInput{Query: "nf-instances", Kind: db.OpenAPIKindOperation},
+			want:  []string{"/nf-instances", "\"kind\": \"operation\""},
+		},
+		{
+			name:  "spec filter excludes",
+			input: SearchOpenAPIInput{Query: "NFProfile", SpecIDs: []string{"TS 23.501"}},
+			none:  true,
+		},
+		{
+			name:  "api filter",
+			input: SearchOpenAPIInput{Query: "NFProfile", APIName: "Nnrf_NFManagement"},
+			want:  []string{"NFProfile"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, err := handler(context.Background(), nil, tt.input)
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %s", getTextContent(result))
+			}
+			text := getTextContent(result)
+
+			var got db.OpenAPISearchResults
+			if err := json.Unmarshal([]byte(text), &got); err != nil {
+				t.Fatalf("unmarshal %q: %v", text, err)
+			}
+			if tt.none {
+				if got.TotalCount != 0 {
+					t.Errorf("total_count = %d, want 0", got.TotalCount)
+				}
+				return
+			}
+			if got.TotalCount == 0 {
+				t.Fatalf("no results for %+v", tt.input)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(text, want) {
+					t.Errorf("result missing %q:\n%s", want, text)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleSearchOpenAPIIncludeBody(t *testing.T) {
+	d := setupOpenAPISearchDB(t)
+	handler := HandleSearchOpenAPI(d)
+
+	result, _, err := handler(context.Background(), nil, SearchOpenAPIInput{Query: "name:NFProfile"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if strings.Contains(getTextContent(result), "\"body\"") {
+		t.Error("body should be omitted unless include_body is set")
+	}
+
+	result, _, err = handler(context.Background(), nil, SearchOpenAPIInput{Query: "name:NFProfile", IncludeBody: true})
+	if err != nil {
+		t.Fatalf("handler with body: %v", err)
+	}
+	if !strings.Contains(getTextContent(result), "nfInstanceId") {
+		t.Errorf("include_body should return the full chunk:\n%s", getTextContent(result))
+	}
+}
+
+func TestHandleSearchOpenAPIErrors(t *testing.T) {
+	d := setupOpenAPISearchDB(t)
+	handler := HandleSearchOpenAPI(d)
+
+	t.Run("empty query", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, SearchOpenAPIInput{})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if !result.IsError {
+			t.Error("empty query should be a tool error")
+		}
+	})
+
+	t.Run("unknown kind", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, SearchOpenAPIInput{Query: "NFProfile", Kind: "component"})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if !result.IsError {
+			t.Error("unknown kind should be a tool error")
+		}
+	})
+}
+
+func TestHandleSearchOpenAPIWithoutIndex(t *testing.T) {
+	// A database from before search_openapi existed answers with the rebuild
+	// instructions rather than a bare SQL error.
+	d := testutil.SetupTestDB(t)
+	if err := d.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+
+	result, _, err := HandleSearchOpenAPI(d)(context.Background(), nil, SearchOpenAPIInput{Query: "NFProfile"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !result.IsError || !strings.Contains(getTextContent(result), "build-openapi-index") {
+		t.Errorf("want a rebuild hint, got: %s", getTextContent(result))
+	}
+}

--- a/tools/search_openapi_test.go
+++ b/tools/search_openapi_test.go
@@ -120,6 +120,23 @@ func TestHandleSearchOpenAPIErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("negative offset starts at the beginning", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, SearchOpenAPIInput{Query: "NFProfile", Offset: -5})
+		if err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error: %s", getTextContent(result))
+		}
+		var got db.OpenAPISearchResults
+		if err := json.Unmarshal([]byte(getTextContent(result)), &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Offset != 0 {
+			t.Errorf("offset = %d, want 0", got.Offset)
+		}
+	})
+
 	t.Run("unknown kind", func(t *testing.T) {
 		result, _, err := handler(context.Background(), nil, SearchOpenAPIInput{Query: "NFProfile", Kind: "component"})
 		if err != nil {


### PR DESCRIPTION
`search` indexes specification clause text only, so the OpenAPI definitions —
sitting in `openapi_specs` as raw YAML — could not be searched at all. Answering
"what does NFProfile carry" or "which API defines PATCH /nf-instances/{id}" meant
guessing an `api_name` for `list_openapi` first, and failing if you did not know it.

This adds a second FTS5 index over the OpenAPI content, kept entirely separate from
`sections_fts`.

## What it does

- `openapi_chunks` / `openapi_chunks_fts` hold **one row per schema and per operation**,
  not per document, so a hit is the thing the question is about: a `components.schemas`
  entry, or one HTTP method of one path (`PUT /nf-instances/{nfInstanceID}`).
- `internal/openapiindex` renders the chunks from the parsed YAML, expanding `$ref`
  exactly one level — including through `items` and `additionalProperties`, which is how
  the 5G SBI definitions state most of their relationships.
- MCP tool `search_openapi` (`query`, `spec_ids`, `api_name`, `kind`, `include_body`,
  `limit`, `offset`) and the matching `search-openapi` CLI subcommand.
- `build-openapi-index` rebuilds the index of an existing database.

`sections_fts` and the `search` tool are untouched.

## Design notes

- **Rebuilt wholesale, never incrementally.** Most `$ref`s cross into another file, so
  importing one document changes the chunks of documents imported before it. `build` and
  `update` rebuild when they finish; `import` / `import-dir` do not, because a `.docx`
  import cannot write `openapi_specs`.
- **No porter stemming.** These rows are identifiers, not prose. `-`, `.` and `_` split
  tokens, so `Nnrf_NFManagement` is also found by `NFManagement`; camelCase is not split.
- **Exact-name hits rank first.** bm25 normalizes by length, and these chunks differ in
  size by three orders of magnitude — the real `NFProfile` schema renders to ~39 KB and
  ranked 8th behind schemas that merely mention it. A single bare term now ranks an
  exact name match, then a substring match, ahead of bm25.
- **The index is never stale.** A rebuild that fails after `openapi_specs` was rewritten
  drops the index rather than leaving chunks that describe the previous corpus, so the
  only failure mode is the honest "missing" one. A failed standalone
  `build-openapi-index` keeps the existing index, which nothing has invalidated.
- **Old databases degrade gracefully.** `serve` opens read-only and cannot create the
  tables, so `SearchOpenAPI` returns `ErrNoOpenAPIIndex` and the tool points at
  `build-openapi-index` instead of failing with a SQL error.

## Verification

`go build`, `gofmt`, `go vet` and `go test ./... -short` all pass. Beyond the unit tests,
the index was built from the real archive (`build --spec 29.510 --latest`) and queried
end to end: 214 chunks from 4 documents, `NFProfile` first for `NFProfile`, operations
found by path fragment, `--body`, `build-openapi-index` re-run, and the missing-index
message on a database with the tables dropped.