### PR TITLE
test: add Playwright e2e suite for web viewer JS behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -61,7 +61,7 @@ jobs:
         working-directory: e2e
       - name: Cache Playwright browser
         id: pw-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.pw-version.outputs.version }}
@@ -83,7 +83,7 @@ jobs:
         working-directory: e2e
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: e2e/playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: e2e
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: e2e
+      - name: Cache Playwright browser
+        id: pw-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright browser
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: e2e
+      - name: Install Playwright system dependencies
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: e2e
       - name: Build e2e server harness
         # Compile ahead of time so a module-cache miss cannot eat into the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,38 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: e2e
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+        working-directory: e2e
+      - name: Build e2e server harness
+        # Compile ahead of time so a module-cache miss cannot eat into the
+        # Playwright webServer startup timeout.
+        run: go build -o /dev/null ./e2eserver
+        working-directory: e2e
+      - name: Run e2e tests
+        run: npx playwright test
+        working-directory: e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ data/*.db-wal
 
 # Added by goreleaser init:
 dist/
+
+# Playwright e2e
+e2e/node_modules/
+e2e/test-results/
+e2e/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@ gofmt -l . && go vet ./... && golangci-lint run   # Lint (CI also runs go test -
 make build-db             # Download + import latest version of every spec (RELEASE=19 for one release, MAX_RELEASE=19 to cap)
 make web                  # HTTP server with web viewer at :8080
 make e2e                  # Playwright suite for web viewer JS behavior (CI job "e2e"); hermetic server harness in e2e/e2eserver
-
 ```
 
 ## Package Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ go test ./...             # Run tests (-short skips tests that hit the 3GPP FTP)
 gofmt -l . && go vet ./... && golangci-lint run   # Lint (CI also runs go test -race)
 make build-db             # Download + import latest version of every spec (RELEASE=19 for one release, MAX_RELEASE=19 to cap)
 make web                  # HTTP server with web viewer at :8080
+make e2e                  # Playwright suite for web viewer JS behavior (CI job "e2e"); hermetic server harness in e2e/e2eserver
+
 ```
 
 ## Package Map

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install import import-dir build-db download-specs download-latest-specs update-specs db-info test clean web
+.PHONY: build install import import-dir build-db download-specs download-latest-specs update-specs db-info test e2e clean web
 
 SPECS_DIR ?= specs
 DB_PATH ?= data/3gpp.db
@@ -70,6 +70,11 @@ web: build
 # Run Go tests
 test:
 	go test ./...
+
+# Run Playwright end-to-end tests for the web viewer (requires Node.js).
+# Set CHROMIUM_PATH to use a system Chromium instead of the managed download.
+e2e:
+	cd e2e && npm ci && npx playwright install chromium && npx playwright test
 
 # Clean build artifacts
 clean:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,9 @@ test:
 # Run Playwright end-to-end tests for the web viewer (requires Node.js).
 # Set CHROMIUM_PATH to use a system Chromium instead of the managed download.
 e2e:
-	cd e2e && npm ci && npx playwright install chromium && npx playwright test
+	cd e2e && npm ci && \
+	if [ -z "$$CHROMIUM_PATH" ]; then npx playwright install chromium; fi && \
+	npx playwright test
 
 # Clean build artifacts
 clean:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  # Playwright e2e server harness: test infrastructure, exercised by the
+  # e2e CI job rather than go test, so it carries no Go coverage.
+  - "e2e/**"

--- a/e2e/e2eserver/main.go
+++ b/e2e/e2eserver/main.go
@@ -1,0 +1,94 @@
+// Command e2eserver runs the web viewer against a seeded throwaway database
+// for the Playwright end-to-end suite in e2e/. It reuses the canonical test
+// seed data and adds a section exercising the browser-only features the suite
+// covers: KaTeX math rendering and the image lightbox.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/higebu/3gpp-mcp/db"
+	"github.com/higebu/3gpp-mcp/internal/testutil"
+	"github.com/higebu/3gpp-mcp/tools"
+	"github.com/higebu/3gpp-mcp/web"
+)
+
+// e2eSeed extends testutil.SeedData with content the Playwright suite needs:
+// inline and display math for the KaTeX test, and an image reference (with a
+// 1x1 PNG marked llm_readable so handleImage serves the real bytes, not the
+// EMF placeholder) for the lightbox test. Kept separate from the shared seed
+// so web_test.go's assertions on that data stay untouched.
+const e2eSeed = `
+INSERT INTO sections (spec_id, version, number, title, level, parent_number, content) VALUES
+    ('TS 23.501', '18.6.0', '9', 'Formulas and figures', 1, NULL, '# 9 Formulas and figures
+The energy is $E = mc^2$ in every frame.
+
+$$\frac{a}{b} = c$$
+
+![Architecture figure](image://e2e-fig.png?w=200&h=100)');
+
+INSERT INTO images (spec_id, version, name, mime_type, data, llm_readable) VALUES
+    ('TS 23.501', '18.6.0', 'e2e-fig.png', 'image/png',
+     X'89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D4944415478DA63FCCFC0500F000485018084A98C210000000049454E44AE426082',
+     1);
+`
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:8877", "listen address")
+	flag.Parse()
+	if err := run(*addr); err != nil {
+		log.Fatalf("e2eserver: %v", err)
+	}
+}
+
+func run(addr string) error {
+	// Shut down on SIGINT/SIGTERM (Playwright's webServer gracefulShutdown
+	// sends SIGTERM) so the deferred temp-dir cleanup actually runs.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	dir, err := os.MkdirTemp("", "3gpp-e2e-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	d, err := db.OpenReadWrite(filepath.Join(dir, "e2e.db"))
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
+
+	for _, script := range []string{db.Schema, testutil.SeedData, e2eSeed} {
+		if err := d.ExecScript(script); err != nil {
+			return fmt.Errorf("seed db: %w", err)
+		}
+	}
+
+	srv := &http.Server{Addr: addr, Handler: web.NewServer(tools.NewSource(d))}
+	errc := make(chan error, 1)
+	go func() { errc <- srv.ListenAndServe() }()
+	log.Printf("e2eserver listening on http://%s", addr)
+
+	select {
+	case err := <-errc:
+		return fmt.Errorf("serve: %w", err)
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("shutdown: %w", err)
+		}
+		return nil
+	}
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "3gpp-mcp-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "3gpp-mcp-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "3gpp-mcp-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:8877',
+    trace: 'on-first-retry',
+    // Escape hatch for environments with a system-provided Chromium instead
+    // of the Playwright-managed download (e.g. CHROMIUM_PATH=/usr/bin/chromium).
+    ...(process.env.CHROMIUM_PATH
+      ? { launchOptions: { executablePath: process.env.CHROMIUM_PATH } }
+      : {}),
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // The harness seeds a throwaway SQLite database and serves the web
+    // viewer with no network access; the first run also compiles it.
+    command: 'go run ./e2eserver -addr 127.0.0.1:8877',
+    url: 'http://127.0.0.1:8877/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    // SIGTERM (not the default SIGKILL) lets the harness remove its temp
+    // database directory on the way out.
+    gracefulShutdown: { signal: 'SIGTERM', timeout: 3000 },
+  },
+});

--- a/e2e/tests/index.spec.ts
+++ b/e2e/tests/index.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('series select auto-submits the filter form', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('TS 29.510')).toBeVisible();
+
+  // The <select> has onchange="this.form.submit()" — no submit button needed.
+  await page.locator('#series').selectOption('23');
+  await expect(page).toHaveURL(/\?series=23/);
+  await expect(page.getByText('TS 23.501')).toBeVisible();
+  await expect(page.getByText('TS 29.510')).toHaveCount(0);
+});

--- a/e2e/tests/lightbox.spec.ts
+++ b/e2e/tests/lightbox.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('clicking a figure opens the lightbox, clicking again closes it', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/9');
+  const figure = page.locator('.section-body img');
+
+  // app.js turns figures into focusable buttons — proves the enhancement ran.
+  await expect(figure).toHaveAttribute('role', 'button');
+  await expect(figure).toHaveAttribute('tabindex', '0');
+
+  await figure.click();
+  const lightbox = page.locator('dialog.lightbox');
+  await expect(lightbox).toBeVisible();
+  await expect(lightbox.locator('img')).toHaveAttribute('src', /\/images\/e2e-fig\.png/);
+
+  await lightbox.click();
+  await expect(lightbox).toBeHidden();
+});
+
+test('keyboard opens and closes the lightbox with focus restored', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/9');
+  const figure = page.locator('.section-body img');
+  const lightbox = page.locator('dialog.lightbox');
+
+  await figure.focus();
+  await page.keyboard.press('Enter');
+  await expect(lightbox).toBeVisible();
+
+  // Escape is native <dialog> behavior; closing restores focus to the figure.
+  await page.keyboard.press('Escape');
+  await expect(lightbox).toBeHidden();
+  await expect(figure).toBeFocused();
+});

--- a/e2e/tests/math.spec.ts
+++ b/e2e/tests/math.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('KaTeX renders inline and display math', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/9');
+
+  // app.js renders the raw LaTeX inside each span in place; a .katex child
+  // only exists if KaTeX actually ran.
+  await expect(page.locator('.math-inline .katex')).toBeVisible();
+  await expect(page.locator('.math-inline .katex-html')).toBeVisible();
+  await expect(page.locator('.math-display .katex-display')).toBeVisible();
+});

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -12,15 +12,15 @@ test('arrow keys navigate to next and previous chapters', async ({ page }) => {
 
 test('arrow keys are ignored in inputs and with modifiers', async ({ page }) => {
   await page.goto('/specs/TS%2023.501/sections/1');
-  const url = page.url();
 
   await page.locator('.navbar-search-input').focus();
   await page.keyboard.press('ArrowRight');
-  await page.waitForTimeout(300);
-  expect(page.url()).toBe(url);
-
   await page.locator('.navbar-search-input').blur();
   await page.keyboard.press('Shift+ArrowRight');
-  await page.waitForTimeout(300);
-  expect(page.url()).toBe(url);
+
+  // An unguarded press proves the handler is live. Had either guarded press
+  // wrongly navigated (1 → 5), this one would land on 5.1 instead of 5, so
+  // the final URL detects a broken guard without timing-based waits.
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/\/specs\/TS%2023\.501\/sections\/5$/);
 });

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test('arrow keys navigate to next and previous chapters', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/1');
+
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/\/specs\/TS%2023\.501\/sections\/5$/);
+
+  await page.keyboard.press('ArrowLeft');
+  await expect(page).toHaveURL(/\/specs\/TS%2023\.501\/sections\/1$/);
+});
+
+test('arrow keys are ignored in inputs and with modifiers', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/1');
+  const url = page.url();
+
+  await page.locator('.navbar-search-input').focus();
+  await page.keyboard.press('ArrowRight');
+  await page.waitForTimeout(300);
+  expect(page.url()).toBe(url);
+
+  await page.locator('.navbar-search-input').blur();
+  await page.keyboard.press('Shift+ArrowRight');
+  await page.waitForTimeout(300);
+  expect(page.url()).toBe(url);
+});

--- a/e2e/tests/theme.spec.ts
+++ b/e2e/tests/theme.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test('dark mode toggle persists across reload', async ({ page }) => {
+  await page.goto('/');
+  // Playwright emulates prefers-color-scheme: light by default.
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+  await page.locator('#theme-toggle').click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  expect(await page.evaluate(() => localStorage.getItem('theme'))).toBe('dark');
+
+  // The inline script in <head> must re-apply the stored theme before paint.
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});
+
+test('settings popover selects code theme, persists and closes', async ({ page }) => {
+  await page.goto('/');
+  const toggle = page.locator('#settings-toggle');
+  const popover = page.locator('#settings-popover');
+  await expect(popover).toBeHidden();
+
+  await toggle.click();
+  await expect(popover).toBeVisible();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+  await popover.locator('input[name="code-theme"][value="monokai"]').check();
+  await expect(page.locator('html')).toHaveAttribute('data-code-theme', 'monokai');
+  expect(await page.evaluate(() => localStorage.getItem('codeTheme'))).toBe('monokai');
+
+  await page.keyboard.press('Escape');
+  await expect(popover).toBeHidden();
+  await expect(toggle).toBeFocused();
+
+  await toggle.click();
+  await expect(popover).toBeVisible();
+  // Click a non-navigating element so the hidden state can only come from
+  // the outside-click handler, not a fresh page load.
+  await page.getByRole('heading', { name: '3GPP Specifications' }).click();
+  await expect(popover).toBeHidden();
+
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-code-theme', 'monokai');
+});

--- a/e2e/tests/toc-mobile.spec.ts
+++ b/e2e/tests/toc-mobile.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test('mobile TOC drawer opens, closes and follows links', async ({ page }) => {
+  await page.goto('/specs/TS%2023.501/sections/5');
+  const sidebar = page.locator('#toc-sidebar');
+
+  await page.locator('#toc-toggle').click();
+  await expect(sidebar).toHaveClass(/open/);
+
+  await page.locator('#toc-close').click();
+  await expect(sidebar).not.toHaveClass(/open/);
+
+  await page.locator('#toc-toggle').click();
+  await expect(sidebar).toHaveClass(/open/);
+  await sidebar.getByRole('link', { name: '5.1.1 Overview' }).click();
+  await expect(page).toHaveURL(/\/sections\/5\.1\.1$/);
+});


### PR DESCRIPTION
## Summary

The web viewer's server-rendered output is already covered by `web/web_test.go`, but the browser-only behavior in `web/static/app.js` had no tests. This adds a small hermetic Playwright suite (9 tests) covering exactly that gap:

- KaTeX math rendering (inline and display)
- Image lightbox (`<dialog>`), via click and keyboard, with focus restore
- Dark mode toggle and persistence across reload (anti-FOUC inline script)
- Settings popover: code theme selection, persistence, Escape / outside-click close
- Mobile TOC drawer open/close/follow-link (375px viewport)
- ArrowLeft/ArrowRight chapter navigation and its input/modifier guards
- Series `<select>` auto-submit on the index page

## Implementation

- `e2e/e2eserver`: Go harness that seeds a throwaway SQLite DB (reusing `testutil.SeedData` plus a section with math and an image) and serves `web.NewServer` — no network access needed. Cleans up its temp dir on SIGTERM (Playwright sends it via `gracefulShutdown`).
- `e2e/`: Playwright project (TypeScript, Chromium only), launched via `webServer` in `playwright.config.ts`. `CHROMIUM_PATH` can point at a system Chromium instead of the managed download.
- CI: separate `e2e` job with SHA-pinned latest actions, browser cache keyed on the Playwright version, and report artifact upload on failure. The existing `go` job is untouched.
- `codecov.yml` ignores `e2e/**` (test infrastructure exercised by the e2e job, not go test).
- `make e2e` target; gitignore and AGENTS.md entries.

## Testing

- All 9 tests pass locally in ~4s (`npx playwright test`)
- `go build ./... && go vet ./...`, `gofmt`, `golangci-lint run` clean
- `go test ./web/` unaffected (shared seed data unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)