### PR TITLE
fix(db): match spec references written without a separator

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1534,6 +1534,20 @@ const spPlus = `(?:` + sp + `+(?:` + lineBreak + sp + `*)?|` + lineBreak + sp + 
 
 const spStar = `(?:` + spPlus + `)?`
 
+// specDesig matches a TS/TR spec designator with optional 3GPP prefix. The
+// separator after the keyword is optional so the no-separator form TR36.873
+// matches (issue #205); the \b rejects a designator glued to a preceding word
+// character (PARTS23.501, 5TS 23.501) — the same trade-off as specPatternRE
+// in converter/docx/metadata.go, which also shares the lack of a trailing
+// boundary: a spec-like prefix of a longer token (TR 38.5MHz) matched before
+// this form existed and still does. The \b sits before the optional 3GPP
+// group so the glued 3GPPTS form still matches.
+// Two capture groups: (TS|TR), (\d+\.\d+).
+const specDesig = `\b(?:3GPP` + spStar + `)?(TS|TR)` + spStar + `(\d+\.\d+)`
+
+// specDesigRaw is specDesig without capture groups, for the context gates.
+const specDesigRaw = `\b(?:3GPP` + spStar + `)?(?:TS|TR)` + spStar + `\d+\.\d+`
+
 // spGapStar returns a possibly-empty separator run holding one optional
 // punctuation character from punct ("TS 23.501, clause 5.1" as well as
 // "TS 23.501 clause 5.1"), still carrying at most one line break in the whole
@@ -1572,13 +1586,13 @@ const bareRefChain = `(?:` + spStar + `(?:[,;]` + spStar + `(?:(?:and|or)` + spS
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
-	tsRefRE = regexp.MustCompile(`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)(?:` + spGapStar(`,;`) + `(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + spPlus + secNum + `)?`)
+	tsRefRE = regexp.MustCompile(specDesig + `(?:` + spGapStar(`,;`) + `(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + spPlus + secNum + `)?`)
 	// "Annex H of 3GPP TS 33.203" or "subclause 5.1 of TS 23.228"
-	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum + spPlus + `of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum + spPlus + `of` + spPlus + specDesig)
 	rfcRefRE      = regexp.MustCompile(`(?:IETF` + spPlus + `)?RFC` + spPlus + `(\d+)(?:` + spGapStar(`,;`) + `(?:section|clause)` + spPlus + `(\d+(?:\.\d+)*))?`)
 
 	// bracketMapRE extracts [N] -> TS/TR XX.YYY mappings from the References section.
-	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spPlus + specDesig)
 	// bracketRefRE matches "[N] clause/section/subclause/annex X" patterns.
 	bracketRefRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spStar + `(?:,` + spStar + `)?(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum)
 
@@ -1587,13 +1601,13 @@ var (
 	tsMultiPrefixRefRE = regexp.MustCompile(
 		`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
 			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b` + spPlus +
-			`of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` +
+			`of` + spPlus + specDesig +
 			`(?:` + spStar + `\[(\d+[A-Za-z]*)\])?`)
 
 	// tsMultiRefRE matches "TS 23.402 clauses 8.2 and 16.11" (spec before multi-section list).
 	// Groups: 1=TS|TR, 2=spec-number, 3=keyword, 4=section-list.
 	tsMultiRefRE = regexp.MustCompile(
-		`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` + spPlus +
+		specDesig + spPlus +
 			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
 			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b`)
 
@@ -1608,7 +1622,7 @@ var (
 	tsCoordPrefixRefRE = regexp.MustCompile(
 		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + spPlus + secNumRaw +
 			`(?:` + spStar + `(?:,|and|or)` + spStar + coordElemTail + `)+)` +
-			spPlus + `(?:of|in)` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+			spPlus + `(?:of|in)` + spPlus + specDesig)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
@@ -1649,8 +1663,8 @@ var (
 
 	// bareTrailingParenSpecRE matches a parenthesized designator right after a
 	// bare reference ("clause 4.2 (TS 23.402)"), tying it to that document.
-	bareTrailingParenSpecRE = regexp.MustCompile(`^` + spStar + `\(` + spStar + `(?:3GPP` + spPlus +
-		`)?(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])`)
+	bareTrailingParenSpecRE = regexp.MustCompile(`^` + spStar + `\(` + spStar +
+		`(?:` + specDesigRaw + `|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])`)
 
 	// bareLeadingSpecRE matches a spec designator or bracket reference before
 	// a bare reference — directly ("TS 23.402 Clause 5.1", "RFC 3748
@@ -1659,7 +1673,7 @@ var (
 	// the lowercase-only qualified patterns (and thus the overlap gate) do
 	// not cover the element itself.
 	bareLeadingSpecRE = regexp.MustCompile(
-		`(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])` +
+		`(?:` + specDesigRaw + `|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])` +
 			`(?:` + spPlus + `(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + spPlus + `)?` + secNumRaw + bareRefChain + `)?` +
 			spGapStar(`,;:`) + `(?:(?:and|or)` + spPlus + `)?$`)
 )

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2520,6 +2520,124 @@ func TestExtractReferences_CoordinatedList(t *testing.T) {
 	}
 }
 
