### PR TITLE
fix(pipeline): reject partial archive listings in latest builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,4 +502,5 @@ Conventions shared by all of them:
 | `THREEGPP_FETCH_BUDGET` | How long a tool call waits for an on-demand fetch (default `60s`) |
 | `THREEGPP_MAX_ZIP_SIZE_MB` | Max ZIP download size (default `512`) |
 | `THREEGPP_CACHE_TTL_HOURS` | Spec list cache TTL in hours (default `24`) |
+| `THREEGPP_LISTING_RETRY_MS` | Initial backoff between archive listing fetch attempts in ms (default `1000`) |
 | `XDG_CACHE_HOME` | Cache directory root, per the XDG Base Directory spec |

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -878,6 +878,8 @@ func TestCmdUpdate_MaxReleaseRemovesAboveCap(t *testing.T) {
 // fails, so a full scrape assembles a partial spec list.
 func partialArchive(t *testing.T, healthyZip string) *httptest.Server {
 	t.Helper()
+	// The failing 23.502 listing would otherwise be retried with backoff.
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ftp/Specs/archive/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ftp/Specs/archive/" {

--- a/converter/pipeline/ondemand.go
+++ b/converter/pipeline/ondemand.go
@@ -46,7 +46,7 @@ func ListVersions(ctx context.Context, client *http.Client, specID string, useCa
 		}
 	}
 	sort.Slice(versions, func(i, j int) bool {
-		return versionKey(versions[i]) > versionKey(versions[j])
+		return compareVersions(versions[i], versions[j]) > 0
 	})
 	return versions, nil
 }

--- a/converter/pipeline/pipeline.go
+++ b/converter/pipeline/pipeline.go
@@ -343,6 +343,13 @@ func applyArchiveVersion(spec *db.Spec, sections []db.Section, sv *SpecVersion) 
 		spec.VersionToken = sv.Version
 		if dotted, ok := specver.TokenToDotted(sv.Version); ok {
 			spec.Version = dotted
+		} else {
+			// A token TokenToDotted cannot expand (it requires exactly three
+			// base-36 digits) must still win over the document metadata:
+			// leaving the cover-page version behind an archive token would
+			// store a row whose Version and VersionToken disagree. Fall back
+			// to the raw token, matching displayVersion.
+			spec.Version = sv.Version
 		}
 	}
 	if sv.Release != 0 {

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -557,10 +557,12 @@ const listingFetchAttempts = 3
 // listingRetryBackoff returns the initial delay between listing fetch
 // attempts; the delay doubles after every failure. Overridable via the
 // THREEGPP_LISTING_RETRY_MS environment variable — tests across packages set
-// it to 0, which is why this is read per call rather than at init.
+// it to 0, which is why this is read per call rather than at init. The upper
+// bound keeps the doubling from overflowing into a negative delay that would
+// silently disable the pacing.
 func listingRetryBackoff() time.Duration {
 	if v := os.Getenv("THREEGPP_LISTING_RETRY_MS"); v != "" {
-		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 && ms <= 10*60*1000 {
 			return time.Duration(ms) * time.Millisecond
 		}
 	}

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"regexp"
@@ -78,7 +79,11 @@ func base36Digit(c byte) int {
 
 // versionValue converts a base-36 version token into a comparable integer.
 // Returns -1 if the token contains an invalid character, so garbage never
-// compares equal to a legitimate all-zero token.
+// compares equal to a legitimate all-zero token. The value saturates at
+// math.MaxInt32: versionTokenRE puts no upper bound on token length, so an
+// absurdly long token must neither overflow int64 here nor truncate when the
+// caller narrows to int on a 32-bit platform. Saturated tokens tie, and
+// compareVersions resolves the tie on the raw token.
 func versionValue(v string) int64 {
 	v = strings.ToLower(strings.TrimSpace(v))
 	var n int64
@@ -88,6 +93,9 @@ func versionValue(v string) int64 {
 			return -1
 		}
 		n = n*36 + int64(d)
+		if n > math.MaxInt32 {
+			return math.MaxInt32
+		}
 	}
 	return n
 }
@@ -269,20 +277,21 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 		}
 	}
 
-	// Level 1: Get series directories
+	// Level 1: Get series directories. The archive root always lists the
+	// *_series directories; a page without any is an unusable response (an
+	// error page served as 200), not an empty archive.
 	log.Println("Fetching series list...")
