### PR TITLE
fix: stop reference regexes from matching across a blank line

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1538,7 +1538,10 @@ const coordElemTail = `(?:(?:of|in)` + spPlus + `(?:[Cc]lauses?|[Ss]ections?|[Ss
 // " and 4.4", ", and 4.4", "; or Annex B", " and in clause 4.12.2a") so
 // bareTrailingQualRE and barePresentDocRE can see through a list to the
 // "of"/"in" that qualifies its every element.
-const bareRefChain = `(?:` + spStar + `(?:[,;]` + spStar + `(?:and|or)?|and|or)` + spStar + coordElemTail + `)*`
+// Each element keeps its separators in one run per gap — a comma with no
+// conjunction after it must not put two runs side by side, or the pair spans a
+// blank line and the chain reads a qualifier out of the next block.
+const bareRefChain = `(?:` + spStar + `(?:[,;]` + spStar + `(?:(?:and|or)` + spStar + `)?|(?:and|or)` + spStar + `)` + coordElemTail + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"

--- a/db/db.go
+++ b/db/db.go
@@ -1486,9 +1486,39 @@ const (
 )
 
 // Compiled regex patterns for extracting cross-references from section content.
-// sp matches ASCII whitespace plus NO-BREAK SPACE (U+00A0) and DEGREE SIGN (U+00B0)
-// which appear in 3GPP DOCX documents as word separators.
-const sp = `[\s\x{00a0}\x{00b0}]`
+// sp matches one horizontal separator: ASCII whitespace plus NO-BREAK SPACE
+// (U+00A0) and DEGREE SIGN (U+00B0), which appear in 3GPP DOCX documents as
+// word separators. Line breaks are deliberately absent — spPlus/spStar are the
+// quantified forms the patterns use, and they bound how far a separator run may
+// cross a line.
+const sp = `[ \t\f\x{00a0}\x{00b0}]`
+
+// lineBreak matches one line ending, CRLF, CR or LF.
+const lineBreak = `(?:\r\n?|\n)`
+
+// spPlus and spStar are the "one or more" and "zero or more" separator runs the
+// reference patterns use in place of sp+ and sp*. A run carries at most one line
+// break, so a reference can span a soft break inside a paragraph (a w:br becomes
+// a "\n") but never a blank line: blocks are joined with "\n\n", so a match
+// across one would emit a link or an unresolved marker spanning a block
+// boundary, and the two blocks would render merged into one — a heading
+// swallowing the paragraph after it (issue #191).
+const spPlus = `(?:` + sp + `+(?:` + lineBreak + sp + `*)?|` + lineBreak + sp + `*)`
+
+const spStar = `(?:` + spPlus + `)?`
+
+// spGapStar returns a possibly-empty separator run holding one optional
+// punctuation character from punct ("TS 23.501, clause 5.1" as well as
+// "TS 23.501 clause 5.1"), still carrying at most one line break in the whole
+// gap. Written as spStar + "[,;]?" + spStar instead, the two runs would each
+// take a line break of their own when the punctuation is absent, and the pair
+// would span the blank line spPlus/spStar exist to keep out.
+func spGapStar(punct string) string {
+	hs := sp + `*`
+	p := `[` + punct + `]?`
+	return `(?:` + hs + `(?:` + lineBreak + hs + `)?` + p + hs +
+		`|` + hs + p + hs + lineBreak + hs + `)`
+}
 
 // secNum matches section numbers: digit-first (5.1.2a, 5.3A.2) or letter-first for annexes (H, A.1).
 // A letter suffix is allowed on every segment to handle mid-number letters such as 5.3A.2 or 4.2.2.2A.1.
@@ -1502,40 +1532,40 @@ const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 // number. A preposition requires a keyword after it ("and in clause 4.12.2a"
 // but not "and in 2024") so a bare number after "of"/"in" is never read as a
 // section reference.
-const coordElemTail = `(?:(?:of|in)` + sp + `+(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+|(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?)` + secNumRaw
+const coordElemTail = `(?:(?:of|in)` + spPlus + `(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + spPlus + `|(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + spPlus + `)?)` + secNumRaw
 
 // bareRefChain matches zero or more coordinated references (", clause 4.3",
 // " and 4.4", ", and 4.4", "; or Annex B", " and in clause 4.12.2a") so
 // bareTrailingQualRE and barePresentDocRE can see through a list to the
 // "of"/"in" that qualifies its every element.
-const bareRefChain = `(?:` + sp + `*(?:[,;]` + sp + `*(?:and|or)?|and|or)` + sp + `*` + coordElemTail + `)*`
+const bareRefChain = `(?:` + spStar + `(?:[,;]` + spStar + `(?:and|or)?|and|or)` + spStar + coordElemTail + `)*`
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
-	tsRefRE = regexp.MustCompile(`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)(?:` + sp + `*[,;]?` + sp + `*(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + sp + `+` + secNum + `)?`)
+	tsRefRE = regexp.MustCompile(`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)(?:` + spGapStar(`,;`) + `(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + spPlus + secNum + `)?`)
 	// "Annex H of 3GPP TS 33.203" or "subclause 5.1 of TS 23.228"
-	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + sp + `+` + secNum + sp + `+of` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
-	rfcRefRE      = regexp.MustCompile(`(?:IETF` + sp + `+)?RFC` + sp + `+(\d+)(?:` + sp + `*[,;]?` + sp + `*(?:section|clause)` + sp + `+(\d+(?:\.\d+)*))?`)
+	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum + spPlus + `of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+	rfcRefRE      = regexp.MustCompile(`(?:IETF` + spPlus + `)?RFC` + spPlus + `(\d+)(?:` + spGapStar(`,;`) + `(?:section|clause)` + spPlus + `(\d+(?:\.\d+)*))?`)
 
 	// bracketMapRE extracts [N] -> TS/TR XX.YYY mappings from the References section.
-	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
+	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
 	// bracketRefRE matches "[N] clause/section/subclause/annex X" patterns.
-	bracketRefRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + sp + `*(?:,` + sp + `*)?(?:clause|section|subclause|[Aa]nnex)` + sp + `+` + secNum)
+	bracketRefRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spStar + `(?:,` + spStar + `)?(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum)
 
 	// tsMultiPrefixRefRE matches "clauses 8.2 and 16.11 of TS 23.402" with optional trailing "[N]".
 	// Groups: 1=keyword, 2=section-list, 3=TS|TR, 4=spec-number, 5=optional bracket number.
 	tsMultiPrefixRefRE = regexp.MustCompile(
-		`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + sp + `+` +
-			`(` + secNumRaw + `(?:(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `))\b` + sp + `+` +
-			`of` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)` +
-			`(?:` + sp + `*\[(\d+[A-Za-z]*)\])?`)
+		`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
+			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b` + spPlus +
+			`of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` +
+			`(?:` + spStar + `\[(\d+[A-Za-z]*)\])?`)
 
 	// tsMultiRefRE matches "TS 23.402 clauses 8.2 and 16.11" (spec before multi-section list).
 	// Groups: 1=TS|TR, 2=spec-number, 3=keyword, 4=section-list.
 	tsMultiRefRE = regexp.MustCompile(
-		`(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)` + sp + `+` +
-			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + sp + `+` +
-			`(` + secNumRaw + `(?:(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `))\b`)
+		`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` + spPlus +
+			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
+			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b`)
 
 	// tsCoordPrefixRefRE matches a coordinated list whose elements may repeat
 	// the keyword and a preposition before naming the spec —
