### PR TITLE
feat: explain get_openapi misses and resolve file-name api_name

### DIFF
--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -716,7 +716,10 @@ func cmdGetOpenAPI(args []string) {
 }
 
 func runGetOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID, apiName, path, schema string) error {
-	content, err := d.GetOpenAPI(ctx, specID, apiName)
+	content, err := d.GetOpenAPIResolved(ctx, specID, apiName)
+	if errors.Is(err, db.ErrOpenAPINotFound) {
+		return errors.New(tools.OpenAPINotFoundMessage(ctx, d, specID, apiName, schema))
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/3gpp-mcp/query.go
+++ b/cmd/3gpp-mcp/query.go
@@ -716,6 +716,9 @@ func cmdGetOpenAPI(args []string) {
 }
 
 func runGetOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID, apiName, path, schema string) error {
+	if specID == "" || apiName == "" {
+		return errors.New("spec-id and api-name must not be empty")
+	}
 	content, err := d.GetOpenAPIResolved(ctx, specID, apiName)
 	if errors.Is(err, db.ErrOpenAPINotFound) {
 		return errors.New(tools.OpenAPINotFoundMessage(ctx, d, specID, apiName, schema))
@@ -724,7 +727,8 @@ func runGetOpenAPI(ctx context.Context, out io.Writer, d *db.DB, specID, apiName
 		return err
 	}
 	if path != "" || schema != "" {
-		if content, err = tools.FilterOpenAPI(content, path, schema); err != nil {
+		hint := func(s string) string { return tools.OpenAPISchemaHint(ctx, d, s) }
+		if content, err = tools.FilterOpenAPI(content, path, schema, hint); err != nil {
 			return err
 		}
 	}

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -669,8 +669,25 @@ func TestRunGetOpenAPI(t *testing.T) {
 		t.Errorf("path filter not applied:\n%s", out.String())
 	}
 
-	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nope_API", "", ""); err == nil {
-		t.Error("expected error for unknown API name")
+	// File-name form resolves to the same document.
+	out.Reset()
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "TS29510_Nnrf_NFManagement", "", ""); err != nil {
+		t.Fatalf("runGetOpenAPI filename fallback: %v", err)
+	}
+	if !strings.Contains(out.String(), "openapi: 3.0.0") {
+		t.Errorf("filename fallback output:\n%s", out.String())
+	}
+
+	err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "Nope_API", "", "")
+	if err == nil {
+		t.Fatal("expected error for unknown API name")
+	}
+	if !strings.Contains(err.Error(), "Available api_name values in TS 29.510: Nnrf_NFManagement") {
+		t.Errorf("expected available api_name listing, got: %v", err)
+	}
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 23.501", "Nnrf_NFManagement", "", ""); err == nil ||
+		!strings.Contains(err.Error(), "provided by TS 29.510 / Nnrf_NFManagement") {
+		t.Errorf("expected wrong-document hint, got: %v", err)
 	}
 }
 

--- a/cmd/3gpp-mcp/query_test.go
+++ b/cmd/3gpp-mcp/query_test.go
@@ -689,6 +689,13 @@ func TestRunGetOpenAPI(t *testing.T) {
 		!strings.Contains(err.Error(), "provided by TS 29.510 / Nnrf_NFManagement") {
 		t.Errorf("expected wrong-document hint, got: %v", err)
 	}
+
+	// Empty positionals are rejected before they can reach the lookup, where
+	// an empty api-name would otherwise match rows with an empty filename.
+	if err := runGetOpenAPI(t.Context(), &out, d, "TS 29.510", "", "", ""); err == nil ||
+		!strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected empty-argument error, got: %v", err)
+	}
 }
 
 // seedTestImage inserts one PNG image row for TS 23.501.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1088,18 +1088,6 @@ func (d *DB) ListOpenAPI(ctx context.Context, specID string) ([]OpenAPISpec, err
 	return specs, nil
 }
 
