### PR TITLE
fix(db): keep part suffix of multi-part spec targets in reference extraction

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1554,6 +1554,20 @@ const secNum = `([A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 // secNumRaw is secNum without capture group, used for multi-section list matching.
 const secNumRaw = `(?:[A-Z](?:\.\d+[A-Za-z]?)*|\d+[A-Za-z]?(?:\.\d+[A-Za-z]?)*)`
 
+// specNumRaw matches a 3GPP spec number including the part suffix of a split
+// multi-part spec: "23.501", "38.101-1", "36.521-1". The part is 1-2 digits,
+// mirroring the canonical spec IDs built from archive filenames
+// (converter/docx/metadata.go filenameRE). The \b keeps a longer digit run
+// from being half-consumed: for "23.501-123" the boundary fails inside the
+// run, the optional group drops, and the match captures the family number.
+// Known limitation: a hyphen-joined spec range ("TS 25.101-25.104") would
+// capture "25.101-25" — RE2 has no lookahead to reject a suffix followed by
+// ".digit" — but that notation does not occur in the corpus.
+const specNumRaw = `(?:\d+\.\d+(?:-\d{1,2}\b)?)`
+
+// specNum is specNumRaw as a capture group, for the extraction patterns.
+const specNum = `(` + specNumRaw + `)`
+
 // coordElemTail matches the reference part of one coordinated-list element:
 // an optional preposition-plus-keyword or bare keyword, then a section
 // number. A preposition requires a keyword after it ("and in clause 4.12.2a"
@@ -1572,13 +1586,13 @@ const bareRefChain = `(?:` + spStar + `(?:[,;]` + spStar + `(?:(?:and|or)` + spS
 
 var (
 	// "TS 23.501 clause 5.1" or "3GPP TS 33.203 Annex H"
-	tsRefRE = regexp.MustCompile(`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)(?:` + spGapStar(`,;`) + `(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + spPlus + secNum + `)?`)
+	tsRefRE = regexp.MustCompile(`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum + `(?:` + spGapStar(`,;`) + `(?:clauses?|sections?|subclauses?|[Aa]nnexe?s?)` + spPlus + secNum + `)?`)
 	// "Annex H of 3GPP TS 33.203" or "subclause 5.1 of TS 23.228"
-	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum + spPlus + `of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+	tsPrefixRefRE = regexp.MustCompile(`(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum + spPlus + `of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum)
 	rfcRefRE      = regexp.MustCompile(`(?:IETF` + spPlus + `)?RFC` + spPlus + `(\d+)(?:` + spGapStar(`,;`) + `(?:section|clause)` + spPlus + `(\d+(?:\.\d+)*))?`)
 
 	// bracketMapRE extracts [N] -> TS/TR XX.YYY mappings from the References section.
-	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+	bracketMapRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum)
 	// bracketRefRE matches "[N] clause/section/subclause/annex X" patterns.
 	bracketRefRE = regexp.MustCompile(`\[(\d+[A-Za-z]*)\]` + spStar + `(?:,` + spStar + `)?(?:clause|section|subclause|[Aa]nnex)` + spPlus + secNum)
 
@@ -1587,13 +1601,13 @@ var (
 	tsMultiPrefixRefRE = regexp.MustCompile(
 		`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
 			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b` + spPlus +
-			`of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` +
+			`of` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum +
 			`(?:` + spStar + `\[(\d+[A-Za-z]*)\])?`)
 
 	// tsMultiRefRE matches "TS 23.402 clauses 8.2 and 16.11" (spec before multi-section list).
 	// Groups: 1=TS|TR, 2=spec-number, 3=keyword, 4=section-list.
 	tsMultiRefRE = regexp.MustCompile(
-		`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)` + spPlus +
+		`(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum + spPlus +
 			`(clauses?|subclauses?|sections?|[Aa]nnexe?s?)` + spPlus +
 			`(` + secNumRaw + `(?:(?:,` + spStar + secNumRaw + `)*` + spPlus + `and` + spPlus + secNumRaw + `))\b`)
 
@@ -1608,7 +1622,7 @@ var (
 	tsCoordPrefixRefRE = regexp.MustCompile(
 		`((?:[Cc]lauses?|[Ss]ubclauses?|[Ss]ections?|[Aa]nnexe?s?)` + spPlus + secNumRaw +
 			`(?:` + spStar + `(?:,|and|or)` + spStar + coordElemTail + `)+)` +
-			spPlus + `(?:of|in)` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + `(\d+\.\d+)`)
+			spPlus + `(?:of|in)` + spPlus + `(?:3GPP` + spPlus + `)?(TS|TR)` + spPlus + specNum)
 
 	// secNumListRE extracts individual section numbers from a comma/and-separated list.
 	secNumListRE = regexp.MustCompile(secNumRaw)
@@ -1650,7 +1664,7 @@ var (
 	// bareTrailingParenSpecRE matches a parenthesized designator right after a
 	// bare reference ("clause 4.2 (TS 23.402)"), tying it to that document.
 	bareTrailingParenSpecRE = regexp.MustCompile(`^` + spStar + `\(` + spStar + `(?:3GPP` + spPlus +
-		`)?(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])`)
+		`)?(?:(?:TS|TR)` + spPlus + specNumRaw + `|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])`)
 
 	// bareLeadingSpecRE matches a spec designator or bracket reference before
 	// a bare reference — directly ("TS 23.402 Clause 5.1", "RFC 3748
@@ -1659,7 +1673,7 @@ var (
 	// the lowercase-only qualified patterns (and thus the overlap gate) do
 	// not cover the element itself.
 	bareLeadingSpecRE = regexp.MustCompile(
-		`(?:(?:TS|TR)` + spPlus + `\d+\.\d+|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])` +
+		`(?:(?:TS|TR)` + spPlus + specNumRaw + `|RFC` + spPlus + `\d+|\[\d+[A-Za-z]*\])` +
 			`(?:` + spPlus + `(?:(?:[Cc]lauses?|[Ss]ections?|[Ss]ubclauses?|[Aa]nnexe?s?)` + spPlus + `)?` + secNumRaw + bareRefChain + `)?` +
 			spGapStar(`,;:`) + `(?:(?:and|or)` + spPlus + `)?$`)
 )

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1259,14 +1259,17 @@ See also 3GPP TS 23.228 annex A.1 for further details.`
 func TestExtractReferences_PrefixPattern(t *testing.T) {
 	// "keyword Y of TS X" pattern (keyword before spec ID)
 	content := `The mode is described in Annex H of 3GPP TS 33.203.
-See subclause 11.9 of TS 29.061 and clause B.1.1 of 3GPP TS 24.186.`
+See subclause 11.9 of TS 29.061 and clause B.1.1 of 3GPP TS 24.186.
+Same as subclause 5.5.4.2 of TS 36.521-1 and clause 6.2 of 3GPP TS 29.198-04.`
 
 	refs := ExtractReferences("TS 24.229", "5.2.2.1", content, nil)
 
 	expect := map[string]string{
-		"TS 33.203": "H",
-		"TS 29.061": "11.9",
-		"TS 24.186": "B.1.1",
+		"TS 33.203":    "H",
+		"TS 29.061":    "11.9",
+		"TS 24.186":    "B.1.1",
+		"TS 36.521-1":  "5.5.4.2",
+		"TS 29.198-04": "6.2",
 	}
 	for spec, section := range expect {
 		found := false
@@ -1279,6 +1282,92 @@ See subclause 11.9 of TS 29.061 and clause B.1.1 of 3GPP TS 24.186.`
 		if !found {
 			t.Errorf("expected reference to %s section %s, got refs: %+v", spec, section, refs)
 		}
+	}
+}
+
+func TestExtractReferences_MultiPartSuffix(t *testing.T) {
+	// Multi-part specs keep their part suffix (#204): before the fix the
+	// suffix was dropped, producing targets like "TS 37.579" that name no
+	// document, and the leftover "-1" blocked tsRefRE's clause tail so the
+	// target section was lost as well.
+	content := `Single cell configuration according to TS 37.579-1 clause 5.2.2.2.1.
+See TS 38.101-2.
+The requirements are defined in 3GPP TS 36.521-3 Annex F.`
+
+	refs := ExtractReferences("TS 37.579-7", "5.1", content, nil)
+	if len(refs) != 3 {
+		t.Fatalf("expected 3 references, got %d: %+v", len(refs), refs)
+	}
+	expect := map[string]string{
+		"TS 37.579-1": "5.2.2.2.1",
+		"TS 38.101-2": "",
+		"TS 36.521-3": "F",
+	}
+	for spec, section := range expect {
+		found := false
+		for _, r := range refs {
+			if r.TargetSpec == spec && r.TargetSection == section {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected reference to %s section %q, got refs: %+v", spec, section, refs)
+		}
+	}
+}
+
+func TestExtractReferences_MultiPartSelfRef(t *testing.T) {
+	// The self-reference exclusion compares full suffixed IDs: a citation of
+	// the source part is excluded, a citation of a sibling part is kept —
+	// it names a different document.
+	content := `See TS 37.579-4 clause 5.1 and TS 37.579-1 clause 5.2.`
+
+	refs := ExtractReferences("TS 37.579-4", "6.2", content, nil)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 37.579-1" || refs[0].TargetSection != "5.2" {
+		t.Errorf("expected TS 37.579-1 clause 5.2, got %+v", refs[0])
+	}
+}
+
+func TestExtractReferences_MultiPartDedup(t *testing.T) {
+	// Repeated citations of one part deduplicate; citations of two parts of
+	// the same family stay distinct.
+	content := `See TS 37.579-1 clause 5.2. As specified in TS 37.579-1 clause 5.2.
+See also TS 37.579-2 clause 5.2.`
+
+	refs := ExtractReferences("TS 37.579-7", "5.1", content, nil)
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d: %+v", len(refs), refs)
+	}
+	for _, spec := range []string{"TS 37.579-1", "TS 37.579-2"} {
+		found := false
+		for _, r := range refs {
+			if r.TargetSpec == spec && r.TargetSection == "5.2" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected reference to %s clause 5.2, got refs: %+v", spec, refs)
+		}
+	}
+}
+
+func TestExtractReferences_SuffixTooLong(t *testing.T) {
+	// A hyphen followed by more than two digits is not a part suffix: the \b
+	// in specNum rejects a partial take of the digit run and the match falls
+	// back to the family number.
+	content := "See TS 23.501-123 for details."
+
+	refs := ExtractReferences("TS 24.229", "5.1", content, nil)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 23.501" || refs[0].TargetSection != "" {
+		t.Errorf("expected section-less reference to TS 23.501, got %+v", refs[0])
 	}
 }
 
