### PR TITLE
fix: address DeepSeek v4 Pro code review findings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
     - go mod tidy
 
 builds:
-  - main: ./...
+  - main: ./cmd/3gpp-mcp
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -1118,8 +1118,12 @@ func cmdUpdate(args []string) {
 		if errors.Is(err, errSidecarsRemain) {
 			log.Fatalf("Database replaced, but %v", err)
 		}
-		discardWorkingCopy(newPath)
-		log.Fatalf("Failed to replace database: %v", err)
+		// The working copy is finalized and self-contained at this point, and
+		// it holds an import that cost hours; the rename is the only step
+		// that failed (e.g. the target is held open on Windows, or a
+		// transient permission error). Keep the copy so the user can rename
+		// it by hand or rerun, matching the finalize-failure branch above.
+		log.Fatalf("Failed to replace database: %v\nThe updated database is left at %s; %s was not replaced.", err, newPath, *dbPath)
 	}
 	fmt.Println("Database updated successfully.")
 }

--- a/converter/docx/emf.go
+++ b/converter/docx/emf.go
@@ -62,13 +62,13 @@ func assignConvertedImages(images map[string]*EmbeddedImage, items []*batchItem)
 	// image1.wmf, kept side by side per the batchItem doc comment above)
 	// would otherwise both convert to "image1.png" and collide: whichever
 	// is assigned last in the map below silently discards the other's image
-	// data. Count how many successfully converted items want each plain PNG
-	// name so colliding items can be given a name that keeps them distinct.
+	// data. Count how many items want each plain PNG name so colliding items
+	// can be given a name that keeps them distinct. Failed items count too:
+	// if image1.wmf failed to convert, naming the surviving sibling plainly
+	// "image1.png" would let UpdateImagePlaceholders' base-name fallback
+	// rewrite image://image1.wmf to the EMF sibling's content.
 	nameCount := make(map[string]int, len(items))
 	for _, item := range items {
-		if item.err != nil {
-			continue
-		}
 		nameCount[toPNGName(item.original.Name)]++
 	}
 

--- a/converter/docx/emf_test.go
+++ b/converter/docx/emf_test.go
@@ -3,6 +3,7 @@ package docx
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -174,6 +175,32 @@ func TestAssignConvertedImages_NameCollision(t *testing.T) {
 	// image2.emf has no colliding sibling, so it keeps the plain name.
 	if got, want := images["image2.emf"].Name, "image2.png"; got != want {
 		t.Errorf("non-colliding image name = %q, want %q", got, want)
+	}
+}
+
+// TestAssignConvertedImages_CollisionWithFailedSibling verifies that a
+// surviving image is still disambiguated when its same-base-name sibling
+// failed to convert. A plain "image1.png" here would let
+// UpdateImagePlaceholders' base-name fallback rewrite the failed sibling's
+// image://image1.wmf reference to the EMF sibling's content.
+func TestAssignConvertedImages_CollisionWithFailedSibling(t *testing.T) {
+	images := map[string]*EmbeddedImage{
+		"image1.emf": {Name: "image1.emf", MIMEType: "image/x-emf", Data: []byte("emf-src")},
+		"image1.wmf": {Name: "image1.wmf", MIMEType: "image/x-wmf", Data: []byte("wmf-src")},
+	}
+	items := []*batchItem{
+		{key: "image1.emf", original: images["image1.emf"], pngData: []byte("emf-png")},
+		{key: "image1.wmf", original: images["image1.wmf"], err: errors.New("soffice produced no output")},
+	}
+
+	if n := assignConvertedImages(images, items); n != 1 {
+		t.Fatalf("assignConvertedImages converted %d images, want 1", n)
+	}
+	if got, want := images["image1.emf"].Name, "image1.emf.png"; got != want {
+		t.Errorf("surviving sibling name = %q, want %q (must stay disambiguated)", got, want)
+	}
+	if got, want := images["image1.wmf"].Name, "image1.wmf"; got != want {
+		t.Errorf("failed sibling name = %q, want %q (must stay unconverted)", got, want)
 	}
 }
 

--- a/converter/docx/image.go
+++ b/converter/docx/image.go
@@ -2,7 +2,6 @@ package docx
 
 import (
 	"archive/zip"
-	"io"
 	"path/filepath"
 	"strings"
 )
@@ -81,5 +80,5 @@ func readZipFileEntry(f *zip.File) ([]byte, error) {
 		return nil, err
 	}
 	defer rc.Close()
-	return io.ReadAll(rc)
+	return readAllLimited(rc, f.Name)
 }

--- a/converter/docx/omml.go
+++ b/converter/docx/omml.go
@@ -150,11 +150,18 @@ func mVal(prNode *ommlNode, childLocal string) (val string, ok bool) {
 	return v, ok
 }
 