@@ -1546,9 +1576,9 @@ var (
 	// candidate collection order decides (this pattern first).
 	// Groups: 1=reference-list, 2=TS|TR, 3=spec-number.
 	tsCoordPrefixRefRE = regexp.MustCompile(
-		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+` + secNumRaw +
-			`(?:` + sp + `*(?:,|and|or)` + sp + `*` + coordElemTail + `)+)` +
-			sp + `+(?:of|in)` + sp + `+(?:3GPP` + sp + `+)?(TS|TR)` + sp + `+(\d+\.\d+)`)
+		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + spPlus + secNumRaw +
+			`(?:` + spStar + `(?:,|and|or)` + spStar + coordElemTail + `)+)` +
+			spPlus + `(?:of|in)` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
@@ -1557,7 +1587,7 @@ var (
 	// tsCoordPrefixRefRE, sharing its keyword classes (plural forms included,
 	// unlike bareRefRE; the keyword is optional, as in the list pattern).
 	// Group 1 = section number.
-	coordElemRE = regexp.MustCompile(`\b(?:(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + sp + `+)?` + secNum)
+	coordElemRE = regexp.MustCompile(`\b(?:(?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + spPlus + `)?` + secNum)
 
 	// bareRefRE matches a reference with no spec designator: "clause 4.2",
 	// "Subclause 5.15.2", "Annex B". Such a reference means the current
@@ -1565,13 +1595,13 @@ var (
 	// match and the surrounding context does not tie it to another document
 	// (bareLeadingSpecRE, bareTrailingQualRE). Sentence-initial capitals are
 	// common in this form, so both cases are accepted.
-	bareRefRE = regexp.MustCompile(`\b(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + sp + `+` + secNum)
+	bareRefRE = regexp.MustCompile(`\b(?:[Cc]lause|[Ss]ection|[Ss]ubclause|[Aa]nnex)` + spPlus + secNum)
 
 	// bareMultiRefRE matches a bare multi-section list: "clauses 4.2, 4.3 and 4.4".
 	// Groups: 1=section-list.
 	bareMultiRefRE = regexp.MustCompile(
-		`\b(?:[Cc]lauses|[Ss]ubclauses|[Ss]ections|[Aa]nnexe?s)` + sp + `+` +
-			`(` + secNumRaw + `(?:,` + sp + `*` + secNumRaw + `)*` + sp + `+and` + sp + `+` + secNumRaw + `)\b`)
+		`\b(?:[Cc]lauses|[Ss]ubclauses|[Ss]ections|[Aa]nnexe?s)` + spPlus +
+			`(` + secNumRaw + `(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `)\b`)
 
 	// bareTrailingQualRE matches an "of"/"in" continuation after a bare
 	// reference, which usually names another document ("clause 5.1 of
@@ -1580,17 +1610,17 @@ var (
 	// first element of "clause 4.2 and clause 4.3 of TS 23.402" is rejected
 	// too. RE2 has no lookahead, so these are applied to the text after a
 	// bare match instead of being part of bareRefRE.
-	bareTrailingQualRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp + `+`)
+	bareTrailingQualRE = regexp.MustCompile(`^` + bareRefChain + spPlus + `(?:of|in)` + spPlus)
 
 	// barePresentDocRE matches the continuations that still mean the current
 	// document, re-allowing a bare reference bareTrailingQualRE would reject.
-	barePresentDocRE = regexp.MustCompile(`^` + bareRefChain + sp + `+(?:of|in)` + sp +
-		`+(?:the` + sp + `+present` + sp + `+(?:document|specification)|this` + sp + `+(?:specification|document))`)
+	barePresentDocRE = regexp.MustCompile(`^` + bareRefChain + spPlus + `(?:of|in)` + spPlus +
+		`(?:the` + spPlus + `present` + spPlus + `(?:document|specification)|this` + spPlus + `(?:specification|document))`)
 
 	// bareTrailingParenSpecRE matches a parenthesized designator right after a
 	// bare reference ("clause 4.2 (TS 23.402)"), tying it to that document.
-	bareTrailingParenSpecRE = regexp.MustCompile(`^` + sp + `*\(` + sp + `*(?:3GPP` + sp +
-		`+)?(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])`)
+	bareTrailingParenSpecRE = regexp.MustCompile(`^` + spStar + `\(` + spStar + `(?:3GPP` + spPlus +
+		`)?(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])`)
 
 	// bareLeadingSpecRE matches a spec designator or bracket reference before
 	// a bare reference — directly ("TS 23.402 Clause 5.1", "RFC 3748
@@ -1599,9 +1629,9 @@ var (
 	// the lowercase-only qualified patterns (and thus the overlap gate) do
 	// not cover the element itself.
 	bareLeadingSpecRE = regexp.MustCompile(
-		`(?:(?:TS|TR)` + sp + `+\d+\.\d+|RFC` + sp + `+\d+|\[\d+[A-Za-z]*\])` +
-			`(?:` + sp + `+(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + sp + `+)?` + secNumRaw + bareRefChain + `)?` +
-			sp + `*[,;:]?` + sp + `*(?:(?:and|or)` + sp + `+)?$`)
+		`(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])` +
+			`(?:` + spPlus + `(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + spPlus + `)?` + secNumRaw + bareRefChain + `)?` +
+			spGapStar(`,;:`) + `(?:(?:and|or)` + spPlus + `)?$`)
 )
 
 // refExtractor converts regex submatch indices into (targetSpec, targetSection, ok).

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1193,6 +1193,21 @@ func TestExtractReferences_UnicodeWhitespace(t *testing.T) {
 	}
 }
 
+// Regression test for #191: a keyword at the end of one block and a section
+// number at the start of the next are two blocks, not a reference.
+func TestExtractReferences_NoMatchAcrossBlankLine(t *testing.T) {
+	content := "The requirements are specified in TS 33.203 clause\n\n" +
+		"5.1 is out of scope of the present document."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 33.203" || refs[0].TargetSection != "" {
+		t.Errorf("expected a section-less reference to TS 33.203, got %+v", refs[0])
+	}
+}
+
 func TestExtractReferences_Annex(t *testing.T) {
 	// "TS X Annex Y" pattern (keyword after spec ID)
 	content := `The security procedures are described in TS 33.203 Annex H.

