### PR TITLE
feat: expose web viewer tools via WebMCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,12 @@ make e2e                  # Playwright suite for web viewer JS behavior (CI job 
 - **HTTP transport runs stateless** (`StreamableHTTPOptions{Stateless: true}`)
   — required to serve MCP protocol 2026-07-28; older protocol versions get
   per-request sessions.
+- **webmcp.js is a thin same-origin passthrough to `/mcp/`** (W3C
+  `document.modelContext`): it registers the tools reported by `tools/list` at
+  page load, so the browser registration stays in sync with the server without
+  a tool list of its own. The e2e harness (`e2e/e2eserver`) mounts `/mcp/`
+  with the same `tools.NewStreamableHTTPHandler` as `buildHTTPHandler`, so
+  the bridge is tested against the real stateless handler.
 - `--convert-image` (EMF/WMF → PNG) requires LibreOffice (`soffice`) at runtime.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Browse specifications in your browser by adding `--web` to the HTTP transport:
 
 Features: spec list with filtering, section viewer with TOC sidebar, full-text search with pagination, past-version browsing (versions are listed per spec and downloaded on demand, like the MCP tools), version comparison (structural summary and per-section diffs), embedded images, cross-reference links, OpenAPI definitions with syntax highlighting, KaTeX rendering of the [LaTeX formulas](#formulas) the converter emits, dark mode, responsive design. Code blocks are syntax-highlighted per notation — ASN.1, Diameter, SIP/RTSP, SDP and XML (see [Code blocks](#code-blocks)).
 
+#### WebMCP
+
+When the browser provides the [W3C WebMCP](https://github.com/webmachinelearning/webmcp) API (`document.modelContext`, a Chrome origin trial as of 2026), the viewer registers all of its MCP tools with the browser at page load, so an in-browser agent can query the spec database directly. The registration is a thin same-origin passthrough to the `/mcp/` endpoint — there is nothing to configure server-side, and browsers without the API are unaffected. During the origin trial, enable it locally via Chrome flags (`chrome://flags`), or for a shared deployment serve an `Origin-Trial` header from a fronting proxy.
+
 ## Deployment
 
 ### Streamable HTTP

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -59,15 +59,10 @@ func bearerAuthMiddleware(token string, next http.Handler) http.Handler {
 // serves the same corpus as the MCP tools, so leaving it open would make the
 // token meaningless.
 func buildHTTPHandler(src *tools.Source, s *mcp.Server, bearerToken string, enableWeb bool) http.Handler {
-	// Stateless mode is required to serve protocol version 2026-07-28,
-	// whose lifecycle has no initialize handshake or Mcp-Session-Id.
-	// Older clients still work: each request runs in a temporary session.
-	// This server never initiates server->client requests, so nothing is
-	// lost by not keeping sessions.
-	mcpHandler := mcp.NewStreamableHTTPHandler(
-		func(r *http.Request) *mcp.Server { return s },
-		&mcp.StreamableHTTPOptions{Stateless: true},
-	)
+	// Stateless mode (see tools.NewStreamableHTTPHandler) is required to
+	// serve protocol version 2026-07-28; older clients still work, each
+	// request running in a temporary session.
+	mcpHandler := tools.NewStreamableHTTPHandler(s)
 
 	appMux := http.NewServeMux()
 	if enableWeb {
@@ -194,35 +189,6 @@ func defaultFetchBudget() time.Duration {
 	return versionstore.DefaultBudget
 }
 
-// newMCPServer builds the MCP server and registers every tool. It is shared
-// by cmdServe and the transport tests.
-func newMCPServer(d *db.DB, src *tools.Source) *mcp.Server {
-	s := mcp.NewServer(&mcp.Implementation{
-		Name:    "3gpp-mcp",
-		Version: version,
-	}, &mcp.ServerOptions{
-		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions, and search_openapi when you know the data type or endpoint but not which API document defines it. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions. For ASN.1-specified protocols (RRC TS 38.331/36.331, NGAP TS 38.413, S1AP TS 36.413, XnAP, F1AP, LPP TS 37.355, ...), use get_asn1 with a type, IE or constant name to get its definition and defining section directly — the ASN.1 clauses are far larger than one get_section page. If you do not know which specification defines the name, omit spec_id and the name is resolved across the whole database; get_asn1 with a spec_id and no name lists what that specification defines.\n\n" +
-			"Notation: section text is Markdown. Figures are `![...](image://NAME)` links. Formulas are LaTeX — a standalone equation is a ```latex code block whose equation number is kept as `\\tag{7.3-1}`, and a formula inside a sentence or a table cell is delimited with `$...$` or `$$...$$`. A paragraph's leading indentation — the nesting of requirement and condition lists — is preserved as no-break spaces (U+00A0), one tab of the source document being four.\n\n" +
-			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then use compare_versions: without section_number it summarizes which sections were added, removed or changed between two versions, and with section_number it returns a line-level diff of that section's text. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. get_image and list_images also accept a version: an archived version's images are downloaded on their own first use, again taking up to a few minutes before a retry succeeds. search and get_references only have data for the version in the database.",
-	})
-
-	mcp.AddTool(s, tools.ListSpecsTool, tools.HandleListSpecs(d))
-	mcp.AddTool(s, tools.ListVersionsTool, tools.HandleListVersions(src))
-	mcp.AddTool(s, tools.GetTOCTool, tools.HandleGetTOC(src))
-	mcp.AddTool(s, tools.GetSectionTool, tools.HandleGetSection(src))
-	mcp.AddTool(s, tools.GetASN1Tool, tools.HandleGetASN1(src))
-	mcp.AddTool(s, tools.CompareVersionsTool, tools.HandleCompareVersions(src))
-	mcp.AddTool(s, tools.SearchTool, tools.HandleSearch(d))
-	mcp.AddTool(s, tools.ListOpenAPITool, tools.HandleListOpenAPI(d))
-	mcp.AddTool(s, tools.GetOpenAPITool, tools.HandleGetOpenAPI(d))
-	mcp.AddTool(s, tools.SearchOpenAPITool, tools.HandleSearchOpenAPI(d))
-	mcp.AddTool(s, tools.GetReferencesTool, tools.HandleGetReferences(d))
-	mcp.AddTool(s, tools.ListImagesTool, tools.HandleListImages(src))
-	mcp.AddTool(s, tools.GetImageTool, tools.HandleGetImage(src))
-
-	return s
-}
-
 func cmdServe(args []string) {
 	defaultTransport := "stdio"
 	if v := os.Getenv("THREEGPP_MCP_TRANSPORT"); v != "" {
@@ -280,7 +246,7 @@ func cmdServe(args []string) {
 		}
 	}
 
-	s := newMCPServer(d, src)
+	s := tools.NewServer(d, src, version)
 
 	switch *transport {
 	case "stdio":

--- a/cmd/3gpp-mcp/main_test.go
+++ b/cmd/3gpp-mcp/main_test.go
@@ -1028,7 +1028,7 @@ func TestMainDispatch_CompletionBash(t *testing.T) {
 // cmdServe.
 func TestStreamableHTTP(t *testing.T) {
 	d := testutil.SetupTestDB(t)
-	s := newMCPServer(d, tools.NewSource(d))
+	s := tools.NewServer(d, tools.NewSource(d), version)
 
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return s },
@@ -1076,7 +1076,7 @@ func TestStreamableHTTP(t *testing.T) {
 // request — no initialize handshake, no session — is served.
 func TestStreamableHTTPNewProtocolRawPOST(t *testing.T) {
 	d := testutil.SetupTestDB(t)
-	s := newMCPServer(d, tools.NewSource(d))
+	s := tools.NewServer(d, tools.NewSource(d), version)
 
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return s },
@@ -1123,7 +1123,7 @@ func TestStreamableHTTPNewProtocolRawPOST(t *testing.T) {
 // as the tools, so an unauthenticated viewer would make the token meaningless.
 func TestBuildHTTPHandler_WebViewerAuth(t *testing.T) {
 	d := testutil.SetupTestDB(t)
-	s := newMCPServer(d, tools.NewSource(d))
+	s := tools.NewServer(d, tools.NewSource(d), version)
 
 	t.Run("token set", func(t *testing.T) {
 		handler := buildHTTPHandler(tools.NewSource(d), s, "secret-token", true)

--- a/e2e/e2eserver/main.go
+++ b/e2e/e2eserver/main.go
@@ -75,7 +75,16 @@ func run(addr string) error {
 		}
 	}
 
-	srv := &http.Server{Addr: addr, Handler: web.NewServer(tools.NewSource(d))}
+	// Mirror cmdServe's production wiring: the same stateless handler
+	// (tools.NewStreamableHTTPHandler) mounted under /mcp/ next to the
+	// viewer, so the webmcp.js bridge is exercised against the real thing.
+	src := tools.NewSource(d)
+	s := tools.NewServer(d, src, "e2e")
+	mux := http.NewServeMux()
+	mux.Handle("/mcp/", http.StripPrefix("/mcp", tools.NewStreamableHTTPHandler(s)))
+	mux.Handle("/", web.NewServer(src))
+
+	srv := &http.Server{Addr: addr, Handler: mux}
 	errc := make(chan error, 1)
 	go func() { errc <- srv.ListenAndServe() }()
 	log.Printf("e2eserver listening on http://%s", addr)

--- a/e2e/tests/webmcp.spec.ts
+++ b/e2e/tests/webmcp.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+const ALL_TOOLS = [
+  'list_specs', 'list_versions', 'get_toc', 'get_section', 'get_asn1',
+  'compare_versions', 'search', 'list_openapi', 'get_openapi',
+  'search_openapi', 'get_references', 'list_images', 'get_image',
+];
+
+// Installs a stub document.modelContext before any page script runs, so
+// webmcp.js registers its tools against it. Registrations are kept on
+// window for the assertions.
+const installStub = (page: import('@playwright/test').Page) =>
+  page.addInitScript(() => {
+    (window as any).__registered = [];
+    (document as any).modelContext = {
+      registerTool(tool: any) {
+        (window as any).__registered.push(tool);
+      },
+    };
+  });
+
+test('registers every MCP tool with schema and read-only annotations', async ({ page }) => {
+  await installStub(page);
+  await page.goto('/');
+
+  // Registration happens after an async tools/list round-trip. Wait for at
+  // least the expected count so an extra tool fails the readable toEqual
+  // assertion below instead of an opaque timeout here.
+  await page.waitForFunction(
+    (n) => (window as any).__registered.length >= n,
+    ALL_TOOLS.length,
+  );
+
+  const tools = await page.evaluate(() =>
+    (window as any).__registered.map((t: any) => ({
+      name: t.name,
+      description: t.description,
+      hasSchema: !!t.inputSchema && typeof t.inputSchema === 'object',
+      readOnlyHint: t.annotations?.readOnlyHint,
+      untrustedContentHint: t.annotations?.untrustedContentHint,
+      hasExecute: typeof t.execute === 'function',
+    })),
+  );
+
+  expect(tools.map((t: any) => t.name).sort()).toEqual([...ALL_TOOLS].sort());
+  for (const tool of tools) {
+    expect(tool.description, tool.name).toBeTruthy();
+    expect(tool.hasSchema, tool.name).toBe(true);
+    expect(tool.readOnlyHint, tool.name).toBe(true);
+    expect(tool.untrustedContentHint, tool.name).toBe(true);
+    expect(tool.hasExecute, tool.name).toBe(true);
+  }
+});
+
+test('execute calls through the real /mcp/ endpoint', async ({ page }) => {
+  await installStub(page);
+  await page.goto('/');
+  await page.waitForFunction(
+    (n) => (window as any).__registered.length >= n,
+    ALL_TOOLS.length,
+  );
+
+  const result = await page.evaluate(() => {
+    const tool = (window as any).__registered.find((t: any) => t.name === 'list_specs');
+    return tool.execute({});
+  });
+
+  expect(result.isError).toBeFalsy();
+  expect(Array.isArray(result.content)).toBe(true);
+  const text = result.content.map((c: any) => c.text ?? '').join('\n');
+  // Seeded by the harness (internal/testutil.SeedData).
+  expect(text).toContain('TS 23.501');
+});
+
+test('page loads cleanly when the browser has no modelContext', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      errors.push(msg.text());
+    }
+  });
+  page.on('pageerror', (err) => errors.push(String(err)));
+
+  await page.goto('/');
+  await expect(page.getByText('TS 23.501')).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"net/http"
+
+	"github.com/higebu/3gpp-mcp/internal/db"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewServer builds the MCP server and registers every tool. It is shared by
+// the serve command, its transport tests and the e2e harness. version is the
+// binary's build version reported in the server implementation info.
+func NewServer(d *db.DB, src *Source, version string) *mcp.Server {
+	s := mcp.NewServer(&mcp.Implementation{
+		Name:    "3gpp-mcp",
+		Version: version,
+	}, &mcp.ServerOptions{
+		Instructions: "3GPP specification server. Use list_specs to find specifications, get_toc to browse structure, get_section to read specification document text (architecture, procedures, requirements), and search to find relevant sections. Use get_references to explore cross-references between specifications (outgoing: what a section references; incoming: what references a spec). For 5G API details (HTTP methods, request/response bodies, paths, schemas, data models) from TS 29.xxx series, use list_openapi to discover APIs and get_openapi to read their OpenAPI definitions, and search_openapi when you know the data type or endpoint but not which API document defines it. Always prefer get_openapi over get_section when looking up API request/response formats or data type definitions. For ASN.1-specified protocols (RRC TS 38.331/36.331, NGAP TS 38.413, S1AP TS 36.413, XnAP, F1AP, LPP TS 37.355, ...), use get_asn1 with a type, IE or constant name to get its definition and defining section directly — the ASN.1 clauses are far larger than one get_section page. If you do not know which specification defines the name, omit spec_id and the name is resolved across the whole database; get_asn1 with a spec_id and no name lists what that specification defines.\n\n" +
+			"Notation: section text is Markdown. Figures are `![...](image://NAME)` links. Formulas are LaTeX — a standalone equation is a ```latex code block whose equation number is kept as `\\tag{7.3-1}`, and a formula inside a sentence or a table cell is delimited with `$...$` or `$$...$$`. A paragraph's leading indentation — the nesting of requirement and condition lists — is preserved as no-break spaces (U+00A0), one tab of the source document being four.\n\n" +
+			"Versions: the database holds one version per specification, and every get_section, get_toc and search result names the specification and version it came from. To compare a procedure across releases, call list_versions to see which versions exist, then use compare_versions: without section_number it summarizes which sections were added, removed or changed between two versions, and with section_number it returns a line-level diff of that section's text. A version that is not in the database is downloaded and converted on first use, which takes up to a few minutes for a large specification; when that happens the tool says so and you should call it again with the same arguments. Section numbers move between releases, so check get_toc for the older version before reading a section of it. get_image and list_images also accept a version: an archived version's images are downloaded on their own first use, again taking up to a few minutes before a retry succeeds. search and get_references only have data for the version in the database.",
+	})
+
+	mcp.AddTool(s, ListSpecsTool, HandleListSpecs(d))
+	mcp.AddTool(s, ListVersionsTool, HandleListVersions(src))
+	mcp.AddTool(s, GetTOCTool, HandleGetTOC(src))
+	mcp.AddTool(s, GetSectionTool, HandleGetSection(src))
+	mcp.AddTool(s, GetASN1Tool, HandleGetASN1(src))
+	mcp.AddTool(s, CompareVersionsTool, HandleCompareVersions(src))
+	mcp.AddTool(s, SearchTool, HandleSearch(d))
+	mcp.AddTool(s, ListOpenAPITool, HandleListOpenAPI(d))
+	mcp.AddTool(s, GetOpenAPITool, HandleGetOpenAPI(d))
+	mcp.AddTool(s, SearchOpenAPITool, HandleSearchOpenAPI(d))
+	mcp.AddTool(s, GetReferencesTool, HandleGetReferences(d))
+	mcp.AddTool(s, ListImagesTool, HandleListImages(src))
+	mcp.AddTool(s, GetImageTool, HandleGetImage(src))
+
+	return s
+}
+
+// NewStreamableHTTPHandler wraps s in the streamable HTTP transport in
+// stateless mode. Stateless mode is required to serve protocol version
+// 2026-07-28, whose lifecycle has no initialize handshake or Mcp-Session-Id.
+// Older clients still work: each request runs in a temporary session. This
+// server never initiates server->client requests, so nothing is lost by not
+// keeping sessions.
+//
+// Shared by cmdServe's buildHTTPHandler and the e2e harness so both serve the
+// exact same handler; mounting it under a prefix (e.g. /mcp/ next to the web
+// viewer, via http.StripPrefix) is the caller's choice.
+func NewStreamableHTTPHandler(s *mcp.Server) http.Handler {
+	return mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return s },
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	)
+}

--- a/internal/web/static/webmcp.js
+++ b/internal/web/static/webmcp.js
@@ -1,0 +1,132 @@
+// WebMCP bridge (W3C document.modelContext): registers the server's MCP
+// tools with the browser so an in-page agent can call them. Tools are read
+// from the same-origin /mcp/ endpoint at page load, so the registration
+// never drifts from what the server actually serves. Every failure is a
+// silent no-op — the viewer must work identically without it.
+(function () {
+    var modelContext = document.modelContext || navigator.modelContext;
+    if (!modelContext || typeof modelContext.registerTool !== 'function') {
+        return;
+    }
+
+    var PROTOCOL = '2026-07-28';
+    var nextId = 1;
+
+    // The response to a single-request POST arrives as text/event-stream by
+    // default; the JSON-RPC response is the data payload carrying a result
+    // or error.
+    var parseSSE = function (text) {
+        var msg = null;
+        text.replace(/\r\n/g, '\n').split('\n\n').forEach(function (event) {
+            var data = event.split('\n').filter(function (line) {
+                return line.indexOf('data:') === 0;
+            }).map(function (line) {
+                return line.slice(5).replace(/^ /, '');
+            }).join('\n');
+            if (!data) {
+                return;
+            }
+            try {
+                var parsed = JSON.parse(data);
+                if (parsed && (parsed.result !== undefined || parsed.error !== undefined)) {
+                    msg = parsed;
+                }
+            } catch (e) { /* not a JSON-RPC message; skip */ }
+        });
+        if (!msg) {
+            throw new Error('no JSON-RPC response in event stream');
+        }
+        return msg;
+    };
+
+    // rpc POSTs one bare JSON-RPC request. The stateless handler has no
+    // initialize handshake, but the 2026-07-28 protocol requires the version
+    // and client capabilities in _meta (SEP-2575) and the method mirrored in
+    // a header (SEP-2243); tools/call also mirrors the tool name.
+    var rpc = function (method, params) {
+        var headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
+            'MCP-Protocol-Version': PROTOCOL,
+            'Mcp-Method': method
+        };
+        if (method === 'tools/call') {
+            headers['Mcp-Name'] = params.name;
+        }
+        params = Object.assign({}, params);
+        params._meta = {
+            'io.modelcontextprotocol/protocolVersion': PROTOCOL,
+            'io.modelcontextprotocol/clientCapabilities': {}
+        };
+        return fetch('/mcp/', {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify({ jsonrpc: '2.0', id: nextId++, method: method, params: params })
+        }).then(function (resp) {
+            if (!resp.ok) {
+                // The stateless handler pairs an error status with a JSON-RPC
+                // error body whose message names the actual problem (e.g. a
+                // header mismatch); surface it when present.
+                return resp.text().then(function (text) {
+                    var message = '';
+                    try {
+                        var parsed = JSON.parse(text);
+                        if (parsed && parsed.error && parsed.error.message) {
+                            message = parsed.error.message;
+                        }
+                    } catch (e) { /* not JSON; fall through to the generic message */ }
+                    throw new Error(message || '/mcp/ returned HTTP ' + resp.status);
+                });
+            }
+            var isSSE = (resp.headers.get('Content-Type') || '').indexOf('text/event-stream') === 0;
+            return resp.text().then(function (text) {
+                return isSSE ? parseSSE(text) : JSON.parse(text);
+            });
+        }).then(function (msg) {
+            if (msg.error) {
+                throw new Error(msg.error.message || 'MCP error ' + msg.error.code);
+            }
+            return msg.result;
+        });
+    };
+
+    var register = function (tool) {
+        modelContext.registerTool({
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            // Every tool is a read-only lookup, and specification text is
+            // external content, so force both hints whatever the server says.
+            annotations: Object.assign({}, tool.annotations, {
+                readOnlyHint: true,
+                untrustedContentHint: true
+            }),
+            execute: function (args) {
+                return rpc('tools/call', { name: tool.name, arguments: args || {} })
+                    .catch(function (err) {
+                        // Resolve with an MCP-style error result rather than
+                        // throwing, matching how the server reports tool errors.
+                        return {
+                            content: [{ type: 'text', text: String((err && err.message) || err) }],
+                            isError: true
+                        };
+                    });
+            }
+        });
+    };
+
+    var listPage = function (cursor) {
+        return rpc('tools/list', cursor ? { cursor: cursor } : {}).then(function (result) {
+            (result.tools || []).forEach(register);
+            if (result.nextCursor) {
+                return listPage(result.nextCursor);
+            }
+        });
+    };
+
+    listPage().catch(function (err) {
+        // /mcp/ may be absent (e.g. stripped by a fronting proxy).
+        console.debug('webmcp: tool registration skipped: ' + err);
+    });
+})();

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -84,5 +84,6 @@
     </main>
     <script src="/static/katex/katex.min.js"></script>
     <script src="/static/app.js"></script>
+    <script src="/static/webmcp.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `internal/web/static/webmcp.js`: registers the server's MCP tools with the browser via the W3C WebMCP API (`document.modelContext`) when available. It is a thin same-origin passthrough to `/mcp/` — `tools/list` at page load keeps the registration in sync with the server, and `execute` forwards to `tools/call`. Browsers without the API, or deployments without `/mcp/`, are unaffected (silent no-op).
- All registered tools carry `readOnlyHint` and `untrustedContentHint` annotations (read-only lookups over external specification text).
- Move MCP server construction to `tools.NewServer` and share the stateless streamable handler via `tools.NewStreamableHTTPHandler`, so the e2e harness mounts `/mcp/` with the same wiring as production.
- e2e: `e2eserver` now serves `/mcp/`; new `webmcp.spec.ts` verifies all 13 tools register with schema/annotations, an `execute` round trip through the real endpoint, and a clean no-op load without the API.
- Docs: README subsection on WebMCP (incl. origin-trial enablement), AGENTS.md invariant bullet.

## Testing

- `go build` / `go vet` / `gofmt` / `golangci-lint run` clean; `go test -short` for cmd, tools and web packages
- Playwright suite: 12 passed (3 new WebMCP specs)
- Manually exercised the bridge against a running server: `tools/list` (SSE framing, 13 tools) and `tools/call` success and error paths

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgrVgE8VhRG2qRJEDC9UHN)_