### PR TITLE
docs: name the baseline the clause-tree gain is measured against

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -276,10 +276,12 @@ on — 50 kB to 537 kB of text per task, a median of 57 clauses — which
 |---|---|---|---|---|
 | Clause-tree references | 2% | 0% | 82% | **86%** |
 
-+86pt over the strongest baseline, and rounds 2 through 20 are worth **+4pt, 9
-wins to 7 losses, p=0.803** — nothing, bought with 13 more tool calls per task
-and 30 times the prompt tokens. Where one call already *is* the aggregation, the
-reading the extra rounds buy is reading the model did not need.
++84pt over the strongest baseline — 42 wins to 0 losses against no tools, and
++86pt with 43/0 against fixed-k, which here is the *weaker* of the two — and
+rounds 2 through 20 are worth **+4pt, 9 wins to 7 losses, p=0.803**: nothing,
+bought with 13 more tool calls per task and 30 times the prompt tokens. Where
+one call already *is* the aggregation, the reading the extra rounds buy is
+reading the model did not need.
 
 **`search_openapi` is a cost, not an accuracy.** Repeating the three
 designation types with the FTS index over the OpenAPI store dropped — the server
@@ -380,9 +382,9 @@ names a schema without saying where it lives.
   engineer's question.
 - n=50 per task type, one pass per condition on that set — enough for the
   +24 to +88pt differences, not for the small ones. The three designation types
-  are n=21: they share one pool of schemas, and 22 of the corpus's 5,664
-  described schemas survive a test that no *other* schema fits the same
-  description.
+  are n=21: they share one pool of schemas, 22 of the corpus's 5,664 described
+  schemas survive a test that no *other* schema fits the same description, and
+  21 of those 22 are selected under a cap of two per API document.
 - The depth and designation tracks ran on DeepSeek only. Their 20-round columns
   sit at 95-100%, where a second model can only tie; the column with room is one
   round, and that is what they were priced to measure.


### PR DESCRIPTION
Two review findings on #189, both valid, fixed after it merged.

**The clause-tree gain named the wrong baseline.** "+86pt over the strongest
baseline" does not follow from its own table: the strongest baseline there is no
tools at 2%, not fixed-k at 0%. Recomputed from the graded runs, 20 rounds beats
no tools by +84pt (42 wins / 0 losses) and fixed-k by +86pt (43/0). The text now
gives both and says which is which, since the point being made is that both
baselines sit on the floor.

The reviewer read the sentence as a claim about the one-round column and
proposed 80pt; that part is a misreading — the sentence is about 20 rounds — but
the mismatch it found is real.

**22 schemas survive the uniqueness test, 21 are used.** The step between them
was a cap of two per API document, which was stated in the private report and
dropped here. Now stated.

Nothing else in the section changed: the NGAP/S1AP table and the +86pt / +28pt
against the same model one round earlier (43/0 and 14/0) recompute exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174KLG8PUGvvr91ynbhiZFJ)_