--- a/db/linkify.go
+++ b/db/linkify.go
@@ -154,9 +154,10 @@ func htmlLink(text, url string) string {
 }
 
 // markerText escapes reference text for use inside an unresolved-reference
-// marker, folding newlines to spaces: the reference regexes can match across
-// a line break (sp includes \s), but the web sanitizer relies on markers
-// never spanning lines, so the invariant is enforced here at generation.
+// marker, folding newlines to spaces: the reference regexes can match across a
+// soft line break inside a block (spPlus allows one), but the web sanitizer
+// relies on markers never spanning lines, so the invariant is enforced here at
+// generation.
 func markerText(text string) string {
 	text = strings.ReplaceAll(text, "\r", " ")
 	text = strings.ReplaceAll(text, "\n", " ")

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -817,11 +817,109 @@ func TestLinkifyRefs_NilURLFor(t *testing.T) {
 	}
 }
 
-// A reference matched across a line break must not produce a multi-line
-// marker: the web sanitizer relies on markers staying on one line.
+// A reference matched across a soft line break inside a paragraph (a w:br in
+// the source document) must not produce a multi-line marker: the web sanitizer
+// relies on markers staying on one line.
 func TestLinkifyRefs_MarkerFoldsNewline(t *testing.T) {
 	input := "See clause\n9.9 for details."
 	want := `See <span class="ref-unresolved" title="Section 9.9 does not exist in this document — possibly a stale or incorrect reference in the source text">clause 9.9</span> for details.`
+	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+	if got != want {
+		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+	}
+}
+
+// Regression test for #191: no reference may span a blank line. Blocks are
+// joined with "\n\n", so a link or marker emitted across one glues the two
+// blocks together — a heading ending in "clause" swallowed the paragraph that
+// followed it, and goldmark rendered both as a single heading.
+func TestLinkifyRefs_NoMatchAcrossBlankLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "heading ending in keyword and following paragraph",
+			input: "# 5 Test clause\n\nUpon receipt of the REGISTRATION ACCEPT message, the UE shall:",
+		},
+		{
+			name:  "two body paragraphs",
+			input: "The procedure is defined in clause\n\nAnnex text follows here.",
+		},
+		{
+			name:  "keyword and section number in separate paragraphs",
+			input: "See clause\n\n4.2 is the relevant one.",
+		},
+		{
+			name:  "CRLF blank line",
+			input: "# 5 Test clause\r\n\r\nUpon receipt of the message.",
+		},
+		{
+			name:  "spec designator split across a blank line",
+			input: "As defined in TS\n\n23.501 the procedure applies.",
+		},
+		{
+			name:  "RFC number split across a blank line",
+			input: "See RFC\n\n6733 for details.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+			if got != tt.input {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want it unchanged", tt.input, got)
+			}
+		})
+	}
+}
+
+// The optional gap between a spec designator and a trailing clause reference
+// holds one optional comma, and it must not span a blank line either: written
+// as two separator runs it would take a line break on each side of the absent
+// comma. Each block linkifies on its own instead.
+func TestLinkifyRefs_QualifiedSectionGapAcrossBlankLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "TS designator and clause in separate blocks",
+			input: "See TS 23.501\n\nclause 5.1 here.",
+			want:  "See [TS 23.501](/specs/TS 23.501)\n\n[clause 5.1](/specs/TS 23.501/sections/5.1) here.",
+		},
+		{
+			name:  "RFC number and section in separate blocks",
+			input: "See RFC 6733\n\nsection 5.1 here.",
+			want:  "See [RFC 6733](https://www.rfc-editor.org/rfc/rfc6733)\n\n[section 5.1](/specs/TS 23.501/sections/5.1) here.",
+		},
+		{
+			name:  "soft break in the gap still links as one reference",
+			input: "See TS 23.501\nclause 5.1 here.",
+			want:  "See [TS 23.501\nclause 5.1](/specs/TS 23.501/sections/5.1) here.",
+		},
+		{
+			name:  "soft break after the comma still links as one reference",
+			input: "See TS 23.501,\nclause 5.1 here.",
+			want:  "See [TS 23.501,\nclause 5.1](/specs/TS 23.501/sections/5.1) here.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// A blank line between a bare reference and the "of TS ..." that qualifies it
+// leaves the reference same-document: bareTrailingQualRE must not see across
+// the block boundary either.
+func TestLinkifyRefs_QualifierAcrossBlankLineIgnored(t *testing.T) {
+	input := "See clause 4.2\n\nof TS 23.402 for details."
+	want := "See [clause 4.2](/specs/TS 23.501/sections/4.2)\n\nof [TS 23.402](/specs/TS 23.402) for details."
 	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
 	if got != want {
 		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -914,14 +914,40 @@ func TestLinkifyRefs_QualifiedSectionGapAcrossBlankLine(t *testing.T) {
 	}
 }
 
-// A blank line between a bare reference and the "of TS ..." that qualifies it
-// leaves the reference same-document: bareTrailingQualRE must not see across
-// the block boundary either.
-func TestLinkifyRefs_QualifierAcrossBlankLineIgnored(t *testing.T) {
-	input := "See clause 4.2\n\nof TS 23.402 for details."
-	want := "See [clause 4.2](/specs/TS 23.501/sections/4.2)\n\nof [TS 23.402](/specs/TS 23.402) for details."
-	got := LinkifyRefs(input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
-	if got != want {
-		t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", input, got, want)
+// The context gates around a bare reference must not see across a block
+// boundary either: a designator or an "of TS ..." qualifier in the neighbouring
+// block belongs to that block, and reading it suppresses a legitimate
+// same-document link.
+func TestLinkifyRefs_ContextGatesStopAtBlankLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trailing qualifier in the next block",
+			input: "See clause 4.2\n\nof TS 23.402 for details.",
+			want:  "See [clause 4.2](/specs/TS 23.501/sections/4.2)\n\nof [TS 23.402](/specs/TS 23.402) for details.",
+		},
+		{
+			name:  "qualifier reached through a coordinated list in the next block",
+			input: "The following apply: clause 4.2,\n\nclause 4.3 of TS 23.402.",
+			want: "The following apply: [clause 4.2](/specs/TS 23.501/sections/4.2),\n\n" +
+				"[clause 4.3 of TS 23.402](/specs/TS 23.402/sections/4.3).",
+		},
+		{
+			name:  "leading designator in the previous block",
+			input: "See TS 23.402 clause 5.1,\n\nclause 4.2 applies.",
+			want: "See [TS 23.402 clause 5.1](/specs/TS 23.402/sections/5.1),\n\n" +
+				"[clause 4.2](/specs/TS 23.501/sections/4.2) applies.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #191.

## Problem

`sp` matched any whitespace, newlines included, so a paragraph ending in the
bare word "clause" and the capitalized paragraph after it matched as one
reference. The emitted link or unresolved marker spanned the block boundary and
goldmark rendered both blocks as one — a heading swallowing the paragraph
below it.

## Change

- `sp` now matches horizontal separators only. `spPlus` / `spStar` are the
  quantified forms the patterns use, and a run carries at most one line break:
  a reference can still span a soft break inside a paragraph (a `w:br` becomes
  `"\n"`) but never a blank line, which is the block separator.
- `spGapStar` covers the gaps holding an optional comma
  ("TS 23.501, clause 5.1"). Two adjacent runs would each take a line break of
  their own when the comma is absent, and the pair would span a blank line
  again.
- `bareRefChain` had the same adjacency after a comma with no conjunction, so
  the context gates read a qualifier or a spec designator out of the
  neighbouring block and suppressed a valid same-document link.

## Verification

- New regression tests in `db/linkify_test.go` (block-boundary matches, the
  qualified-section gap, the context gates) and `db/db_test.go`
  (`ExtractReferences`); soft-break cases are asserted to keep linking.
- `go test ./...`, `gofmt`, `go vet` clean.
- Web viewer checked with Playwright on a seeded database with the issue's
  repro content: before, `<h1>5 Test clause Upon receipt of the REGISTRATION
  ACCEPT message, the UE shall:</h1>`; after, the heading and each paragraph
  render as separate blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CptUBL3GH42moH1BpkdEoc)_