+// Regression test for #205: a reference written without a separator between
+// the TS/TR keyword and the spec number (TR36.873) must still produce an edge.
+func TestExtractReferences_NoSeparator(t *testing.T) {
+	content := "Channel models are described in TR36.873 [14] and evaluated further."
+
+	refs := ExtractReferences("TR 38.843", "6.2.1", content, nil)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TR 36.873" || refs[0].TargetSection != "" {
+		t.Errorf("expected a section-less reference to TR 36.873, got %+v", refs[0])
+	}
+}
+
+func TestExtractReferences_NoSeparatorWithClause(t *testing.T) {
+	content := "The procedures are described in TS23.501 clause 5.1."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 23.501" || refs[0].TargetSection != "5.1" {
+		t.Errorf("expected TS 23.501 section 5.1, got %+v", refs[0])
+	}
+}
+
+func TestExtractReferences_NoSeparatorPrefixForm(t *testing.T) {
+	// Like TestExtractReferences_PrefixPattern, only the sectioned reference
+	// is asserted: the prefix form also emits a whole-spec reference from
+	// tsRefRE, with or without a separator.
+	content := "As specified in clause 7.2 of TR36.873."
+
+	refs := ExtractReferences("TR 38.843", "6.2.1", content, nil)
+	found := false
+	for _, r := range refs {
+		if r.TargetSpec == "TR 36.873" && r.TargetSection == "7.2" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected reference to TR 36.873 section 7.2, got refs: %+v", refs)
+	}
+}
+
+func TestExtractReferences_NoSeparatorMultiSection(t *testing.T) {
+	content := "See TR36.873 clauses 5.1 and 5.2 for details."
+
+	refs := ExtractReferences("TR 38.843", "6.2.1", content, nil)
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d: %+v", len(refs), refs)
+	}
+	for _, want := range []string{"5.1", "5.2"} {
+		found := false
+		for _, r := range refs {
+			if r.TargetSpec == "TR 36.873" && r.TargetSection == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected reference to TR 36.873 section %s, got refs: %+v", want, refs)
+		}
+	}
+	for _, r := range refs {
+		if r.TargetSection == "" {
+			t.Errorf("unexpected reference with empty TargetSection: %+v", r)
+		}
+	}
+}
+
+// The \b guard that pays for the optional separator: a TS/TR glued to a
+// preceding word character (letter, digit or underscore) is an identifier,
+// not a reference. "PARTS 23.501" and "5TS 23.501" matched before #205; the
+// guard drops them deliberately.
+func TestExtractReferences_GluedPrefixRejected(t *testing.T) {
+	content := "The variable PARTS23.501, the token NRTR38.331, the field _TS 23.501 and " +
+		"the label 5TS 23.501 are identifiers, and PARTS 23.501 is not a spec."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+	if len(refs) != 0 {
+		t.Fatalf("expected 0 references, got %d: %+v", len(refs), refs)
+	}
+}
+
+// A glued 3GPP prefix (3GPPTS 23.501) matched before #205 because nothing
+// guarded the keyword's left side; the \b sits before the optional 3GPP group
+// so both the old glued form and the fully glued form keep matching.
+func TestExtractReferences_GluedGPPPrefix(t *testing.T) {
+	content := "See 3GPPTS 23.501 and 3GPPTS23.502 for details."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d: %+v", len(refs), refs)
+	}
+	specSet := make(map[string]bool)
+	for _, r := range refs {
+		specSet[r.TargetSpec] = true
+	}
+	if !specSet["TS 23.501"] {
+		t.Error("expected reference to TS 23.501 (glued 3GPP prefix)")
+	}
+	if !specSet["TS 23.502"] {
+		t.Error("expected reference to TS 23.502 (fully glued designator)")
+	}
+}
+
+func TestParseBracketedRefMap_NoSeparator(t *testing.T) {
+	content := "[14]\t3GPP TR36.873: \"Study on 3D channel model for LTE\""
+	m := ParseBracketedRefMap(content)
+	if m == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if m["14"] != "TR 36.873" {
+		t.Errorf("expected TR 36.873, got %q", m["14"])
+	}
+}
+
 // TestSanitizeFTS5Query_CaretKeepsAnchor verifies the initial-token anchor
 // still anchors after sanitizing: quoting the caret into the string would
 // silently turn "^scope" into a match-anywhere query.

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -618,6 +618,51 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 	}
 }
 