@@ -1508,14 +1597,15 @@ func TestParseBracketedRefMap(t *testing.T) {
 [1]	3GPP TR 21.905: "Vocabulary for 3GPP Specifications"
 [2]	3GPP TS 23.228: "IP Multimedia Subsystem (IMS)"
 [19]	3GPP TS 33.203: "Access security for IP-based services"
-[13D]	TS 29.214: "Policy and Charging Control"`
+[13D]	TS 29.214: "Policy and Charging Control"
+[45]	3GPP TS 37.579-1: "Mission Critical (MC) services over LTE; Part 1"`
 
 	m := ParseBracketedRefMap(content)
 	if m == nil {
 		t.Fatal("expected non-nil map")
 	}
-	if len(m) != 4 {
-		t.Fatalf("expected 4 mappings, got %d: %v", len(m), m)
+	if len(m) != 5 {
+		t.Fatalf("expected 5 mappings, got %d: %v", len(m), m)
 	}
 
 	expect := map[string]string{
@@ -1523,6 +1613,7 @@ func TestParseBracketedRefMap(t *testing.T) {
 		"2":   "TS 23.228",
 		"19":  "TS 33.203",
 		"13D": "TS 29.214",
+		"45":  "TS 37.579-1",
 	}
 	for k, v := range expect {
 		if m[k] != v {
@@ -1607,6 +1698,23 @@ func TestExtractReferences_BracketedSelfRef(t *testing.T) {
 	refs := ExtractReferences("TS 24.229", "3", content, bracketMap)
 	if len(refs) != 0 {
 		t.Errorf("expected 0 refs (self-reference excluded), got %d: %+v", len(refs), refs)
+	}
+}
+
+func TestExtractReferences_BracketedMultiPart(t *testing.T) {
+	// Bracket entries resolve to suffixed part IDs: a bracket naming the
+	// source part is a self-reference, a sibling part is kept.
+	content := `See [2] clause 5.2 and [3] clause 6.1.`
+	bracketMap := map[string]string{
+		"2": "TS 37.579-1",
+		"3": "TS 37.579-2",
+	}
+	refs := ExtractReferences("TS 37.579-2", "5.1", content, bracketMap)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].TargetSpec != "TS 37.579-1" || refs[0].TargetSection != "5.2" {
+		t.Errorf("expected TS 37.579-1 clause 5.2, got %+v", refs[0])
 	}
 }
 
@@ -2517,6 +2625,53 @@ func TestExtractReferences_CoordinatedList(t *testing.T) {
 		if !found {
 			t.Errorf("expected reference to TS 23.502 section %s, got refs: %+v", want, refs)
 		}
+	}
+}
+
+func TestExtractReferences_MultiPartMultiSection(t *testing.T) {
+	// The three multi-section patterns keep the part suffix too.
+	cases := []struct {
+		name    string
+		content string
+		wants   []string
+	}{
+		{
+			name:    "prefix list",
+			content: "as defined in clauses 8.2 and 16.11 of TS 38.101-1 [45].",
+			wants:   []string{"8.2", "16.11"},
+		},
+		{
+			name:    "spec-first list",
+			content: "See TS 38.101-1 clauses 8.2 and 16.11 for details.",
+			wants:   []string{"8.2", "16.11"},
+		},
+		{
+			name:    "coordinated list",
+			content: "described in clause 4.12.2 and in clause 4.12.2a of TS 38.101-1, respectively.",
+			wants:   []string{"4.12.2", "4.12.2a"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs := ExtractReferences("TS 24.229", "5.1", tc.content, nil)
+			for _, want := range tc.wants {
+				found := false
+				for _, r := range refs {
+					if r.TargetSpec == "TS 38.101-1" && r.TargetSection == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected reference to TS 38.101-1 section %s, got refs: %+v", want, refs)
+				}
+			}
+			for _, r := range refs {
+				if r.TargetSpec != "TS 38.101-1" {
+					t.Errorf("unexpected target spec %q (part suffix dropped?): %+v", r.TargetSpec, r)
+				}
+			}
+		})
 	}
 }
 

--- a/db/linkify_test.go
+++ b/db/linkify_test.go
@@ -70,6 +70,21 @@ func TestLinkifyRefs_TS(t *testing.T) {
 			input: "See clause 4.2.2.2A.1 of TS 24.502.",
 			want:  "See [clause 4.2.2.2A.1 of TS 24.502](/specs/TS 24.502/sections/4.2.2.2A.1).",
 		},
+		{
+			name:  "multi-part spec with clause",
+			input: "See TS 38.101-1 clause 5.2 for details.",
+			want:  "See [TS 38.101-1 clause 5.2](/specs/TS 38.101-1/sections/5.2) for details.",
+		},
+		{
+			name:  "multi-part spec sentence-final",
+			input: "as specified in TS 36.521-1.",
+			want:  "as specified in [TS 36.521-1](/specs/TS 36.521-1).",
+		},
+		{
+			name:  "clause before multi-part spec",
+			input: "Same as subclause 5.5.4.2 of TS 36.521-1.",
+			want:  "Same as [subclause 5.5.4.2 of TS 36.521-1](/specs/TS 36.521-1/sections/5.5.4.2).",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,6 +133,7 @@ func TestLinkifyRefs_Bracket(t *testing.T) {
 		"19":  "TS 33.203",
 		"2":   "TS 23.228",
 		"13D": "TS 29.214",
+		"45":  "TS 37.579-1",
 	}
 
 	tests := []struct {
@@ -144,6 +160,11 @@ func TestLinkifyRefs_Bracket(t *testing.T) {
 			name:  "unknown bracket ref ignored",
 			input: "See [99] clause 3.",
 			want:  "See [99] clause 3.",
+		},
+		{
+			name:  "bracket ref to multi-part spec",
+			input: "See [45] clause 5.2.",
+			want:  "See [[45] clause 5.2](/specs/TS 37.579-1/sections/5.2).",
 		},
 	}
 	for _, tt := range tests {
@@ -206,6 +227,11 @@ func TestLinkifyRefs_MultiSection(t *testing.T) {
 			name:  "single clause still uses existing pattern",
 			input: "clause 5.1 of TS 23.501",
 			want:  "[clause 5.1 of TS 23.501](/specs/TS 23.501/sections/5.1)",
+		},
+		{
+			name:  "spec-first multi-section with part suffix",
+			input: "TS 38.101-1 clauses 8.2 and 16.11",
+			want:  "[TS 38.101-1](/specs/TS 38.101-1) clauses [8.2](/specs/TS 38.101-1/sections/8.2) and [16.11](/specs/TS 38.101-1/sections/16.11)",
 		},
 	}
 	for _, tt := range tests {
@@ -538,6 +564,16 @@ func TestLinkifyRefs_BareRefs(t *testing.T) {
 			want:  "See clause 4.2 ([TS 23.402](/specs/TS 23.402)).",
 		},
 		{
+			name:  "capitalized after multi-part spec not linked bare",
+			input: "See TS 38.101-1 Clause 5.1.",
+			want:  "See [TS 38.101-1](/specs/TS 38.101-1) Clause 5.1.",
+		},
+		{
+			name:  "parenthesized multi-part designator not linked bare",
+			input: "See clause 4.2 (TS 38.101-1).",
+			want:  "See clause 4.2 ([TS 38.101-1](/specs/TS 38.101-1)).",
+		},
+		{
 			name:  "colon after spec not linked bare",
 			input: "See TS 23.402: Clause 5.1.",
 			want:  "See [TS 23.402](/specs/TS 23.402): Clause 5.1.",
@@ -661,13 +697,16 @@ func TestLinkifyRefs_BareRefsNilGate(t *testing.T) {
 }
 
 // stubTargetInfo validates cross-spec references: TS 23.502 has only 4.12.2,
-// TS 33.203 has only 6; other specs cannot be validated.
+// TS 33.203 has only 6, TS 36.521-1 has only 5.5.4.2; other specs cannot be
+// validated.
 func stubTargetInfo(spec, section string) (bool, string, bool) {
 	switch spec {
 	case "TS 23.502":
 		return section == "4.12.2", "20.2.0", true
 	case "TS 33.203":
 		return section == "6", "18.0.0", true
+	case "TS 36.521-1":
+		return section == "5.5.4.2", "18.5.0", true
 	}
 	return false, "", false
 }
@@ -720,6 +759,11 @@ func TestLinkifyRefs_TargetValidation(t *testing.T) {
 			name:  "RFC references are never validated",
 			input: "See RFC 3748 section 99.9.",
 			want:  "See [RFC 3748 section 99.9](https://www.rfc-editor.org/rfc/rfc3748#section-99.9).",
+		},
+		{
+			name:  "multi-part spec validates against the suffixed ID",
+			input: "See TS 36.521-1 clause 5.5.4.2.",
+			want:  "See [TS 36.521-1 clause 5.5.4.2](/specs/TS 36.521-1/sections/5.5.4.2).",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #204.

## Problem

The reference extractor captured spec numbers as `(\d+\.\d+)`, so citations of multi-part specs like `TS 37.579-1` / `TS 37.579-2` were both stored as target `TS 37.579` — a family number that names no document. On the pinned benchmark database, 28,358 of 352,514 reference edges (8.0%) pointed at such nonexistent unsuffixed targets. This also broke:

- **self-reference exclusion**: the unsuffixed target never equals the suffixed source ID, so `TS 37.579-4` appeared to reference `TS 37.579`
- **target sections**: in `TS 37.579-1 clause 5.2` the leftover `-1` blocked the clause tail of `tsRefRE`, so the section was lost too
- **web viewer links**: `LinkifyRefs` produced `/specs/TS 37.579` links to a spec that does not exist

## Change

Add `specNum`/`specNumRaw` constants that accept an optional 1–2 digit part suffix (`(\d+\.\d+(?:-\d{1,2}\b)?)`, matching the canonical spec IDs built from archive filenames) and use them in all eight spec-number patterns: the six extraction regexes (`tsRefRE`, `tsPrefixRefRE`, `bracketMapRE`, `tsMultiPrefixRefRE`, `tsMultiRefRE`, `tsCoordPrefixRefRE`) and the two bare-ref context gates (`bareLeadingSpecRE`, `bareTrailingParenSpecRE`), so `TS 38.101-1 Clause 5.1` keeps suppressing the bare link.

The extractors, dedup keys, self-reference exclusion, `ParseBracketedRefMap` and `LinkifyRefs` all operate on the captured string and need no changes. Cross-part references (`TS 37.579-7` → `TS 37.579-1`) are kept — they name a different document. The `\b` keeps longer digit runs (`TS 23.501-123`) falling back to the family number. No schema change; no `versionstore.cacheSchemaVersion` bump (converted Markdown output is untouched). Existing databases pick up the fix on the next rebuild.

## Tests

- extraction: suffix kept with clause/annex/section-less citations, part-aware self-reference exclusion and dedup, `-123` fallback, suffixed bracket-map entries and bracket refs, all three multi-section patterns
- linkify: suffixed spec/prefix/bracket/multi-section links, bare-ref gate regressions, target validation against the suffixed ID

`gofmt` / `go vet` / `golangci-lint` clean, `go test ./...` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzBLPiGG5hh6qZCd19DBpx)_