-func (d *DB) GetOpenAPI(ctx context.Context, specID, apiName string) (string, error) {
-	var content string
-	err := d.conn.QueryRowContext(ctx,
-		"SELECT content FROM openapi_specs WHERE spec_id = ? AND api_name = ?",
-		specID, apiName,
-	).Scan(&content)
-	if err != nil {
-		return "", fmt.Errorf("get openapi: %w", err)
-	}
-	return content, nil
-}
-
 // UpsertOpenAPI inserts or replaces an OpenAPI spec.
 func (d *DB) UpsertOpenAPI(specID, apiName, version, filename, content string) error {
 	_, err := d.conn.Exec(

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1080,27 +1080,6 @@ func TestListOpenAPI(t *testing.T) {
 	})
 }
 
-func TestGetOpenAPI(t *testing.T) {
-	d := setupTestDB(t)
-
-	t.Run("existing", func(t *testing.T) {
-		content, err := d.GetOpenAPI(t.Context(), "TS 29.510", "Nnrf_NFManagement")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if content == "" {
-			t.Error("expected non-empty content")
-		}
-	})
-
-	t.Run("nonexistent", func(t *testing.T) {
-		_, err := d.GetOpenAPI(t.Context(), "TS 29.510", "Nonexistent")
-		if err == nil {
-			t.Fatal("expected error for nonexistent api")
-		}
-	})
-}
-
 func TestUpsertOpenAPI(t *testing.T) {
 	d := setupTestDB(t)
 
@@ -1109,7 +1088,7 @@ func TestUpsertOpenAPI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		content, err := d.GetOpenAPI(t.Context(), "TS 29.512", "Npcf_SMPolicyControl")
+		content, err := d.GetOpenAPIResolved(t.Context(), "TS 29.512", "Npcf_SMPolicyControl")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1123,7 +1102,7 @@ func TestUpsertOpenAPI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		content, err := d.GetOpenAPI(t.Context(), "TS 29.510", "Nnrf_NFManagement")
+		content, err := d.GetOpenAPIResolved(t.Context(), "TS 29.510", "Nnrf_NFManagement")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2546,7 +2525,7 @@ func TestQueryMethodsHonorContext(t *testing.T) {
 		{"GetImage", func() error { _, err := d.GetImage(ctx, "TS 23.501", "", "figure1.png"); return err }},
 		{"ListImages", func() error { _, err := d.ListImages(ctx, "TS 23.501", ""); return err }},
 		{"ListOpenAPI", func() error { _, err := d.ListOpenAPI(ctx, ""); return err }},
-		{"GetOpenAPI", func() error { _, err := d.GetOpenAPI(ctx, "TS 29.510", "Nnrf_NFManagement"); return err }},
+		{"GetOpenAPIResolved", func() error { _, err := d.GetOpenAPIResolved(ctx, "TS 29.510", "Nnrf_NFManagement"); return err }},
 		{"GetReferences", func() error {
 			_, err := d.GetReferences(ctx, "TS 24.229", "", "5.1", DirectionOutgoing, false)
 			return err

--- a/internal/db/openapi_lookup.go
+++ b/internal/db/openapi_lookup.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrOpenAPINotFound reports that no stored OpenAPI document matches a
+// (spec_id, api_name) request, even through the filename fallback of
+// GetOpenAPIResolved. Callers turn it into a hint about what does exist
+// rather than surfacing a bare SQL error.
+var ErrOpenAPINotFound = errors.New("openapi definition not found")
+
+// openapiNameMatch matches a requested api_name against a row: the api_name
+// itself, or the stored filename with or without its .yaml extension, all
+// case-insensitively — models copy file names out of prose
+// ("TS29571_CommonData") as often as API names ("Nudm_UECM").
+const openapiNameMatch = "(LOWER(api_name) = LOWER(?) OR LOWER(COALESCE(filename, '')) IN (LOWER(?), LOWER(? || '.yaml')))"
+
+// GetOpenAPIResolved returns the content stored for (specID, apiName),
+// resolving apiName as GetOpenAPI does not: case-insensitively, and by
+// filename with or without the .yaml extension. When several rows qualify the
+// exact api_name match wins. A miss is ErrOpenAPINotFound.
+func (d *DB) GetOpenAPIResolved(ctx context.Context, specID, apiName string) (string, error) {
+	var content string
+	err := d.conn.QueryRowContext(ctx,
+		"SELECT content FROM openapi_specs WHERE spec_id = ? AND "+openapiNameMatch+
+			" ORDER BY CASE WHEN api_name = ? THEN 0 WHEN LOWER(api_name) = LOWER(?) THEN 1 ELSE 2 END LIMIT 1",
+		specID, apiName, apiName, apiName, apiName, apiName,
+	).Scan(&content)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrOpenAPINotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("get openapi: %w", err)
+	}
+	return content, nil
+}
+
+// FindOpenAPIByAPIName returns every stored OpenAPI document whose api_name
+// or filename matches apiName, across all specifications. It serves the
+// wrong-document hint: a get_openapi call that named an api_name under the
+// wrong spec_id learns which specification actually provides it.
+func (d *DB) FindOpenAPIByAPIName(ctx context.Context, apiName string) ([]OpenAPISpec, error) {
+	rows, err := d.conn.QueryContext(ctx,
+		"SELECT spec_id, api_name FROM openapi_specs WHERE "+openapiNameMatch+" ORDER BY spec_id, api_name",
+		apiName, apiName, apiName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find openapi by api name: %w", err)
+	}
+	defer rows.Close()
+
+	var specs []OpenAPISpec
+	for rows.Next() {
+		var s OpenAPISpec
+		if err := rows.Scan(&s.SpecID, &s.APIName); err != nil {
+			return nil, fmt.Errorf("scan openapi by api name: %w", err)
+		}
+		specs = append(specs, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("find openapi by api name: iterate: %w", err)
+	}
+	return specs, nil
+}
+
+// OpenAPISchemaSources returns the documents whose components.schemas define
+// the named schema, answered from the openapi_chunks index. A database
+// without the index reports ErrNoOpenAPIIndex, which callers treat as "no
+// hint" rather than as a failure.
+func (d *DB) OpenAPISchemaSources(ctx context.Context, schema string) ([]OpenAPISpec, error) {
+	ok, err := d.HasOpenAPIIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNoOpenAPIIndex
+	}
+
+	rows, err := d.conn.QueryContext(ctx,
+		"SELECT DISTINCT spec_id, api_name FROM openapi_chunks WHERE kind = ? AND LOWER(name) = LOWER(?) ORDER BY spec_id, api_name",
+		OpenAPIKindSchema, schema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find openapi schema sources: %w", err)
+	}
+	defer rows.Close()
+
+	var specs []OpenAPISpec
+	for rows.Next() {
+		var s OpenAPISpec
+		if err := rows.Scan(&s.SpecID, &s.APIName); err != nil {
+			return nil, fmt.Errorf("scan openapi schema source: %w", err)
+		}
+		specs = append(specs, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("find openapi schema sources: iterate: %w", err)
+	}
+	return specs, nil
+}

--- a/internal/db/openapi_lookup.go
+++ b/internal/db/openapi_lookup.go
@@ -20,10 +20,15 @@ var ErrOpenAPINotFound = errors.New("openapi definition not found")
 const openapiNameMatch = "(LOWER(api_name) = LOWER(?) OR LOWER(COALESCE(filename, '')) IN (LOWER(?), LOWER(? || '.yaml')))"
 
 // GetOpenAPIResolved returns the content stored for (specID, apiName),
-// resolving apiName as GetOpenAPI does not: case-insensitively, and by
-// filename with or without the .yaml extension. When several rows qualify the
-// exact api_name match wins. A miss is ErrOpenAPINotFound.
+// resolving apiName case-insensitively and by filename with or without the
+// .yaml extension. When several rows qualify the exact api_name match wins.
+// A miss is ErrOpenAPINotFound.
 func (d *DB) GetOpenAPIResolved(ctx context.Context, specID, apiName string) (string, error) {
+	// An empty apiName would match every row whose filename is NULL or empty
+	// through the COALESCE below; it can never name a document.
+	if apiName == "" {
+		return "", ErrOpenAPINotFound
+	}
 	var content string
 	err := d.conn.QueryRowContext(ctx,
 		"SELECT content FROM openapi_specs WHERE spec_id = ? AND "+openapiNameMatch+
@@ -44,6 +49,9 @@ func (d *DB) GetOpenAPIResolved(ctx context.Context, specID, apiName string) (st
 // wrong-document hint: a get_openapi call that named an api_name under the
 // wrong spec_id learns which specification actually provides it.
 func (d *DB) FindOpenAPIByAPIName(ctx context.Context, apiName string) ([]OpenAPISpec, error) {
+	if apiName == "" {
+		return nil, nil
+	}
 	rows, err := d.conn.QueryContext(ctx,
 		"SELECT spec_id, api_name FROM openapi_specs WHERE "+openapiNameMatch+" ORDER BY spec_id, api_name",
 		apiName, apiName, apiName,

--- a/internal/db/openapi_lookup_test.go
+++ b/internal/db/openapi_lookup_test.go
@@ -1,0 +1,125 @@
+package db
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func seedOpenAPILookup(t *testing.T) *DB {
+	t.Helper()
+	d := setupTestDB(t)
+	if err := d.UpsertOpenAPI("TS 29.571", "CommonData", "v1.5.0", "TS29571_CommonData.yaml",
+		"openapi: 3.0.0\ncomponents:\n  schemas:\n    ProblemDetails:\n      type: object\n"); err != nil {
+		t.Fatalf("seed openapi: %v", err)
+	}
+	return d
+}
+
+func TestGetOpenAPIResolved(t *testing.T) {
+	d := seedOpenAPILookup(t)
+
+	for name, apiName := range map[string]string{
+		"exact api_name":           "CommonData",
+		"case-insensitive":         "commondata",
+		"filename with extension":  "TS29571_CommonData.yaml",
+		"filename sans extension":  "TS29571_CommonData",
+		"filename case-insensitve": "ts29571_commondata",
+	} {
+		t.Run(name, func(t *testing.T) {
+			content, err := d.GetOpenAPIResolved(t.Context(), "TS 29.571", apiName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(content, "ProblemDetails") {
+				t.Errorf("unexpected content: %s", content)
+			}
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := d.GetOpenAPIResolved(t.Context(), "TS 29.571", "Nonexistent")
+		if !errors.Is(err, ErrOpenAPINotFound) {
+			t.Fatalf("expected ErrOpenAPINotFound, got %v", err)
+		}
+	})
+
+	t.Run("wrong spec", func(t *testing.T) {
+		_, err := d.GetOpenAPIResolved(t.Context(), "TS 29.510", "CommonData")
+		if !errors.Is(err, ErrOpenAPINotFound) {
+			t.Fatalf("expected ErrOpenAPINotFound, got %v", err)
+		}
+	})
+}
+
+func TestFindOpenAPIByAPIName(t *testing.T) {
+	d := seedOpenAPILookup(t)
+
+	for name, apiName := range map[string]string{
+		"api_name":                "CommonData",
+		"filename sans extension": "TS29571_CommonData",
+		"filename with extension": "TS29571_CommonData.yaml",
+	} {
+		t.Run(name, func(t *testing.T) {
+			specs, err := d.FindOpenAPIByAPIName(t.Context(), apiName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(specs) != 1 || specs[0].SpecID != "TS 29.571" || specs[0].APIName != "CommonData" {
+				t.Errorf("unexpected result: %+v", specs)
+			}
+		})
+	}
+
+	t.Run("no match", func(t *testing.T) {
+		specs, err := d.FindOpenAPIByAPIName(t.Context(), "Nonexistent")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 0 {
+			t.Errorf("expected no results, got %+v", specs)
+		}
+	})
+}
+
+func TestOpenAPISchemaSources(t *testing.T) {
+	d := seedOpenAPILookup(t)
+	chunks := []OpenAPIChunk{
+		{SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml", Kind: OpenAPIKindSchema, Name: "NFProfile", Body: "NFProfile"},
+		{SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Filename: "TS29510_Nnrf_NFManagement.yaml", Kind: OpenAPIKindOperation, Name: "GET /nf-instances", Body: "list"},
+		{SpecID: "TS 29.571", APIName: "CommonData", Filename: "TS29571_CommonData.yaml", Kind: OpenAPIKindSchema, Name: "ProblemDetails", Body: "ProblemDetails"},
+	}
+	if err := d.ReplaceOpenAPIChunks(chunks); err != nil {
+		t.Fatalf("seed chunks: %v", err)
+	}
+
+	t.Run("schema found", func(t *testing.T) {
+		specs, err := d.OpenAPISchemaSources(t.Context(), "nfprofile")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 || specs[0].SpecID != "TS 29.510" || specs[0].APIName != "Nnrf_NFManagement" {
+			t.Errorf("unexpected result: %+v", specs)
+		}
+	})
+
+	t.Run("operation name is not a schema", func(t *testing.T) {
+		specs, err := d.OpenAPISchemaSources(t.Context(), "GET /nf-instances")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 0 {
+			t.Errorf("expected no results, got %+v", specs)
+		}
+	})
+
+	t.Run("without index", func(t *testing.T) {
+		if err := d.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
+			t.Fatalf("drop index: %v", err)
+		}
+		_, err := d.OpenAPISchemaSources(t.Context(), "NFProfile")
+		if !errors.Is(err, ErrNoOpenAPIIndex) {
+			t.Fatalf("expected ErrNoOpenAPIIndex, got %v", err)
+		}
+	})
+}

--- a/internal/tools/openapi.go
+++ b/internal/tools/openapi.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -68,7 +69,10 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 			return errorResult("api_name is required"), nil, nil
 		}
 
-		content, err := d.GetOpenAPI(ctx, input.SpecID, input.APIName)
+		content, err := d.GetOpenAPIResolved(ctx, input.SpecID, input.APIName)
+		if errors.Is(err, db.ErrOpenAPINotFound) {
+			return errorResult(OpenAPINotFoundMessage(ctx, d, input.SpecID, input.APIName, input.Schema)), nil, nil
+		}
 		if err != nil {
 			return errorResult(fmt.Sprintf("failed to get openapi: %v", err)), nil, nil
 		}
@@ -84,6 +88,56 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 
 		return paginateText(content, input.Offset, input.MaxLines, 0), nil, nil
 	}
+}
+
+// OpenAPINotFoundMessage explains a (spec_id, api_name) miss with what to do
+// next instead of a bare SQL error: which specification actually provides the
+// requested api_name when the guess named the wrong document, which document
+// defines the requested schema (answered from the openapi_chunks index, in the
+// crossSpecHint manner of get_asn1), and which api_name values the spec does
+// carry. A hint that cannot be answered — no index, a query error — is
+// omitted rather than turning the not-found into a failure. Shared with the
+// CLI's get-openapi command.
+func OpenAPINotFoundMessage(ctx context.Context, d *db.DB, specID, apiName, schema string) string {
+	msg := fmt.Sprintf("OpenAPI definition %q not found in %s.", apiName, specID)
+
+	// The wrong-document guess: the api_name exists, under another spec.
+	if specs, err := d.FindOpenAPIByAPIName(ctx, apiName); err == nil && len(specs) > 0 {
+		msg += fmt.Sprintf(" %s is provided by %s — call get_openapi with that spec_id and api_name.",
+			apiName, joinOpenAPISources(specs))
+	}
+
+	// A schema name pins the defining document more precisely than the
+	// api_name guess does, so answer it directly from the index.
+	if schema != "" {
+		if sources, err := d.OpenAPISchemaSources(ctx, schema); err == nil && len(sources) > 0 {
+			msg += fmt.Sprintf(" Schema %q is defined in %s — call get_openapi there, or use search_openapi to find definitions by name.",
+				schema, joinOpenAPISources(sources))
+		}
+	}
+
+	if avail, err := d.ListOpenAPI(ctx, specID); err == nil {
+		if len(avail) > 0 {
+			names := make([]string, len(avail))
+			for i, s := range avail {
+				names[i] = s.APIName
+			}
+			msg += fmt.Sprintf(" Available api_name values in %s: %s.", specID, strings.Join(names, ", "))
+		} else {
+			msg += fmt.Sprintf(" %s has no OpenAPI definitions in the database — use list_openapi to see which specifications have them.", specID)
+		}
+	}
+	return msg
+}
+
+// joinOpenAPISources renders OpenAPI documents as "spec_id / api_name" pairs,
+// the two arguments a follow-up get_openapi call needs.
+func joinOpenAPISources(specs []db.OpenAPISpec) string {
+	parts := make([]string, len(specs))
+	for i, s := range specs {
+		parts[i] = s.SpecID + " / " + s.APIName
+	}
+	return strings.Join(parts, ", ")
 }
 
 // FilterOpenAPI narrows an OpenAPI YAML document to a path and/or schema

--- a/internal/tools/openapi.go
+++ b/internal/tools/openapi.go
@@ -79,7 +79,9 @@ func HandleGetOpenAPI(d *db.DB) func(ctx context.Context, req *mcp.CallToolReque
 
 		// If path or schema filter is specified, parse YAML and extract
 		if input.Path != "" || input.Schema != "" {
-			filtered, err := FilterOpenAPI(content, input.Path, input.Schema)
+			filtered, err := FilterOpenAPI(content, input.Path, input.Schema, func(schema string) string {
+				return OpenAPISchemaHint(ctx, d, schema)
+			})
 			if err != nil {
 				return errorResult(fmt.Sprintf("failed to filter openapi: %v", err)), nil, nil
 			}
@@ -110,10 +112,7 @@ func OpenAPINotFoundMessage(ctx context.Context, d *db.DB, specID, apiName, sche
 	// A schema name pins the defining document more precisely than the
 	// api_name guess does, so answer it directly from the index.
 	if schema != "" {
-		if sources, err := d.OpenAPISchemaSources(ctx, schema); err == nil && len(sources) > 0 {
-			msg += fmt.Sprintf(" Schema %q is defined in %s — call get_openapi there, or use search_openapi to find definitions by name.",
-				schema, joinOpenAPISources(sources))
-		}
+		msg += OpenAPISchemaHint(ctx, d, schema)
 	}
 
 	if avail, err := d.ListOpenAPI(ctx, specID); err == nil {
@@ -130,6 +129,20 @@ func OpenAPINotFoundMessage(ctx context.Context, d *db.DB, specID, apiName, sche
 	return msg
 }
 
+// OpenAPISchemaHint reports which documents define the named schema, answered
+// from the openapi_chunks index, as a sentence that can be appended to a
+// not-found message. On a database without the index, or a schema the index
+// does not know, it is "" rather than an error, in the crossSpecHint manner
+// of get_asn1. Shared with the CLI's get-openapi command.
+func OpenAPISchemaHint(ctx context.Context, d *db.DB, schema string) string {
+	sources, err := d.OpenAPISchemaSources(ctx, schema)
+	if err != nil || len(sources) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" Schema %q is defined in %s — call get_openapi there, or use search_openapi to find definitions by name.",
+		schema, joinOpenAPISources(sources))
+}
+
 // joinOpenAPISources renders OpenAPI documents as "spec_id / api_name" pairs,
 // the two arguments a follow-up get_openapi call needs.
 func joinOpenAPISources(specs []db.OpenAPISpec) string {
@@ -141,8 +154,12 @@ func joinOpenAPISources(specs []db.OpenAPISpec) string {
 }
 
 // FilterOpenAPI narrows an OpenAPI YAML document to a path and/or schema
-// subset. It is shared with the CLI's get-openapi command.
-func FilterOpenAPI(content, pathFilter, schemaFilter string) (string, error) {
+// subset. schemaHint, when non-nil, is consulted on a schema the document
+// does not define, so the miss can say where the schema actually lives (the
+// 5G SBI documents keep their common types in TS 29.571) instead of only
+// listing this document's schemas. It is shared with the CLI's get-openapi
+// command.
+func FilterOpenAPI(content, pathFilter, schemaFilter string, schemaHint func(string) string) (string, error) {
 	var doc map[string]any
 	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
 		return "", fmt.Errorf("parse yaml: %w", err)
@@ -203,7 +220,11 @@ func FilterOpenAPI(content, pathFilter, schemaFilter string) (string, error) {
 					available = append(available, name)
 				}
 				sort.Strings(available)
-				fmt.Fprintf(&sb, "Schema %q not found. Available schemas:\n", schemaFilter)
+				fmt.Fprintf(&sb, "Schema %q not found in this document.", schemaFilter)
+				if schemaHint != nil {
+					sb.WriteString(schemaHint(schemaFilter))
+				}
+				sb.WriteString(" Available schemas:\n")
 				for _, s := range available {
 					fmt.Fprintf(&sb, "  %s\n", s)
 				}

--- a/internal/tools/openapi_notfound_test.go
+++ b/internal/tools/openapi_notfound_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/higebu/3gpp-mcp/internal/openapiindex"
 )
 
 // TestHandleGetOpenAPI_FilenameFallback verifies that an api_name given in
@@ -87,6 +89,30 @@ func TestHandleGetOpenAPI_NotFoundHints(t *testing.T) {
 		}
 		if !strings.Contains(text, "search_openapi") {
 			t.Errorf("missing search_openapi pointer: %s", text)
+		}
+	})
+
+	t.Run("schema miss in a found document names the defining document", func(t *testing.T) {
+		other := setupTestDB(t)
+		if err := other.UpsertOpenAPI("TS 29.571", "CommonData", "v1.5.0", "TS29571_CommonData.yaml",
+			"openapi: 3.0.0\ncomponents:\n  schemas:\n    ProblemDetails:\n      type: object\n"); err != nil {
+			t.Fatalf("seed openapi: %v", err)
+		}
+		if _, err := openapiindex.Build(context.Background(), other); err != nil {
+			t.Fatalf("build openapi index: %v", err)
+		}
+		result, _, _ := HandleGetOpenAPI(other)(context.Background(), nil, GetOpenAPIInput{
+			SpecID: "TS 29.510", APIName: "Nnrf_NFManagement", Schema: "ProblemDetails",
+		})
+		text := getTextContent(result)
+		if !strings.Contains(text, `Schema "ProblemDetails" not found in this document.`) {
+			t.Errorf("missing local not-found statement: %s", text)
+		}
+		if !strings.Contains(text, `Schema "ProblemDetails" is defined in TS 29.571 / CommonData`) {
+			t.Errorf("missing cross-document schema hint: %s", text)
+		}
+		if !strings.Contains(text, "Available schemas:") || !strings.Contains(text, "NFProfile") {
+			t.Errorf("missing local schema listing: %s", text)
 		}
 	})
 

--- a/internal/tools/openapi_notfound_test.go
+++ b/internal/tools/openapi_notfound_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestHandleGetOpenAPI_FilenameFallback verifies that an api_name given in
+// file-name form — the "TS29510_Nnrf_NFManagement" the models copy out of
+// prose, with or without .yaml — still resolves to the stored document.
+func TestHandleGetOpenAPI_FilenameFallback(t *testing.T) {
+	d := setupTestDB(t)
+	handler := HandleGetOpenAPI(d)
+
+	for _, apiName := range []string{"TS29510_Nnrf_NFManagement", "TS29510_Nnrf_NFManagement.yaml", "nnrf_nfmanagement"} {
+		t.Run(apiName, func(t *testing.T) {
+			result, _, err := handler(context.Background(), nil, GetOpenAPIInput{
+				SpecID: "TS 29.510", APIName: apiName,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected error result: %s", getTextContent(result))
+			}
+			if !strings.Contains(getTextContent(result), "openapi: 3.0.0") {
+				t.Errorf("expected YAML content, got: %s", getTextContent(result))
+			}
+		})
+	}
+}
+
+// TestHandleGetOpenAPI_NotFoundHints verifies that a (spec_id, api_name) miss
+// answers with what to do next rather than a raw SQL error: the api_name list
+// of the spec, the specification that does provide the requested api_name,
+// and — when a schema was named — the document that defines it.
+func TestHandleGetOpenAPI_NotFoundHints(t *testing.T) {
+	d := setupOpenAPISearchDB(t)
+	handler := HandleGetOpenAPI(d)
+
+	t.Run("wrong spec for api_name", func(t *testing.T) {
+		result, _, _ := handler(context.Background(), nil, GetOpenAPIInput{
+			SpecID: "TS 23.501", APIName: "Nnrf_NFManagement",
+		})
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+		text := getTextContent(result)
+		if strings.Contains(text, "no rows in result set") {
+			t.Errorf("raw SQL error leaked: %s", text)
+		}
+		if !strings.Contains(text, "not found in TS 23.501") {
+			t.Errorf("missing not-found statement: %s", text)
+		}
+		if !strings.Contains(text, "provided by TS 29.510 / Nnrf_NFManagement") {
+			t.Errorf("missing wrong-document hint: %s", text)
+		}
+		if !strings.Contains(text, "list_openapi") {
+			t.Errorf("missing list_openapi pointer for a spec with no definitions: %s", text)
+		}
+	})
+
+	t.Run("unknown api_name lists what the spec has", func(t *testing.T) {
+		result, _, _ := handler(context.Background(), nil, GetOpenAPIInput{
+			SpecID: "TS 29.510", APIName: "Nope_API",
+		})
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, "Available api_name values in TS 29.510: Nnrf_NFManagement") {
+			t.Errorf("missing available api_name listing: %s", text)
+		}
+	})
+
+	t.Run("schema hint answers from the index", func(t *testing.T) {
+		result, _, _ := handler(context.Background(), nil, GetOpenAPIInput{
+			SpecID: "TS 23.501", APIName: "Namf_Wrong", Schema: "NFProfile",
+		})
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+		text := getTextContent(result)
+		if !strings.Contains(text, `Schema "NFProfile" is defined in TS 29.510 / Nnrf_NFManagement`) {
+			t.Errorf("missing schema hint: %s", text)
+		}
+		if !strings.Contains(text, "search_openapi") {
+			t.Errorf("missing search_openapi pointer: %s", text)
+		}
+	})
+
+	t.Run("schema hint omitted without index", func(t *testing.T) {
+		bare := setupTestDB(t)
+		if err := bare.Exec("DROP TABLE openapi_chunks_fts"); err != nil {
+			t.Fatalf("drop index: %v", err)
+		}
+		result, _, _ := HandleGetOpenAPI(bare)(context.Background(), nil, GetOpenAPIInput{
+			SpecID: "TS 23.501", APIName: "Namf_Wrong", Schema: "NFProfile",
+		})
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+		text := getTextContent(result)
+		if strings.Contains(text, "is defined in") {
+			t.Errorf("schema hint should be omitted without the index: %s", text)
+		}
+		if !strings.Contains(text, "not found in TS 23.501") {
+			t.Errorf("not-found statement should survive a missing index: %s", text)
+		}
+	})
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -593,7 +593,7 @@ func (h *handler) handleOpenAPI(w http.ResponseWriter, r *http.Request) {
 	specID := r.PathValue("specID")
 	apiName := r.PathValue("apiName")
 
-	content, err := h.db.GetOpenAPI(r.Context(), specID, apiName)
+	content, err := h.db.GetOpenAPIResolved(r.Context(), specID, apiName)
 	if err != nil {
 		h.renderError(w, http.StatusNotFound, fmt.Sprintf("OpenAPI definition %q not found", apiName))
 		return


### PR DESCRIPTION
A `(spec_id, api_name)` miss answered with a raw SQL error (`sql: no rows in result set`). Now it lists the spec's api_name values, names the spec that provides the requested api_name, and answers a `schema` argument from the openapi_chunks index, in the crossSpecHint manner of get_asn1. api_name also resolves case-insensitively and as the stored filename with or without `.yaml`. The CLI `get-openapi` and the web viewer share the same lookup.

Benchmarked before/after with deepseek-v4-flash on the 250 OpenAPI tasks (tools condition, pinned latest-v2 DB): raw SQL errors 3 → 0, answer accuracy 99.2% → 99.6%, tool calls/task 3.47 → 3.31, prompt tokens −6.8%.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSdUzZgStoUxZ7F5UaREQg)_