-	html, err := fetchPageRetry(ctx, client, baseURL)
+	html, err := fetchPageRetry(ctx, client, baseURL, func(html string) error {
+		if !slices.ContainsFunc(extractLinks(html), seriesDirRE.MatchString) {
+			return fmt.Errorf("listing contains no *_series directories")
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch archive root: %w", err)
 	}
 
 	seriesDirs := extractLinks(html)
-	// The archive root always lists the *_series directories; a page without
-	// any is an unusable response (an error page served as 200), not an
-	// empty archive.
-	if !slices.ContainsFunc(seriesDirs, seriesDirRE.MatchString) {
-		return nil, fmt.Errorf("archive root listing contains no *_series directories: unusable response from %s", baseURL)
-	}
 	var filtered []string
 	for _, name := range seriesDirs {
 		if !seriesDirRE.MatchString(name) {
@@ -318,25 +327,24 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			html, err := fetchPageRetry(ctx, client, baseURL+sd+"/")
+			// Every series directory holds spec directories; none means the
+			// response was unusable, same as a failed fetch.
+			html, err := fetchPageRetry(ctx, client, baseURL+sd+"/", func(html string) error {
+				if !slices.ContainsFunc(extractLinks(html), specDirRE.MatchString) {
+					return fmt.Errorf("listing contains no spec directories")
+				}
+				return nil
+			})
 			if err != nil {
 				log.Printf("Failed to fetch %s: %v", sd, err)
 				fetchFailures.Add(1)
 				return
 			}
-			links := extractLinks(html)
 			var specDirs []string
-			for _, name := range links {
+			for _, name := range extractLinks(html) {
 				if specDirRE.MatchString(name) {
 					specDirs = append(specDirs, name)
 				}
-			}
-			// Every series directory holds spec directories; none means the
-			// response was unusable, same as a failed fetch.
-			if len(specDirs) == 0 {
-				log.Printf("warning: no spec directories found in %s; treating the listing as failed", sd)
-				fetchFailures.Add(1)
-				return
 			}
 			mu.Lock()
 			for _, name := range specDirs {
@@ -360,26 +368,27 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			html, err := fetchPageRetry(ctx, client, baseURL+pair.seriesDir+"/"+pair.specDir+"/")
+			// Every spec directory in the archive holds at least one version
+			// (FetchSpecZips relies on the same invariant), so a page with no
+			// .zip links is an unusable response, same as a failed fetch.
+			html, err := fetchPageRetry(ctx, client, baseURL+pair.seriesDir+"/"+pair.specDir+"/", func(html string) error {
+				if !slices.ContainsFunc(extractLinks(html), func(name string) bool {
+					return strings.HasSuffix(name, ".zip")
+				}) {
+					return fmt.Errorf("listing contains no .zip entries")
+				}
+				return nil
+			})
 			if err != nil {
 				log.Printf("Failed to fetch %s/%s: %v", pair.seriesDir, pair.specDir, err)
 				fetchFailures.Add(1)
 				return
 			}
-			links := extractLinks(html)
 			var zips []string
-			for _, name := range links {
+			for _, name := range extractLinks(html) {
 				if strings.HasSuffix(name, ".zip") {
 					zips = append(zips, pair.seriesDir+"/"+pair.specDir+"/"+name)
 				}
-			}
-			// Every spec directory in the archive holds at least one version
-			// (FetchSpecZips relies on the same invariant), so a page with no
-			// .zip links is an unusable response, same as a failed fetch.
-			if len(zips) == 0 {
-				log.Printf("warning: no .zip entries found in %s/%s; treating the listing as failed", pair.seriesDir, pair.specDir)
-				fetchFailures.Add(1)
-				return
 			}
 			mu.Lock()
 			entries = append(entries, zips...)
@@ -559,10 +568,13 @@ func listingRetryBackoff() time.Duration {
 }
 
 // fetchPageRetry fetches a listing page, retrying transient failures with
-// exponential backoff. It is used by the full archive scrape, where a single
-// flaky listing among thousands would otherwise abort the whole build;
-// single-spec fetches stay single-shot so interactive tools fail fast.
-func fetchPageRetry(ctx context.Context, client *http.Client, url string) (string, error) {
+// exponential backoff. A non-nil validate runs on each successful fetch and
+// its error counts as a failed attempt, so a transiently unusable body — a
+// WAF block page served as a complete 200 — is retried like a transport
+// error. It is used by the full archive scrape, where a single flaky listing
+// among thousands would otherwise abort the whole build; single-spec fetches
+// stay single-shot so interactive tools fail fast.
+func fetchPageRetry(ctx context.Context, client *http.Client, url string, validate func(html string) error) (string, error) {
 	var lastErr error
 	backoff := listingRetryBackoff()
 	for attempt := 0; attempt < listingFetchAttempts; attempt++ {
@@ -576,7 +588,12 @@ func fetchPageRetry(ctx context.Context, client *http.Client, url string) (strin
 		}
 		html, err := fetchPage(ctx, client, url)
 		if err == nil {
-			return html, nil
+			if validate == nil {
+				return html, nil
+			}
+			if err = validate(html); err == nil {
+				return html, nil
+			}
 		}
 		if ctx.Err() != nil {
 			return "", ctx.Err()

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -74,14 +75,15 @@ func base36Digit(c byte) int {
 }
 
 // versionValue converts a base-36 version token into a comparable integer.
-// Returns 0 if the token contains an invalid character.
+// Returns -1 if the token contains an invalid character, so garbage never
+// compares equal to a legitimate all-zero token.
 func versionValue(v string) int64 {
 	v = strings.ToLower(strings.TrimSpace(v))
 	var n int64
 	for i := 0; i < len(v); i++ {
 		d := base36Digit(v[i])
 		if d < 0 {
-			return 0
+			return -1
 		}
 		n = n*36 + int64(d)
 	}
@@ -146,14 +148,6 @@ func ParseSpecEntry(entry string) *SpecVersion {
 		Release:       base36Digit(token[0]),
 		URL:           baseURL + entry,
 	}
-}
-
-// IsNewerVersion compares version strings (e.g., "k10" vs "j60").
-func IsNewerVersion(newVer, oldVer string) bool {
-	if oldVer == "" {
-		return true
-	}
-	return versionValue(newVer) > versionValue(oldVer)
 }
 
 // FetchSpecZips fetches zip file entries for a single spec directly,
@@ -451,7 +445,7 @@ func FilterSpecs(specs []*SpecVersion, f SpecFilter) []*SpecVersion {
 		best := make(map[string]*SpecVersion)
 		for _, s := range filtered {
 			key := s.SpecID
-			if existing, ok := best[key]; !ok || versionKey(s) > versionKey(existing) {
+			if existing, ok := best[key]; !ok || compareVersions(s, existing) > 0 {
 				best[key] = s
 			}
 		}
@@ -468,8 +462,20 @@ func FilterSpecs(specs []*SpecVersion, f SpecFilter) []*SpecVersion {
 	return filtered
 }
 
-func versionKey(s *SpecVersion) int64 {
-	return int64(s.Release)*10000 + int64(s.VersionMinor)
+// compareVersions orders two versions of the same spec: release first, then
+// the base-36 value of the token's remainder. Comparing the components keeps
+// a large VersionMinor — possible because versionTokenRE puts no upper bound
+// on token length — from bleeding into the release, which the previous
+// Release*10000+VersionMinor key allowed. The raw token is the final
+// tie-break so ties resolve deterministically regardless of input order.
+func compareVersions(a, b *SpecVersion) int {
+	if c := cmp.Compare(a.Release, b.Release); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.VersionMinor, b.VersionMinor); c != 0 {
+		return c
+	}
+	return strings.Compare(a.Version, b.Version)
 }
 
 func fetchPage(ctx context.Context, client *http.Client, url string) (string, error) {

--- a/converter/pipeline/speclist.go
+++ b/converter/pipeline/speclist.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -269,12 +271,18 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 
 	// Level 1: Get series directories
 	log.Println("Fetching series list...")
-	html, err := fetchPage(ctx, client, baseURL)
+	html, err := fetchPageRetry(ctx, client, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch archive root: %w", err)
 	}
 
 	seriesDirs := extractLinks(html)
+	// The archive root always lists the *_series directories; a page without
+	// any is an unusable response (an error page served as 200), not an
+	// empty archive.
+	if !slices.ContainsFunc(seriesDirs, seriesDirRE.MatchString) {
+		return nil, fmt.Errorf("archive root listing contains no *_series directories: unusable response from %s", baseURL)
+	}
 	var filtered []string
 	for _, name := range seriesDirs {
 		if !seriesDirRE.MatchString(name) {
@@ -310,20 +318,31 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			html, err := fetchPage(ctx, client, baseURL+sd+"/")
+			html, err := fetchPageRetry(ctx, client, baseURL+sd+"/")
 			if err != nil {
 				log.Printf("Failed to fetch %s: %v", sd, err)
 				fetchFailures.Add(1)
 				return
 			}
 			links := extractLinks(html)
-			mu.Lock()
+			var specDirs []string
 			for _, name := range links {
 				if specDirRE.MatchString(name) {
-					allSpecPairs = append(allSpecPairs, specPair{sd, name})
+					specDirs = append(specDirs, name)
 				}
 			}
-			log.Printf("%s: %d specs", sd, len(links))
+			// Every series directory holds spec directories; none means the
+			// response was unusable, same as a failed fetch.
+			if len(specDirs) == 0 {
+				log.Printf("warning: no spec directories found in %s; treating the listing as failed", sd)
+				fetchFailures.Add(1)
+				return
+			}
+			mu.Lock()
+			for _, name := range specDirs {
+				allSpecPairs = append(allSpecPairs, specPair{sd, name})
+			}
+			log.Printf("%s: %d specs", sd, len(specDirs))
 			mu.Unlock()
 		}()
 	}
@@ -341,19 +360,29 @@ func FetchSpecList(ctx context.Context, client *http.Client, seriesFilter []stri
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			html, err := fetchPage(ctx, client, baseURL+pair.seriesDir+"/"+pair.specDir+"/")
+			html, err := fetchPageRetry(ctx, client, baseURL+pair.seriesDir+"/"+pair.specDir+"/")
 			if err != nil {
 				log.Printf("Failed to fetch %s/%s: %v", pair.seriesDir, pair.specDir, err)
 				fetchFailures.Add(1)
 				return
 			}
 			links := extractLinks(html)
-			mu.Lock()
+			var zips []string
 			for _, name := range links {
 				if strings.HasSuffix(name, ".zip") {
-					entries = append(entries, pair.seriesDir+"/"+pair.specDir+"/"+name)
+					zips = append(zips, pair.seriesDir+"/"+pair.specDir+"/"+name)
 				}
 			}
+			// Every spec directory in the archive holds at least one version
+			// (FetchSpecZips relies on the same invariant), so a page with no
+			// .zip links is an unusable response, same as a failed fetch.
+			if len(zips) == 0 {
+				log.Printf("warning: no .zip entries found in %s/%s; treating the listing as failed", pair.seriesDir, pair.specDir)
+				fetchFailures.Add(1)
+				return
+			}
+			mu.Lock()
+			entries = append(entries, zips...)
 			mu.Unlock()
 		}()
 	}
@@ -495,11 +524,66 @@ func fetchPage(ctx context.Context, client *http.Client, url string) (string, er
 		return "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPageSize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPageSize+1))
 	if err != nil {
 		return "", err
 	}
+	if len(body) > maxPageSize {
+		return "", fmt.Errorf("listing page %s exceeds %d bytes; refusing truncated body", url, maxPageSize)
+	}
+	// A listing that opens an <html> document but never closes it lost its
+	// tail somewhere along the way. Directory listings are sorted by name, so
+	// a truncated body keeps only the oldest versions and would otherwise be
+	// accepted as a complete, much shorter listing (issue #206). Bodies
+	// without an <html> tag are left alone: extractLinks only needs anchors.
+	lower := strings.ToLower(string(body))
+	if strings.Contains(lower, "<html") && !strings.Contains(lower, "</html>") {
+		return "", fmt.Errorf("listing page %s appears truncated: response opens an <html> document but never closes it", url)
+	}
 	return string(body), nil
+}
+
+const listingFetchAttempts = 3
+
+// listingRetryBackoff returns the initial delay between listing fetch
+// attempts; the delay doubles after every failure. Overridable via the
+// THREEGPP_LISTING_RETRY_MS environment variable — tests across packages set
+// it to 0, which is why this is read per call rather than at init.
+func listingRetryBackoff() time.Duration {
+	if v := os.Getenv("THREEGPP_LISTING_RETRY_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return time.Second
+}
+
+// fetchPageRetry fetches a listing page, retrying transient failures with
+// exponential backoff. It is used by the full archive scrape, where a single
+// flaky listing among thousands would otherwise abort the whole build;
+// single-spec fetches stay single-shot so interactive tools fail fast.
+func fetchPageRetry(ctx context.Context, client *http.Client, url string) (string, error) {
+	var lastErr error
+	backoff := listingRetryBackoff()
+	for attempt := 0; attempt < listingFetchAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+		html, err := fetchPage(ctx, client, url)
+		if err == nil {
+			return html, nil
+		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("after %d attempts: %w", listingFetchAttempts, lastErr)
 }
 
 func extractLinks(html string) []string {

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -95,41 +95,6 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
-// TestFilterSpecs_LatestAcrossTokenEras pits legacy all-digit tokens against
-// letter-era tokens through the real parser, in several input orders: the
-// newest version must win regardless of how the archive listed the files.
-func TestFilterSpecs_LatestAcrossTokenEras(t *testing.T) {
-	entries := []string{
-		"37_series/37.571-5/37571-5-100.zip",
-		"37_series/37.571-5/37571-5-200.zip",
-		"37_series/37.571-5/37571-5-g50.zip",
-		"37_series/37.571-5/37571-5-i10.zip",
-		"37_series/37.571-5/37571-5-j10.zip",
-	}
-	orders := [][]int{
-		{0, 1, 2, 3, 4},
-		{4, 3, 2, 1, 0},
-		{2, 4, 0, 3, 1},
-	}
-	for _, order := range orders {
-		var specs []*SpecVersion
-		for _, i := range order {
-			sv := ParseSpecEntry(entries[i])
-			if sv == nil {
-				t.Fatalf("ParseSpecEntry(%q) = nil", entries[i])
-			}
-			specs = append(specs, sv)
-		}
-		got := FilterSpecs(specs, SpecFilter{LatestOnly: true})
-		if len(got) != 1 {
-			t.Fatalf("order %v: expected 1 spec, got %d", order, len(got))
-		}
-		if got[0].Version != "j10" {
-			t.Errorf("order %v: latest = %q, want %q", order, got[0].Version, "j10")
-		}
-	}
-}
-
 func TestFilterSpecs(t *testing.T) {
 	specs := []*SpecVersion{
 		{Series: "23", SpecID: "23.501", Release: 19, VersionMinor: 10, VersionLetter: "j"},
@@ -513,6 +478,7 @@ func TestFetchSpecList_Race(t *testing.T) {
 func TestFetchSpecList_PartialNotCached(t *testing.T) {
 	cacheHome := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
 
 	archivePath := "/ftp/Specs/archive/"
 	mux := http.NewServeMux()
@@ -632,5 +598,276 @@ func TestFetchSpecList_CancelReturnsContextError(t *testing.T) {
 
 	if _, err := FetchSpecList(ctx, client, nil, false, 1); !errors.Is(err, context.Canceled) {
 		t.Fatalf("FetchSpecList err = %v, want context.Canceled", err)
+	}
+}
+
+// issueArchive serves a mock archive shaped like the TS 37.571-5 incident
+// (issue #206): one healthy spec directory and one whose listing the given
+// handler controls.
+func issueArchive(t *testing.T, spec5 http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != archivePath {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="37_series/">37_series</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"37_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="37.571-1/">37.571-1</a>`+"\n"+`<a href="37.571-5/">37.571-5</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"37_series/37.571-1/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<a href="37571-1-j10.zip">37571-1-j10.zip</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"37_series/37.571-5/", spec5)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestFetchSpecList_TruncatedListingIsFailure reproduces issue #206: a spec
+// directory listing that lost its tail mid-transfer keeps only the
+// name-ascending first zip — the spec's oldest version. Such a body must be
+// treated like a failed fetch, not accepted as a complete one-version listing
+// and cached for the TTL.
+func TestFetchSpecList_TruncatedListingIsFailure(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	ts := issueArchive(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body><table><a href="37571-5-100.zip">37571-5-100.zip</a>`)
+	})
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	entries, err := FetchSpecList(context.Background(), client, nil, true, 2)
+	var partial *PartialSpecListError
+	if !errors.As(err, &partial) {
+		t.Fatalf("FetchSpecList err = %v, want *PartialSpecListError", err)
+	}
+	if partial.FailedListings != 1 {
+		t.Errorf("FailedListings = %d, want 1", partial.FailedListings)
+	}
+	for _, e := range entries {
+		if strings.Contains(e, "37571-5-100.zip") {
+			t.Errorf("truncated listing leaked its oldest version into the result: %v", entries)
+		}
+	}
+	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_TruncatedListingRetrySucceeds verifies that a transient
+// truncation is healed by the retry: the second, complete listing is used, the
+// list is cached, and latest-only selection picks the newest version across
+// the legacy digit and letter token eras.
+func TestFetchSpecList_TruncatedListingRetrySucceeds(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	var calls int
+	ts := issueArchive(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			fmt.Fprint(w, `<html><body><table><a href="37571-5-100.zip">37571-5-100.zip</a>`)
+			return
+		}
+		for _, v := range []string{"100", "200", "g50", "i10", "j10"} {
+			fmt.Fprintf(w, `<a href="37571-5-%s.zip">37571-5-%s.zip</a>`+"\n", v, v)
+		}
+	})
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	entries, err := FetchSpecList(context.Background(), client, nil, true, 2)
+	if err != nil {
+		t.Fatalf("FetchSpecList: %v", err)
+	}
+	if len(entries) != 6 {
+		t.Fatalf("expected 6 entries (1 + 5), got %d: %v", len(entries), entries)
+	}
+
+	var specs []*SpecVersion
+	for _, e := range entries {
+		if sv := ParseSpecEntry(e); sv != nil {
+			specs = append(specs, sv)
+		}
+	}
+	latest := FilterSpecs(specs, SpecFilter{LatestOnly: true})
+	var got string
+	for _, s := range latest {
+		if s.SpecID == "37.571-5" {
+			got = s.Version
+		}
+	}
+	if got != "j10" {
+		t.Errorf("latest version for 37.571-5 = %q, want %q", got, "j10")
+	}
+
+	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Errorf("recovered complete spec list should be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_ZeroZipListingIsFailure verifies that a well-formed page
+// with no .zip links at all — a WAF block page or error page served as 200 —
+// counts as a failed listing. Every spec directory in the archive holds at
+// least one version, so "no versions" is never a real answer.
+func TestFetchSpecList_ZeroZipListingIsFailure(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	ts := issueArchive(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body>This transfer is blocked.</body></html>`)
+	})
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	_, err := FetchSpecList(context.Background(), client, nil, true, 2)
+	var partial *PartialSpecListError
+	if !errors.As(err, &partial) {
+		t.Fatalf("FetchSpecList err = %v, want *PartialSpecListError", err)
+	}
+	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_EmptySeriesListingIsFailure verifies that a series page
+// listing no spec directories is treated as a failed listing rather than a
+// series that silently contributes nothing.
+func TestFetchSpecList_EmptySeriesListingIsFailure(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != archivePath {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `<a href="23_series/">23_series</a>`+"\n")
+	})
+	mux.HandleFunc(archivePath+"23_series/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body>This transfer is blocked.</body></html>`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	_, err := FetchSpecList(context.Background(), client, nil, false, 2)
+	var partial *PartialSpecListError
+	if !errors.As(err, &partial) {
+		t.Fatalf("FetchSpecList err = %v, want *PartialSpecListError", err)
+	}
+}
+
+// TestFetchSpecList_EmptyRootFails verifies that an archive root listing
+// without any *_series directory is a hard error: there is nothing usable to
+// scrape, partial or otherwise.
+func TestFetchSpecList_EmptyRootFails(t *testing.T) {
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	archivePath := "/ftp/Specs/archive/"
+	mux := http.NewServeMux()
+	mux.HandleFunc(archivePath, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body>This transfer is blocked.</body></html>`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	_, err := FetchSpecList(context.Background(), client, nil, false, 2)
+	if err == nil {
+		t.Fatal("expected error for a root listing with no series directories")
+	}
+	var partial *PartialSpecListError
+	if errors.As(err, &partial) {
+		t.Fatalf("err = %v; an unusable root is a hard error, not a partial list", err)
+	}
+}
+
+// TestFetchSpecZips_TruncatedListingFails verifies the single-spec listing
+// path rejects a truncated body instead of returning the few entries that
+// survived the cut.
+func TestFetchSpecZips_TruncatedListingFails(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ftp/Specs/archive/37_series/37.571-5/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body><table><a href="37571-5-100.zip">37571-5-100.zip</a>`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	if _, err := FetchSpecZips(context.Background(), client, "37.571-5", true); err == nil {
+		t.Fatal("expected error for a truncated listing")
+	}
+	if names, _ := filepath.Glob(filepath.Join(cacheHome, "3gpp-mcp", "*")); len(names) != 0 {
+		t.Errorf("nothing should be cached for a truncated listing, found %v", names)
+	}
+}
+
+// TestFilterSpecs_LatestAcrossTokenEras pits legacy all-digit tokens against
+// letter-era tokens through the real parser, in several input orders: the
+// newest version must win regardless of how the archive listed the files.
+func TestFilterSpecs_LatestAcrossTokenEras(t *testing.T) {
+	entries := []string{
+		"37_series/37.571-5/37571-5-100.zip",
+		"37_series/37.571-5/37571-5-200.zip",
+		"37_series/37.571-5/37571-5-g50.zip",
+		"37_series/37.571-5/37571-5-i10.zip",
+		"37_series/37.571-5/37571-5-j10.zip",
+	}
+	orders := [][]int{
+		{0, 1, 2, 3, 4},
+		{4, 3, 2, 1, 0},
+		{2, 4, 0, 3, 1},
+	}
+	for _, order := range orders {
+		var specs []*SpecVersion
+		for _, i := range order {
+			sv := ParseSpecEntry(entries[i])
+			if sv == nil {
+				t.Fatalf("ParseSpecEntry(%q) = nil", entries[i])
+			}
+			specs = append(specs, sv)
+		}
+		got := FilterSpecs(specs, SpecFilter{LatestOnly: true})
+		if len(got) != 1 {
+			t.Fatalf("order %v: expected 1 spec, got %d", order, len(got))
+		}
+		if got[0].Version != "j10" {
+			t.Errorf("order %v: latest = %q, want %q", order, got[0].Version, "j10")
+		}
+	}
+}
+
+// TestFetchPage_BodyAtLimitFails verifies that a listing body reaching
+// maxPageSize is rejected: the limit reader would silently drop the tail, so
+// hitting it means the listing cannot be trusted.
+func TestFetchPage_BodyAtLimitFails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := strings.Repeat("x", 1<<20)
+		for written := 0; written <= maxPageSize; written += len(chunk) {
+			if _, err := w.Write([]byte(chunk)); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	_, err := fetchPage(context.Background(), http.DefaultClient, ts.URL)
+	if err == nil || !strings.Contains(err.Error(), "refusing truncated body") {
+		t.Fatalf("err = %v, want the over-limit refusal", err)
 	}
 }

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -59,32 +59,74 @@ func TestParseSpecEntry(t *testing.T) {
 	}
 }
 
-func TestIsNewerVersion(t *testing.T) {
-	tests := []struct {
-		newVer, oldVer string
-		want           bool
-	}{
-		{"k10", "j60", true},
-		{"j60", "k10", false},
-		{"k10", "k10", false},
-		{"k20", "k10", true},
-		{"a01", "", true},
-		{"", "", true}, // oldVer=="" always returns true
-		{"300", "200", true},
-		{"200", "300", false},
-		// Base-36 versions: "fa0" (technical=10) is newer than "f20".
-		{"fa0", "f20", true},
-		{"f20", "fa0", false},
-		{"j50", "j40", true},
+func TestCompareVersions(t *testing.T) {
+	entry := func(t *testing.T, e string) *SpecVersion {
+		t.Helper()
+		sv := ParseSpecEntry(e)
+		if sv == nil {
+			t.Fatalf("ParseSpecEntry(%q) = nil", e)
+		}
+		return sv
 	}
-
+	tests := []struct {
+		name string
+		a, b string // archive entries
+		want int    // sign of compareVersions(a, b)
+	}{
+		{"newer release wins", "23_series/23.501/23501-k10.zip", "23_series/23.501/23501-j60.zip", 1},
+		{"older release loses", "23_series/23.501/23501-j60.zip", "23_series/23.501/23501-k10.zip", -1},
+		{"same version ties", "23_series/23.501/23501-k10.zip", "23_series/23.501/23501-k10.zip", 0},
+		{"minor decides within release", "23_series/23.501/23501-k20.zip", "23_series/23.501/23501-k10.zip", 1},
+		{"legacy vs letter era", "37_series/37.571-5/37571-5-j10.zip", "37_series/37.571-5/37571-5-100.zip", 1},
+		{"base36 minor", "34_series/34.108/34108-fa0.zip", "34_series/34.108/34108-f20.zip", 1},
+		// A long token's remainder must stay inside the minor component
+		// instead of bleeding into the release comparison: release 18 with a
+		// huge minor ("izzz") still loses to release 20 ("k00").
+		{"long token cannot outrank a newer release", "23_series/23.501/23501-izzz.zip", "23_series/23.501/23501-k00.zip", -1},
+	}
 	for _, tt := range tests {
-		t.Run(tt.newVer+"_vs_"+tt.oldVer, func(t *testing.T) {
-			got := IsNewerVersion(tt.newVer, tt.oldVer)
-			if got != tt.want {
-				t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.newVer, tt.oldVer, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareVersions(entry(t, tt.a), entry(t, tt.b))
+			switch {
+			case tt.want > 0 && got <= 0, tt.want < 0 && got >= 0, tt.want == 0 && got != 0:
+				t.Errorf("compareVersions = %d, want sign %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestFilterSpecs_LatestAcrossTokenEras pits legacy all-digit tokens against
+// letter-era tokens through the real parser, in several input orders: the
+// newest version must win regardless of how the archive listed the files.
+func TestFilterSpecs_LatestAcrossTokenEras(t *testing.T) {
+	entries := []string{
+		"37_series/37.571-5/37571-5-100.zip",
+		"37_series/37.571-5/37571-5-200.zip",
+		"37_series/37.571-5/37571-5-g50.zip",
+		"37_series/37.571-5/37571-5-i10.zip",
+		"37_series/37.571-5/37571-5-j10.zip",
+	}
+	orders := [][]int{
+		{0, 1, 2, 3, 4},
+		{4, 3, 2, 1, 0},
+		{2, 4, 0, 3, 1},
+	}
+	for _, order := range orders {
+		var specs []*SpecVersion
+		for _, i := range order {
+			sv := ParseSpecEntry(entries[i])
+			if sv == nil {
+				t.Fatalf("ParseSpecEntry(%q) = nil", entries[i])
+			}
+			specs = append(specs, sv)
+		}
+		got := FilterSpecs(specs, SpecFilter{LatestOnly: true})
+		if len(got) != 1 {
+			t.Fatalf("order %v: expected 1 spec, got %d", order, len(got))
+		}
+		if got[0].Version != "j10" {
+			t.Errorf("order %v: latest = %q, want %q", order, got[0].Version, "j10")
+		}
 	}
 }
 

--- a/converter/pipeline/speclist_test.go
+++ b/converter/pipeline/speclist_test.go
@@ -83,6 +83,9 @@ func TestCompareVersions(t *testing.T) {
 		// instead of bleeding into the release comparison: release 18 with a
 		// huge minor ("izzz") still loses to release 20 ("k00").
 		{"long token cannot outrank a newer release", "23_series/23.501/23501-izzz.zip", "23_series/23.501/23501-k00.zip", -1},
+		// A remainder long enough to saturate versionValue must still order
+		// by release rather than overflow.
+		{"saturating token stays within its release", "23_series/23.501/23501-jzzzzzzzzzzzzzz.zip", "23_series/23.501/23501-k00.zip", -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -736,6 +739,33 @@ func TestFetchSpecList_ZeroZipListingIsFailure(t *testing.T) {
 	cachePath := filepath.Join(cacheHome, "3gpp-mcp", CacheKey("speclist"))
 	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
 		t.Errorf("partial spec list must not be cached; stat err = %v", err)
+	}
+}
+
+// TestFetchSpecList_ZeroZipListingRetrySucceeds verifies that a transient
+// WAF block page is healed by the retry: the validation failure counts as a
+// failed attempt, so the next attempt sees the real listing.
+func TestFetchSpecList_ZeroZipListingRetrySucceeds(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("THREEGPP_LISTING_RETRY_MS", "0")
+
+	var calls int
+	ts := issueArchive(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			fmt.Fprint(w, `<html><body>This transfer is blocked.</body></html>`)
+			return
+		}
+		fmt.Fprint(w, `<a href="37571-5-j10.zip">37571-5-j10.zip</a>`+"\n")
+	})
+	client := &http.Client{Transport: &redirectTransport{base: http.DefaultTransport, testURL: ts.URL}}
+
+	entries, err := FetchSpecList(context.Background(), client, nil, false, 2)
+	if err != nil {
+		t.Fatalf("FetchSpecList: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
 	}
 }
 


### PR DESCRIPTION
## Problem

The `latest-v2-2026-08-11` benchmark database holds TS 37.571-5 at 1.0.0 (`100`) instead of the newest 19.1.0 (`j10`). `FetchSpecList` accepted any 200 response for a directory listing: 3GPP listings are name-ascending, so a truncated body keeps only the oldest zip, and the resulting spec list was cached for 24h. The version comparison itself was correct — the input list for that spec had been silently reduced.

## Changes

- `fetchPage` rejects truncated bodies: at the 10MB limit, or an `<html>` document that never closes.
- Listing fetches in the full scrape retry with exponential backoff (`THREEGPP_LISTING_RETRY_MS` overrides the initial delay, clamped). A validate callback runs per attempt, so an unusable-but-complete body (WAF block page served as 200) is retried like a transport error. Single-spec fetches stay single-shot so interactive tools fail fast.
- Zero-entry listings (no `*_series` dirs at root, no spec dirs in a series, no `.zip` in a spec dir) count as failed fetches feeding the existing `PartialSpecListError` path: `build`/`download` abort, `update` warns and skips, and the partial list is never cached.
- `versionKey` (`Release*10000+VersionMinor`) replaced by a component-wise comparator with a raw-token tie-break: fixes the radix overflow for long tokens and the map-iteration-order nondeterminism on ties. `versionValue` saturates at `MaxInt32` and returns -1 on invalid characters.
- `applyArchiveVersion` falls back to the raw archive token when it cannot be expanded to a dotted version, keeping `Version`/`VersionToken` consistent.
- Dead `IsNewerVersion` removed.

Note for operators: a bad list cached before this fix may still be inside its TTL; run once with `--no-cache` if the last build predates it.

Fixes #206

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhykLCZNaG1UDL7jWp7cQC)_