-// isTrue reports whether an OMML boolean attribute value is set. OMML on/off
-// values are "1"/"true"/"on" for true; an absent value defaults to true.
-func isTrue(v string, present bool) bool {
-	if !present {
+// mFlag reads an OMML on/off property child of prNode (e.g. the degHide of a
+// radPr). An absent child is false; a present child without m:val is true per
+// ECMA-376 (<m:degHide/> means "hide"); otherwise "0"/"false"/"off" are false
+// and anything else is true.
+func mFlag(prNode *ommlNode, childLocal string) bool {
+	c := child(prNode, childLocal)
+	if c == nil {
 		return false
+	}
+	v, ok := c.Attr["val"]
+	if !ok {
+		return true
 	}
 	switch strings.ToLower(v) {
 	case "0", "false", "off":
@@ -358,9 +365,9 @@ func renderDelimiter(n *ommlNode) string {
 
 func renderRadical(n *ommlNode) string {
 	e := renderOMML(child(n, "e"))
-	degHide, present := mVal(child(n, "radPr"), "degHide")
+	degHide := mFlag(child(n, "radPr"), "degHide")
 	deg := renderOMML(child(n, "deg"))
-	if isTrue(degHide, present) || trimMathSpace(deg) == "" {
+	if degHide || trimMathSpace(deg) == "" {
 		return "\\sqrt{" + e + "}"
 	}
 	return "\\sqrt[" + deg + "]{" + e + "}"
@@ -373,17 +380,17 @@ func renderNary(n *ommlNode) string {
 	if ok {
 		op = naryOp(chr)
 	}
-	subHide, sp := mVal(naryPr, "subHide")
-	supHide, pp := mVal(naryPr, "supHide")
+	subHide := mFlag(naryPr, "subHide")
+	supHide := mFlag(naryPr, "supHide")
 
 	var b strings.Builder
 	b.WriteString(op)
 	limits := false
-	if sub := child(n, "sub"); sub != nil && !isTrue(subHide, sp) {
+	if sub := child(n, "sub"); sub != nil && !subHide {
 		b.WriteString("_{" + renderOMML(sub) + "}")
 		limits = true
 	}
-	if sup := child(n, "sup"); sup != nil && !isTrue(supHide, pp) {
+	if sup := child(n, "sup"); sup != nil && !supHide {
 		b.WriteString("^{" + renderOMML(sup) + "}")
 		limits = true
 	}

--- a/converter/docx/omml_test.go
+++ b/converter/docx/omml_test.go
@@ -188,12 +188,30 @@ func TestOMMLToLaTeX(t *testing.T) {
 			want: "\\sqrt{x}",
 		},
 		{
+			// An on/off property present without m:val is true per ECMA-376:
+			// <m:degHide/> hides the degree even when m:deg has content.
+			name: "radical with valueless degHide",
+			xml: `<m:oMath ` + mXMLNS + `><m:rad><m:radPr><m:degHide/></m:radPr>` +
+				`<m:deg>` + mrun("3") + `</m:deg><m:e>` + mrun("x") + `</m:e>` +
+				`</m:rad></m:oMath>`,
+			want: "\\sqrt{x}",
+		},
+		{
 			name: "nary sum",
 			xml: `<m:oMath ` + mXMLNS + `><m:nary><m:naryPr><m:chr m:val="∑"/></m:naryPr>` +
 				`<m:sub>` + mrun("i=1") + `</m:sub><m:sup>` + mrun("n") + `</m:sup>` +
 				`<m:e>` + mrun("i") + `</m:e>` +
 				`</m:nary></m:oMath>`,
 			want: "\\sum_{i=1}^{n}i",
+		},
+		{
+			name: "nary with valueless subHide and supHide",
+			xml: `<m:oMath ` + mXMLNS + `><m:nary><m:naryPr><m:chr m:val="∑"/>` +
+				`<m:subHide/><m:supHide/></m:naryPr>` +
+				`<m:sub>` + mrun("i=1") + `</m:sub><m:sup>` + mrun("n") + `</m:sup>` +
+				`<m:e>` + mrun("i") + `</m:e>` +
+				`</m:nary></m:oMath>`,
+			want: "\\sum i",
 		},
 		{
 			// Without limits to close it, the operator command would run into

--- a/converter/docx/parser.go
+++ b/converter/docx/parser.go
@@ -847,6 +847,25 @@ func getHeadingLevel(styleName string) int {
 	return 0
 }
 
+// maxEntrySize caps how far a single archive entry may decompress. Zip and
+// gzip size metadata is attacker-controlled, so the guard sits on the read
+// itself: a crafted entry could otherwise expand without bound (a zip bomb)
+// before any content validation runs. The largest document.xml in the 3GPP
+// corpus is far below this.
+const maxEntrySize = 1 << 30 // 1 GiB
+
+// readAllLimited reads r to EOF but fails once the data exceeds maxEntrySize.
+func readAllLimited(r io.Reader, what string) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxEntrySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxEntrySize {
+		return nil, fmt.Errorf("%s exceeds %d bytes decompressed", what, maxEntrySize)
+	}
+	return data, nil
+}
+
 // readZipFile reads a file from within a zip archive.
 func readZipFile(r *zip.Reader, name string) ([]byte, error) {
 	for _, f := range r.File {
@@ -856,7 +875,7 @@ func readZipFile(r *zip.Reader, name string) ([]byte, error) {
 				return nil, err
 			}
 			defer rc.Close()
-			return io.ReadAll(rc)
+			return readAllLimited(rc, name)
 		}
 	}
 	return nil, fmt.Errorf("file not found in zip: %s", name)

--- a/converter/docx/pcz.go
+++ b/converter/docx/pcz.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io"
 )
 
 // gzipMagic is the magic number at the start of a gzip stream.
@@ -30,7 +29,7 @@ func decompressPCZ(data []byte) ([]byte, error) {
 	}
 	defer r.Close()
 
-	raw, err := io.ReadAll(r)
+	raw, err := readAllLimited(r, "pcz payload")
 	if err != nil {
 		return nil, fmt.Errorf("gzip decompress: %w", err)
 	}

--- a/converter/pipeline/cache.go
+++ b/converter/pipeline/cache.go
@@ -46,14 +46,30 @@ func CacheDir() (string, error) {
 
 // CacheKey generates a cache file name from a prefix and parameters.
 // e.g., CacheKey("speclist", "23", "29") -> "speclist_23_29.txt"
+// Characters that carry meaning in file paths are replaced so the result can
+// never name anything outside the cache directory.
 func CacheKey(prefix string, params ...string) string {
 	if len(params) == 0 {
 		return prefix + ".txt"
 	}
 	sorted := make([]string, len(params))
-	copy(sorted, params)
+	for i, p := range params {
+		sorted[i] = sanitizeKeyPart(p)
+	}
 	sort.Strings(sorted)
 	return prefix + "_" + strings.Join(sorted, "_") + ".txt"
+}
+
+// sanitizeKeyPart keeps a cache-key parameter to filename-safe characters.
+func sanitizeKeyPart(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			return r
+		default:
+			return '.'
+		}
+	}, s)
 }
 
 // LoadCache reads cached entries from a file if it exists and is within TTL.

--- a/converter/pipeline/cache.go
+++ b/converter/pipeline/cache.go
@@ -61,15 +61,20 @@ func CacheKey(prefix string, params ...string) string {
 }
 
 // sanitizeKeyPart keeps a cache-key parameter to filename-safe characters.
+// Every other byte becomes %XX (with % itself encoded), so distinct
+// parameters can never collide onto the same cache file.
 func sanitizeKeyPart(s string) string {
-	return strings.Map(func(r rune) rune {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
 		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
-			return r
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '.':
+			b.WriteByte(c)
 		default:
-			return '.'
+			fmt.Fprintf(&b, "%%%02X", c)
 		}
-	}, s)
+	}
+	return b.String()
 }
 
 // LoadCache reads cached entries from a file if it exists and is within TTL.

--- a/converter/pipeline/download.go
+++ b/converter/pipeline/download.go
@@ -60,28 +60,40 @@ func DownloadAndExtract(ctx context.Context, client *http.Client, spec *SpecVers
 
 	result := &DownloadResult{SpecID: spec.SpecID}
 
+	// backoff sleeps before the next retry, or reports false immediately
+	// when ctx is cancelled: retrying a cancelled download cannot succeed,
+	// and each worker sitting out its full backoff would stall shutdown.
+	backoff := func(attempt int) bool {
+		t := time.NewTimer(time.Duration(1<<uint(attempt+1)) * time.Second)
+		defer t.Stop()
+		select {
+		case <-t.C:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
 	var lastErr error
 	for attempt := range 3 {
 		data, err := downloadZip(ctx, client, spec.URL)
 		if err != nil {
 			lastErr = err
-			if attempt < 2 {
-				time.Sleep(time.Duration(1<<uint(attempt+1)) * time.Second)
+			if attempt < 2 && backoff(attempt) {
 				continue
 			}
 			result.Status = "FAILED"
-			return result, fmt.Errorf("download failed after 3 attempts: %w", lastErr)
+			return result, fmt.Errorf("download failed after %d attempt(s): %w", attempt+1, lastErr)
 		}
 
 		r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 		if err != nil {
 			lastErr = err
-			if attempt < 2 {
-				time.Sleep(time.Duration(1<<uint(attempt+1)) * time.Second)
+			if attempt < 2 && backoff(attempt) {
 				continue
 			}
 			result.Status = "FAILED"
-			return result, fmt.Errorf("bad zip after 3 attempts: %w", lastErr)
+			return result, fmt.Errorf("bad zip after %d attempt(s): %w", attempt+1, lastErr)
 		}
 
 		if err := os.MkdirAll(outputDir, 0o700); err != nil {

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -162,6 +162,13 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 	if err != nil {
 		return "FAILED", err
 	}
+
+	// Import OpenAPI YAML before the docx status gate: DownloadAndExtract
+	// extracts the _yaml directory even when the archive holds no usable
+	// document, and a spec whose only artifact is YAML must still reach
+	// openapi_specs.
+	p.importYAML(tmpDir)
+
 	if result.Status != "OK" {
 		if result.Status == "DOC_ONLY" && p.ConvertDoc {
 			docDir := filepath.Join(tmpDir, "_doc_files")
@@ -253,35 +260,39 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 		}
 	}
 
-	// Import YAML files if present
+	return "OK", nil
+}
+
+// importYAML upserts every OpenAPI YAML file extracted into tmpDir/_yaml.
+func (p *Pipeline) importYAML(tmpDir string) {
 	yamlDir := filepath.Join(tmpDir, "_yaml")
-	if entries, err := os.ReadDir(yamlDir); err == nil {
-		for _, entry := range entries {
-			match := yamlFilenameRE.FindStringSubmatch(entry.Name())
-			if match == nil {
-				continue
-			}
-			series, num, apiName := match[1], match[2], match[3]
-			specID := fmt.Sprintf("TS %s.%s", series, num)
+	entries, err := os.ReadDir(yamlDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		match := yamlFilenameRE.FindStringSubmatch(entry.Name())
+		if match == nil {
+			continue
+		}
+		series, num, apiName := match[1], match[2], match[3]
+		specID := fmt.Sprintf("TS %s.%s", series, num)
 
-			content, err := os.ReadFile(filepath.Join(yamlDir, entry.Name()))
-			if err != nil {
-				log.Printf("  %s: failed to read YAML %s: %v", specID, entry.Name(), err)
-				continue
-			}
+		content, err := os.ReadFile(filepath.Join(yamlDir, entry.Name()))
+		if err != nil {
+			log.Printf("  %s: failed to read YAML %s: %v", specID, entry.Name(), err)
+			continue
+		}
 
-			var version string
-			if verMatch := yamlVersionRE.FindSubmatch(content); verMatch != nil {
-				version = strings.TrimSpace(string(verMatch[1]))
-			}
+		var version string
+		if verMatch := yamlVersionRE.FindSubmatch(content); verMatch != nil {
+			version = strings.TrimSpace(string(verMatch[1]))
+		}
 
-			if err := p.DB.UpsertOpenAPI(specID, apiName, version, entry.Name(), string(content)); err != nil {
-				log.Printf("  OpenAPI import error %s: %v", entry.Name(), err)
-			}
+		if err := p.DB.UpsertOpenAPI(specID, apiName, version, entry.Name(), string(content)); err != nil {
+			log.Printf("  OpenAPI import error %s: %v", entry.Name(), err)
 		}
 	}
-
-	return "OK", nil
 }
 
 // docTypeID replaces the "TS "/"TR " document-type prefix of a spec ID with

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -163,12 +163,6 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 		return "FAILED", err
 	}
 
-	// Import OpenAPI YAML before the docx status gate: DownloadAndExtract
-	// extracts the _yaml directory even when the archive holds no usable
-	// document, and a spec whose only artifact is YAML must still reach
-	// openapi_specs.
-	p.importYAML(tmpDir)
-
 	if result.Status != "OK" {
 		if result.Status == "DOC_ONLY" && p.ConvertDoc {
 			docDir := filepath.Join(tmpDir, "_doc_files")
@@ -196,6 +190,13 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 			}
 		}
 		if result.Status != "OK" {
+			// No document text will be imported, so the YAML is this spec's
+			// only artifact: DownloadAndExtract extracted it before deciding
+			// DOC_ONLY/NO_DOC, and skipping it here would keep the spec out
+			// of openapi_specs entirely. Mid-parse failures below deliberately
+			// do not import, so a FAILED spec cannot advance openapi_specs
+			// ahead of its text.
+			p.importYAML(tmpDir)
 			return result.Status, nil
 		}
 	}
@@ -259,6 +260,9 @@ func (p *Pipeline) processOne(ctx context.Context, spec *SpecVersion) (string, e
 			return "FAILED", fmt.Errorf("db insert: %w", err)
 		}
 	}
+
+	// Import YAML files if present
+	p.importYAML(tmpDir)
 
 	return "OK", nil
 }

--- a/converter/pipeline/pipeline_test.go
+++ b/converter/pipeline/pipeline_test.go
@@ -32,6 +32,42 @@ func setupTestDB(t *testing.T) *db.DB {
 	return d
 }
 
+// TestImportYAML exercises the _yaml import directly: matching files are
+// upserted with the version read from the document, and non-matching names
+// are skipped.
+func TestImportYAML(t *testing.T) {
+	d := setupTestDB(t)
+	tmpDir := t.TempDir()
+	yamlDir := filepath.Join(tmpDir, "_yaml")
+	if err := os.MkdirAll(yamlDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "openapi: 3.0.0\ninfo:\n  version: '1.2.3'\n  title: Nnrf_NFManagement\n"
+	if err := os.WriteFile(filepath.Join(yamlDir, "TS29510_Nnrf_NFManagement.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(yamlDir, "readme.txt"), []byte("not yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Pipeline{DB: d}
+	p.importYAML(tmpDir)
+
+	apis, err := d.ListOpenAPI(t.Context(), "TS 29.510")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(apis) != 1 {
+		t.Fatalf("imported %d OpenAPI specs, want 1", len(apis))
+	}
+	if apis[0].APIName != "Nnrf_NFManagement" || apis[0].Version != "1.2.3" {
+		t.Errorf("imported %q version %q, want Nnrf_NFManagement version 1.2.3", apis[0].APIName, apis[0].Version)
+	}
+
+	// A spec directory without _yaml is a no-op.
+	p.importYAML(t.TempDir())
+}
+
 func makeZipWithFile(t *testing.T, name string, content []byte) []byte {
 	t.Helper()
 	return makeZipWithFiles(t, map[string][]byte{name: content})

--- a/db/db.go
+++ b/db/db.go
@@ -1091,20 +1091,26 @@ var fts5Operators = map[string]bool{
 }
 
 // needsFTS5Quoting reports whether a bare token contains a character FTS5
-// cannot parse as part of an unquoted bareword: a hyphen (misread as the
-// column-filter/NOT operator), a period (e.g. spec numbers like "38.101",
-// which FTS5 otherwise rejects with "syntax error near \".\""), a stray
-// double quote, a parenthesis riding along inside the token (an unquoted
-// "(38.331" or "SMF)" is a hard syntax error), a star (valid only as a
-// trailing prefix operator; quoteFTS5Term keeps that meaning and quotes
-// every other placement, so a bare "*" degrades to no results instead of
-// "unknown special query"), a comma (only valid as the NEAR distance
-// separator, so "AMF, SMF" is a syntax error), or a colon (valid only as
-// the separator of a column filter naming a real column, which
-// classifyToken checks before falling back here: "NOTE: mentions" would
-// otherwise fail the whole match with "no such column: NOTE").
+// cannot parse as part of an unquoted bareword. FTS5 barewords are ASCII
+// alphanumerics, "_", and bytes >= 0x80 (non-ASCII text); every other
+// character is either an operator there — a hyphen is the column-filter/NOT
+// separator, a star the prefix operator, a comma the NEAR distance
+// separator, a colon a column filter (classifyToken checks for a real
+// column before falling back here) — or a hard "fts5: syntax error", as
+// with the period in "38.101", the slash in "N1/N2", or the plus in "C++".
+// Quoting turns all of them into literal search text; quoteFTS5Term keeps a
+// single trailing "*" meaningful as a prefix match.
 func needsFTS5Quoting(s string) bool {
-	return strings.ContainsAny(s, `-."()*,:`)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9', c == '_', c >= 0x80:
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 // quoteFTS5String wraps s in double quotes, doubling any quote already

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -511,6 +511,12 @@ func TestSanitizeFTS5Query_ExecutesWithoutError(t *testing.T) {
 		// Mixed-case NEAR is not a keyword but still a hard syntax error
 		// when left bare.
 		"Near(a b)", "near(AMF UE)",
+		// Any ASCII punctuation outside the FTS5 bareword set is a hard
+		// syntax error unquoted; slash-joined reference points (N1/N2,
+		// S5/S8) are routine 3GPP query text.
+		"N1/N2", "S5/S8 interface", "C++", "a=b", "AMF & SMF",
+		"[bracket]", "{brace}", "what?", "don't", "a\\b", "x|y",
+		"100%", "#5", "~x", "N1/N2*", "title:N1/N2",
 	}
 	for _, q := range queries {
 		sanitized := sanitizeFTS5Query(q)

--- a/internal/specver/specver.go
+++ b/internal/specver/specver.go
@@ -106,11 +106,17 @@ func IsDotted(s string) bool {
 // counterpart, and callers display whichever form they have.
 func Normalize(s string) (dotted, token string, err error) {
 	s = strings.TrimSpace(s)
-	// A leading v/V is decoration only in the dotted notation ("v18.6.0").
-	// In a token it is the base-36 digit 31 ("va0" is 31.10.0), so strip the
-	// prefix only when a dotted version follows.
-	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') && IsDotted(s[1:]) {
-		s = s[1:]
+	// A leading v/V is decoration in the dotted notation ("v18.6.0") and in
+	// front of a token ("v920" is the token 920) — but it is also the base-36
+	// digit 31, so a three-character input like "va0" is itself a token
+	// (31.10.0), not a prefixed "a0". Strip the prefix only when what follows
+	// is a dotted version or a full-length token.
+	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') {
+		if rest := s[1:]; IsDotted(rest) {
+			s = rest
+		} else if _, ok := TokenToDotted(strings.ToLower(rest)); ok && len(s) != tokenLength {
+			s = rest
+		}
 	}
 	if s == "" {
 		return "", "", fmt.Errorf("empty version")

--- a/internal/specver/specver.go
+++ b/internal/specver/specver.go
@@ -67,8 +67,8 @@ func DottedToToken(dotted string) (string, bool) {
 	}
 	token := make([]byte, tokenLength)
 	for i, p := range parts {
-		v, err := strconv.Atoi(p)
-		if err != nil || v < 0 || v > maxComponent {
+		v, err := parseComponent(p)
+		if err != nil || v > maxComponent {
 			return "", false
 		}
 		token[i] = digitChar(v)
@@ -76,31 +76,64 @@ func DottedToToken(dotted string) (string, bool) {
 	return string(token), true
 }
 
+// parseComponent parses one dotted-version component: an unsigned decimal
+// number. Unlike strconv.Atoi it rejects a sign, so "+18" is not a component.
+func parseComponent(p string) (int, error) {
+	if p == "" {
+		return 0, fmt.Errorf("empty component")
+	}
+	for i := 0; i < len(p); i++ {
+		if p[i] < '0' || p[i] > '9' {
+			return 0, fmt.Errorf("non-numeric component %q", p)
+		}
+	}
+	v, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, fmt.Errorf("component %q out of range", p)
+	}
+	return v, nil
+}
+
 // IsDotted reports whether s looks like a dotted version ("18.6.0").
 func IsDotted(s string) bool {
 	return strings.Contains(s, ".")
 }
 
-// Normalize accepts either notation and returns both. When only one of the two
-// can be derived, the other is returned empty rather than guessed: unusual
-// tokens (not three digits) and versions with a component above 35 have no
+// Normalize accepts either notation and returns both. The dotted form comes
+// back canonical ("018.6.0" is "18.6.0"). When only one of the two can be
+// derived, the other is returned empty rather than guessed: unusual tokens
+// (not three digits) and versions with a component above 35 have no
 // counterpart, and callers display whichever form they have.
 func Normalize(s string) (dotted, token string, err error) {
 	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "v")
-	s = strings.TrimPrefix(s, "V")
+	// A leading v/V is decoration only in the dotted notation ("v18.6.0").
+	// In a token it is the base-36 digit 31 ("va0" is 31.10.0), so strip the
+	// prefix only when a dotted version follows.
+	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') && IsDotted(s[1:]) {
+		s = s[1:]
+	}
 	if s == "" {
 		return "", "", fmt.Errorf("empty version")
 	}
 
 	if IsDotted(s) {
-		if t, ok := DottedToToken(s); ok {
-			return s, t, nil
-		}
-		if len(strings.Split(s, ".")) != tokenLength {
+		parts := strings.Split(s, ".")
+		if len(parts) != tokenLength {
 			return "", "", fmt.Errorf("invalid version %q: expected three dot-separated components", s)
 		}
-		return s, "", nil
+		nums := make([]string, tokenLength)
+		for i, p := range parts {
+			v, err := parseComponent(p)
+			if err != nil {
+				return "", "", fmt.Errorf("invalid version %q: %w", s, err)
+			}
+			nums[i] = strconv.Itoa(v)
+		}
+		dotted = strings.Join(nums, ".")
+		if t, ok := DottedToToken(dotted); ok {
+			return dotted, t, nil
+		}
+		return dotted, "", nil
 	}
 
 	s = strings.ToLower(s)

--- a/internal/specver/specver_test.go
+++ b/internal/specver/specver_test.go
@@ -44,6 +44,9 @@ func TestDottedToToken(t *testing.T) {
 		{"18.6", "", false},
 		{"18.6.0.1", "", false},
 		{"x.y.z", "", false},
+		{"+18.6.0", "", false},                   // strconv leniency must not admit a sign
+		{"18..0", "", false},                     // empty component
+		{"18.99999999999999999999.0", "", false}, // component overflows int
 		{"", "", false},
 	}
 	for _, tt := range tests {

--- a/internal/specver/specver_test.go
+++ b/internal/specver/specver_test.go
@@ -84,6 +84,8 @@ func TestNormalize(t *testing.T) {
 		{in: "k2", dotted: "", token: "k2", desc: "odd token kept as-is"},
 		{in: "va0", dotted: "31.10.0", token: "va0", desc: "token starting with the digit v"},
 		{in: "v00", dotted: "31.0.0", token: "v00", desc: "token v00 is release 31, not a prefixed 00"},
+		{in: "v920", dotted: "9.2.0", token: "920", desc: "v prefix on a token"},
+		{in: "V920", dotted: "9.2.0", token: "920", desc: "uppercase prefix on a token"},
 		{in: "018.6.0", dotted: "18.6.0", token: "i60", desc: "leading zeros canonicalized"},
 		{in: "18.6", wantErr: true, desc: "two components"},
 		{in: "+18.6.0", wantErr: true, desc: "signed component"},

--- a/internal/specver/specver_test.go
+++ b/internal/specver/specver_test.go
@@ -82,7 +82,12 @@ func TestNormalize(t *testing.T) {
 		{in: " 18.6.0 ", dotted: "18.6.0", token: "i60", desc: "surrounding space"},
 		{in: "36.0.0", dotted: "36.0.0", token: "", desc: "no token counterpart"},
 		{in: "k2", dotted: "", token: "k2", desc: "odd token kept as-is"},
+		{in: "va0", dotted: "31.10.0", token: "va0", desc: "token starting with the digit v"},
+		{in: "v00", dotted: "31.0.0", token: "v00", desc: "token v00 is release 31, not a prefixed 00"},
+		{in: "018.6.0", dotted: "18.6.0", token: "i60", desc: "leading zeros canonicalized"},
 		{in: "18.6", wantErr: true, desc: "two components"},
+		{in: "+18.6.0", wantErr: true, desc: "signed component"},
+		{in: "18.foo.0", wantErr: true, desc: "non-numeric component"},
 		{in: "", wantErr: true, desc: "empty"},
 	}
 	for _, tt := range tests {

--- a/internal/structdiff/imageref.go
+++ b/internal/structdiff/imageref.go
@@ -66,9 +66,14 @@ func foldName(name string) string {
 }
 
 // foldAlt maps an alt text that adds no information beyond the filename to
-// the "Figure" default the converter uses.
+// the "Figure" default the converter uses. The comparison uses foldName on
+// both sides so a filename-shaped alt still folds against a
+// collision-disambiguated conversion name: alt "image1.wmf" must match name
+// "image1.wmf.png" the same way it matches the unconverted "image1.wmf", or
+// the two sides of a compare would fold differently and a pure conversion
+// difference would show up as a content change.
 func foldAlt(alt, name string) string {
-	if alt == "" || alt == name ||
+	if alt == "" || alt == name || foldName(alt) == foldName(name) ||
 		strings.TrimSuffix(alt, path.Ext(alt)) == strings.TrimSuffix(name, path.Ext(name)) {
 		return "Figure"
 	}

--- a/internal/structdiff/imageref_test.go
+++ b/internal/structdiff/imageref_test.go
@@ -91,6 +91,15 @@ func TestNormalizeImageRefs(t *testing.T) {
 			b:    "![Figure](image://image1.wmf.png)",
 			same: true,
 		},
+		{
+			// A filename-shaped alt must fold the same way against the
+			// disambiguated conversion name as against the original, or the
+			// alt survives on one side only and the keys differ.
+			name: "filename alt folds against disambiguated conversion name",
+			a:    "![image1.wmf](image://image1.wmf)",
+			b:    "![image1.wmf](image://image1.wmf.png)",
+			same: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -93,13 +93,15 @@ func SetupTestDB(t testing.TB) *db.DB {
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
+	// Register before the ExecScript calls: their t.Fatalf would otherwise
+	// leave the database open.
+	t.Cleanup(func() { _ = d.Close() })
 	if err := d.ExecScript(db.Schema); err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 	if err := d.ExecScript(SeedData); err != nil {
 		t.Fatalf("failed to seed data: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() })
 	return d
 }
 

--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -195,7 +195,11 @@ func familyPartsHint(ctx context.Context, src *Source, specID string, oldErr, ne
 
 func checkComparable(ctx context.Context, src *Source, specID, sectionNumber string, oldSecs, newSecs []db.Section, oldRes, newRes Resolution) *mcp.CallToolResult {
 	if len(oldSecs) == 0 && len(newSecs) == 0 {
-		if parts, err := src.DB.FindSpecIDsByFamily(ctx, specID); err == nil && len(parts) > 0 {
+		parts, err := src.DB.FindSpecIDsByFamily(ctx, specID)
+		if err != nil {
+			return errorResult(fmt.Sprintf("failed to check %s for parts: %v", specID, err))
+		}
+		if len(parts) > 0 {
 			return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", specID, strings.Join(parts, ", ")))
 		}
 		if sectionNumber != "" {

--- a/tools/compare_versions.go
+++ b/tools/compare_versions.go
@@ -187,7 +187,11 @@ func familyPartsHint(ctx context.Context, src *Source, specID string, oldErr, ne
 	if oldErr == nil || newErr == nil {
 		return nil
 	}
-	if parts, err := src.DB.FindSpecIDsByFamily(ctx, specID); err == nil && len(parts) > 0 {
+	parts, err := src.DB.FindSpecIDsByFamily(ctx, specID)
+	if err != nil {
+		return errorResult(fmt.Sprintf("failed to check %s for parts: %v", specID, err))
+	}
+	if len(parts) > 0 {
 		return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", specID, strings.Join(parts, ", ")))
 	}
 	return nil

--- a/tools/get_section.go
+++ b/tools/get_section.go
@@ -39,7 +39,11 @@ func HandleGetSection(src *Source) func(ctx context.Context, req *mcp.CallToolRe
 		}
 
 		if len(sections) == 0 {
-			if parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID); partsErr == nil && len(parts) > 0 {
+			parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID)
+			if partsErr != nil {
+				return errorResult(fmt.Sprintf("failed to check %s for parts: %v", input.SpecID, partsErr)), nil, nil
+			}
+			if len(parts) > 0 {
 				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 			}
 			return errorResult(fmt.Sprintf("section %s not found in %s%s", input.SectionNumber, input.SpecID, versionSuffix(res))), nil, nil

--- a/tools/get_toc.go
+++ b/tools/get_toc.go
@@ -31,7 +31,11 @@ func HandleGetTOC(src *Source) func(ctx context.Context, req *mcp.CallToolReques
 		}
 
 		if len(sections) == 0 {
-			if parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID); partsErr == nil && len(parts) > 0 {
+			parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID)
+			if partsErr != nil {
+				return errorResult(fmt.Sprintf("failed to check %s for parts: %v", input.SpecID, partsErr)), nil, nil
+			}
+			if len(parts) > 0 {
 				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 			}
 			return errorResult(fmt.Sprintf("no sections found for %s%s", input.SpecID, versionSuffix(res))), nil, nil
@@ -44,10 +48,13 @@ func HandleGetTOC(src *Source) func(ctx context.Context, req *mcp.CallToolReques
 // RenderTOC renders a specification's sections as a Markdown table of
 // contents. It is shared with the CLI's get-toc command.
 func RenderTOC(sections []db.Section) string {
+	if len(sections) == 0 {
+		return ""
+	}
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# %s - Table of Contents\n\n", specLabel(sections[0]))
 	for _, s := range sections {
-		indent := strings.Repeat("  ", s.Level-1)
+		indent := strings.Repeat("  ", max(s.Level-1, 0))
 		if s.Number != "" && s.Number != s.Title {
 			fmt.Fprintf(&sb, "%s- %s %s\n", indent, s.Number, s.Title)
 		} else {

--- a/tools/list_images.go
+++ b/tools/list_images.go
@@ -33,7 +33,11 @@ func HandleListImages(src *Source) func(ctx context.Context, req *mcp.CallToolRe
 
 		if len(images) == 0 {
 			if !res.Archived {
-				if parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID); partsErr == nil && len(parts) > 0 {
+				parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID)
+				if partsErr != nil {
+					return errorResult(fmt.Sprintf("failed to check %s for parts: %v", input.SpecID, partsErr)), nil, nil
+				}
+				if len(parts) > 0 {
 					return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 				}
 			}

--- a/tools/list_versions.go
+++ b/tools/list_versions.go
@@ -133,7 +133,11 @@ func HandleListVersions(src *Source) func(ctx context.Context, req *mcp.CallTool
 			if archiveErr != nil {
 				return errorResult(fmt.Sprintf("no versions found for %s: %v", input.SpecID, archiveErr)), nil, nil
 			}
-			if parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID); partsErr == nil && len(parts) > 0 {
+			parts, partsErr := src.DB.FindSpecIDsByFamily(ctx, input.SpecID)
+			if partsErr != nil {
+				return errorResult(fmt.Sprintf("failed to check %s for parts: %v", input.SpecID, partsErr)), nil, nil
+			}
+			if len(parts) > 0 {
 				return errorResult(fmt.Sprintf("%s has multiple parts: %s — specify one", input.SpecID, strings.Join(parts, ", "))), nil, nil
 			}
 			return errorResult(fmt.Sprintf("no versions found for %s", input.SpecID)), nil, nil

--- a/tools/search.go
+++ b/tools/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/higebu/3gpp-mcp/db"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -48,7 +49,7 @@ Tips:
 
 func HandleSearch(d *db.DB) func(ctx context.Context, req *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchInput) (*mcp.CallToolResult, any, error) {
-		if input.Query == "" {
+		if strings.TrimSpace(input.Query) == "" {
 			return errorResult("query is required"), nil, nil
 		}
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -106,6 +106,17 @@ func TestHandleGetTOC(t *testing.T) {
 		}
 	})
 
+	t.Run("render guards", func(t *testing.T) {
+		if got := RenderTOC(nil); got != "" {
+			t.Errorf("RenderTOC(nil) = %q, want empty", got)
+		}
+		// A non-positive level must not panic strings.Repeat.
+		got := RenderTOC([]db.Section{{SpecID: "TS 23.501", Number: "1", Title: "Scope", Level: 0}})
+		if !strings.Contains(got, "- 1 Scope") {
+			t.Errorf("RenderTOC with level 0 = %q, want it to contain %q", got, "- 1 Scope")
+		}
+	})
+
 	t.Run("family spec id with multiple parts", func(t *testing.T) {
 		if err := d.ExecScript(`INSERT INTO specs (id, version, version_token, title, release, series) VALUES
     ('TS 38.101-1', '18.6.0', 'i60', 'Part 1', '18', '38'),

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -150,7 +150,7 @@ func (h *handler) initTemplates() {
 			return "/specs/" + url.PathEscape(specID)
 		},
 		"sectionURL": func(specID, number, version string) string {
-			u := "/specs/" + url.PathEscape(specID) + "/sections/" + number
+			u := "/specs/" + url.PathEscape(specID) + "/sections/" + url.PathEscape(number)
 			if version != "" {
 				u += "?version=" + url.QueryEscape(version)
 			}
@@ -672,7 +672,7 @@ func refURL(ref db.Reference) string {
 	}
 	u := "/specs/" + url.PathEscape(target)
 	if ref.TargetSection != "" {
-		u += "/sections/" + ref.TargetSection
+		u += "/sections/" + url.PathEscape(ref.TargetSection)
 	}
 	return u
 }

--- a/web/segment.go
+++ b/web/segment.go
@@ -110,10 +110,41 @@ func fenceInfo(line string) (char byte, length int, info string) {
 }
 
 // splitInlineCode splits a chunk containing no fenced blocks into text and
-// inline-code segments. Per CommonMark 6.1, a code span opens with a run of
-// backticks and closes at the next run of exactly the same length; an
-// unmatched run is literal text, and a span may not cross a blank line.
+// inline-code segments. A converter-emitted <table> region is kept whole as
+// text first: backticks inside it are cell content, and a code span opening
+// or closing inside the region would slice the table across segments —
+// breaking the verbatim passthrough escapeOutsideTables gives table markup,
+// so LinkifyRefs anchors and cell wrappers would render as literal text.
+// Region bounds mirror escapeOutsideTables: a line-start opener, and an
+// opener without a closer is not a region.
 func splitInlineCode(chunk string) []mdSegment {
+	var segs []mdSegment
+	for len(chunk) > 0 {
+		loc := tableOpenRE.FindStringIndex(chunk)
+		end := -1
+		if loc != nil {
+			if rel := strings.Index(chunk[loc[0]:], "</table>"); rel >= 0 {
+				end = loc[0] + rel + len("</table>")
+			}
+		}
+		if end < 0 {
+			segs = append(segs, scanInlineCode(chunk)...)
+			return segs
+		}
+		if loc[0] > 0 {
+			segs = append(segs, scanInlineCode(chunk[:loc[0]])...)
+		}
+		segs = append(segs, mdSegment{text: chunk[loc[0]:end]})
+		chunk = chunk[end:]
+	}
+	return segs
+}
+
+// scanInlineCode performs the code-span scan on a chunk containing no fenced
+// blocks and no table regions. Per CommonMark 6.1, a code span opens with a
+// run of backticks and closes at the next run of exactly the same length; an
+// unmatched run is literal text, and a span may not cross a blank line.
+func scanInlineCode(chunk string) []mdSegment {
 	var segs []mdSegment
 	textStart := 0
 	i := 0

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -5,11 +5,19 @@
     const toggle = document.getElementById('theme-toggle');
     const html = document.documentElement;
 
+    // localStorage can throw (private browsing, storage disabled); the
+    // preference then simply lasts for the page instead of persisting.
+    const persist = function (key, value) {
+        try {
+            localStorage.setItem(key, value);
+        } catch (e) { /* ignore */ }
+    };
+
     if (toggle) {
         toggle.addEventListener('click', function () {
             const next = html.dataset.theme === 'dark' ? 'light' : 'dark';
             html.dataset.theme = next;
-            localStorage.setItem('theme', next);
+            persist('theme', next);
         });
     }
 
@@ -54,7 +62,7 @@
             setOpen(settingsPopover.hidden);
         });
         document.addEventListener('click', function (e) {
-            if (!settingsPopover.hidden && !settingsPopover.contains(e.target) && e.target !== settingsToggle) {
+            if (!settingsPopover.hidden && !settingsPopover.contains(e.target) && !settingsToggle.contains(e.target)) {
                 setOpen(false);
             }
         });
@@ -71,7 +79,7 @@
             radio.addEventListener('change', function () {
                 if (radio.checked) {
                     html.dataset.codeTheme = radio.value;
-                    localStorage.setItem('codeTheme', radio.value);
+                    persist('codeTheme', radio.value);
                 }
             });
         });
@@ -145,7 +153,7 @@
     // ::backdrop target the dialog itself), and Escape is native <dialog>
     // behavior.
     const sectionBody = document.querySelector('.section-body');
-    if (sectionBody) {
+    if (sectionBody && typeof HTMLDialogElement !== 'undefined' && HTMLDialogElement.prototype.showModal) {
         let lightbox = null;
         const openLightbox = function (img) {
             if (!lightbox) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1397,6 +1397,12 @@ body:has(dialog.lightbox[open]) {
 /* GenericTraceback */ [data-theme="dark"][data-code-theme="github"] .chroma .gt { color: #ff7b72 }
 /* GenericUnderline */ [data-theme="dark"][data-code-theme="github"] .chroma .gl { text-decoration: underline }
 /* TextWhitespace */ [data-theme="dark"][data-code-theme="github"] .chroma .w { color: #6e7681 }
+/* Classes only the light half styles, pinned to the dark style's base colour so light ink cannot bleed into dark mode: */
+/* NameAttribute */ [data-theme="dark"][data-code-theme="github"] .chroma .na { color: #e6edf3 }
+/* NameBuiltin */ [data-theme="dark"][data-code-theme="github"] .chroma .nb { color: #e6edf3 }
+/* NameBuiltinPseudo */ [data-theme="dark"][data-code-theme="github"] .chroma .bp { color: #e6edf3 }
+/* NameOther */ [data-theme="dark"][data-code-theme="github"] .chroma .nx { color: #e6edf3 }
+/* Punctuation */ [data-theme="dark"][data-code-theme="github"] .chroma .p { color: #e6edf3 }
 
 /* --- monokai: monokailight (light) --- */
 /* Error */ [data-code-theme="monokai"] .chroma .err { color: #960050; background-color: #1e0010 }
@@ -1519,6 +1525,20 @@ body:has(dialog.lightbox[open]) {
 /* GenericInserted */ [data-theme="dark"][data-code-theme="monokai"] .chroma .gi { color: #a6e22e }
 /* GenericStrong */ [data-theme="dark"][data-code-theme="monokai"] .chroma .gs { font-weight: bold }
 /* GenericSubheading */ [data-theme="dark"][data-code-theme="monokai"] .chroma .gu { color: #75715e }
+/* Classes only the light half styles, pinned to the dark style's base colour so light ink cannot bleed into dark mode: */
+/* Name */ [data-theme="dark"][data-code-theme="monokai"] .chroma .n { color: #f8f8f2 }
+/* NameBuiltin */ [data-theme="dark"][data-code-theme="monokai"] .chroma .nb { color: #f8f8f2 }
+/* NameBuiltinPseudo */ [data-theme="dark"][data-code-theme="monokai"] .chroma .bp { color: #f8f8f2 }
+/* NameEntity */ [data-theme="dark"][data-code-theme="monokai"] .chroma .ni { color: #f8f8f2 }
+/* NameLabel */ [data-theme="dark"][data-code-theme="monokai"] .chroma .nl { color: #f8f8f2 }
+/* NameNamespace */ [data-theme="dark"][data-code-theme="monokai"] .chroma .nn { color: #f8f8f2 }
+/* NameProperty */ [data-theme="dark"][data-code-theme="monokai"] .chroma .py { color: #f8f8f2 }
+/* NameVariable */ [data-theme="dark"][data-code-theme="monokai"] .chroma .nv { color: #f8f8f2 }
+/* NameVariableClass */ [data-theme="dark"][data-code-theme="monokai"] .chroma .vc { color: #f8f8f2 }
+/* NameVariableGlobal */ [data-theme="dark"][data-code-theme="monokai"] .chroma .vg { color: #f8f8f2 }
+/* NameVariableInstance */ [data-theme="dark"][data-code-theme="monokai"] .chroma .vi { color: #f8f8f2 }
+/* NameVariableMagic */ [data-theme="dark"][data-code-theme="monokai"] .chroma .vm { color: #f8f8f2 }
+/* Punctuation */ [data-theme="dark"][data-code-theme="monokai"] .chroma .p { color: #f8f8f2 }
 
 /* --- xcode-dracula: xcode (light) --- */
 /* Error */ [data-code-theme="xcode-dracula"] .chroma .err { color: #000000 }
@@ -1641,6 +1661,18 @@ body:has(dialog.lightbox[open]) {
 /* GenericOutput */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .go { color: #44475a }
 /* GenericSubheading */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .gu { font-weight: bold }
 /* GenericUnderline */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .gl { text-decoration: underline }
+/* Classes only the light half styles, pinned to the dark style's base colour so light ink cannot bleed into dark mode: */
+/* Error */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .err { color: #f8f8f2 }
+/* Literal */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .l { color: #f8f8f2 }
+/* LiteralDate */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .ld { color: #f8f8f2 }
+/* Name */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .n { color: #f8f8f2 }
+/* NameConstant */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .no { color: #f8f8f2 }
+/* NameDecorator */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .nd { color: #f8f8f2 }
+/* NameEntity */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .ni { color: #f8f8f2 }
+/* NameException */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .ne { color: #f8f8f2 }
+/* NameNamespace */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .nn { color: #f8f8f2 }
+/* NameOther */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .nx { color: #f8f8f2 }
+/* NameProperty */ [data-theme="dark"][data-code-theme="xcode-dracula"] .chroma .py { color: #f8f8f2 }
 
 /* === Settings popover (code highlighting theme) === */
 .settings-menu { position: relative; }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -70,6 +70,16 @@ func TestRenderMarkdown(t *testing.T) {
 			specID:  "TS 38.211",
 			want:    `<span class="math-display">\frac{1}{2}</span>`,
 		},
+		{
+			// Two backticks inside one table region must not open a code
+			// span: a span crossing cell boundaries would slice the table
+			// across segments and mangle the markup the table passthrough
+			// protects, such as LinkifyRefs anchors.
+			name:    "table with backticks stays whole",
+			content: "<table><tr><td>rate `a</td><td>rate `b</td><td><a href=\"/specs/TS%2023.501\">TS 23.501</a></td></tr></table>",
+			specID:  "TS 38.211",
+			want:    `<a href="/specs/TS%2023.501">TS 23.501</a>`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes verified findings from a full-repo review with OpenCodeReview (`ocr`) using DeepSeek v4 Pro, followed by a code review pass and a delegated re-review of files the first scan missed.

## Bug fixes

- **specver**: `Normalize` stripped a leading `v`/`V` unconditionally, corrupting base-36 tokens whose first digit is `v` (release 31, e.g. `va0`). It now strips the prefix only before a dotted version or a full-length token, rejects signed/non-numeric components, and returns the dotted form in canonical shape.
- **release**: `.goreleaser.yaml` pointed `main` at `./...`, which `go build -o` rejects; every release build would have failed. Now builds `./cmd/3gpp-mcp`.
- **converter**: decompressed reads of zip entries and PCZ payloads were unbounded; a crafted archive could exhaust memory. Reads are now capped at 1 GiB.
- **converter**: `<m:degHide/>` and friends without `m:val` mean true per ECMA-376 but were treated as false, rendering radical degrees and n-ary limits Word hides. Name-collision handling also ignored failed siblings, so `image://image1.wmf` could be rewritten to the EMF sibling's content.
- **pipeline**: OpenAPI YAML extracted from DOC_ONLY/NO_DOC archives was never imported; it is now imported on the no-document path (and only there, so a failed parse cannot advance `openapi_specs` ahead of the spec text). Cache keys are percent-encoded so parameters can neither escape the cache directory nor collide. Retry backoff is context-aware.
- **db**: FTS5 quoting listed only eight punctuation characters, so routine queries like `N1/N2` or `C++` failed the whole search with a syntax error. Any character outside FTS5's bareword set is now quoted.
- **web**: dark mode kept light Chroma token colors for classes the dark themes left unstyled (near-invisible `#111111` on `#0d1117` for monokai names/punctuation); the dark blocks are now complete, generated from chroma v2.27.0. Backticks inside a table no longer slice the region across segments and mangle linkified anchors. Section numbers are URL-escaped; the settings popover, lightbox and localStorage handling are hardened.
- **tools**: five tools silently folded `FindSpecIDsByFamily` errors into definitive "not found" answers; failures are now surfaced. TOC rendering and search input are guarded against empty/whitespace edge cases.
- **update**: a failed final rename no longer deletes the finalized working copy, which holds an import that cost hours.

## Validation

- `gofmt` / `go vet` / `golangci-lint` (0 issues), `go test -short ./...` all green; regression tests added for the specver, OMML, image-collision, FTS5, table-segmentation and structdiff fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMwSb3Sg2yvToiCGB3JBCB)_