+// Regression tests for #205: designators written without a separator
+// (TR36.873) are linkified, and the context gates recognize them as qualified
+// territory so no spurious same-document link appears next to them.
+func TestLinkifyRefs_NoSeparator(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no-separator TR ref",
+			input: "Channel models are given in TR36.873 [14].",
+			want:  "Channel models are given in [TR36.873](/specs/TR 36.873) [14].",
+		},
+		{
+			name:  "no-separator TS ref with clause",
+			input: "See TS23.402 clause 5.1 for details.",
+			want:  "See [TS23.402 clause 5.1](/specs/TS 23.402/sections/5.1) for details.",
+		},
+		{
+			name:  "capitalized after no-separator spec not linked bare",
+			input: "See TR36.873 Clause 5.1.",
+			want:  "See [TR36.873](/specs/TR 36.873) Clause 5.1.",
+		},
+		{
+			name:  "parenthesized no-separator designator not linked bare",
+			input: "See clause 4.2 (TR36.873).",
+			want:  "See clause 4.2 ([TR36.873](/specs/TR 36.873)).",
+		},
+		{
+			name:  "letter-glued designator stays plain",
+			input: "the identifier PARTS23.501 stays plain",
+			want:  "the identifier PARTS23.501 stays plain",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LinkifyRefs(tt.input, LinkifyRefsOpts{URLFor: bareURLFor, SectionExists: bareSectionSet})
+			if got != tt.want {
+				t.Errorf("LinkifyRefs(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLinkifyRefs_BareRefsWithBracketMap(t *testing.T) {
 	bracketMap := map[string]string{"19": "TS 33.203"}
 	tests := []struct {


### PR DESCRIPTION
## Summary

- The reference patterns in db/db.go required at least one separator
  between the TS/TR keyword and the spec number, so references written
  as `TR36.873` produced no `spec_references` edge (#205).
- Add a shared spec-designator building block with an optional
  separator and a `\b` guard rejecting word-glued prefixes
  (`PARTS23.501`), mirroring `specPatternRE` in
  `converter/docx/metadata.go`.
- Apply it to all extraction patterns and both linkifier context gates
  in lockstep, so no-separator references are extracted, linkified,
  and recognized as qualified territory (no spurious same-document
  links next to them).

## Notes

- New edges materialize on the next database build / re-import; the
  stale-row delete on re-import handles same-version refresh.
- No versionstore.cacheSchemaVersion bump: cross-references are
  prebuilt-only and never enter the version cache.
- Out of scope, same family: no-separator RFC references (`RFC2119`)
  and fully glued bracket entries (`[12]TR36.873`).

Fixes #205