### PR TITLE
feat: rename Tools heading and add init-db command

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ combined.
 To run on Cloud Run, see `cloudbuild.yaml` (build + push + deploy) and
 `service.yaml` (Cloud Run service spec).
 
-## MCP Tools
+## Tools
 
 Every tool below also has a CLI twin (`list_specs` → `3gpp-mcp list-specs`, and
 so on) for shell use and scripting — see the

--- a/cmd/3gpp-mcp/main.go
+++ b/cmd/3gpp-mcp/main.go
@@ -108,6 +108,7 @@ func init() {
 		{name: "update", desc: "Update database to latest spec versions", run: cmdUpdate},
 		{name: "build-openapi-index", desc: "Rebuild the OpenAPI search index", run: cmdBuildOpenAPIIndex},
 		{name: "build-asn1-index", desc: "Rebuild the ASN.1 name index", run: cmdBuildASN1Index},
+		{name: "init-db", desc: "Create an empty database with just the schema", run: cmdInitDB},
 		{name: "list-specs", desc: "List specifications in the database", run: cmdListSpecs},
 		{name: "list-versions", desc: "List versions of a specification", run: cmdListVersions},
 		{name: "get-toc", desc: "Print a specification's table of contents", run: cmdGetTOC},
@@ -738,6 +739,30 @@ func runBuildASN1Index(ctx context.Context, dbPath string) error {
 	}
 
 	return rebuildASN1Index(ctx, d)
+}
+
+// cmdInitDB creates a database file with the schema but no data. serve only
+// needs the schema to answer the MCP handshake (tool list, prompts,
+// resources): registration is unconditional, so a container build that only
+// needs to pass server introspection doesn't have to run the full spec
+// import first.
+func cmdInitDB(args []string) {
+	fs := flag.NewFlagSet("init-db", flag.ExitOnError)
+	dbPath := fs.String("db", "3gpp.db", "Output SQLite database path")
+	_ = fs.Parse(args)
+	requireArgs(fs, 0, "3gpp-mcp init-db [options]")
+
+	d, err := db.OpenReadWrite(*dbPath)
+	if err != nil {
+		log.Printf("Open database failed: %v", err)
+		exit(1)
+	}
+	defer d.Close()
+
+	if err := d.InitSchema(); err != nil {
+		log.Printf("Init schema failed: %v", err)
+		exit(1)
+	}
 }
 
 func cmdBuildOpenAPIIndex(args []string) {


### PR DESCRIPTION
## Summary
- Rename the `## MCP Tools` README heading to `## Tools` so mcp.so's README-based tool list extraction picks it up.
- Add an `init-db` CLI command that creates a database with just the schema (no specs). `serve` opens the database read-only and registers every MCP tool unconditionally, so a directory build that only needs to pass tool-list introspection (e.g. Glama) can skip the full spec import.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `go vet ./...`
- [x] `go test -short ./...`
- [x] `golangci-lint run`
- [x] Manually verified: `init-db` output opens via the same read-only path as `serve`, and `newMCPServer` constructs successfully against the schema-only database


---
_Generated by [Claude Code](https://claude.ai/code/session_01XEZxqUcC3TFowjMNyJcJEe)_