### PR TITLE
feat(docx): number headings from Word numbering definitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ make e2e                  # Playwright suite for web viewer JS behavior (CI job 
   path and fetched by `internal/tdoc` — the group's DynaReport meeting index
   gives the meeting whose TDoc range covers the number, and the document is
   downloaded from that meeting's `Docs/<id>.zip` (the listing is cached 24h).
-  Conversion runs with `docx.ParseOptions{KeepPreamble: true}` so a CR cover
-  sheet / LS header survives as the `""` (preamble) section, and repeated
+  Conversion runs with `docx.ParseOptions{KeepPreamble: true, NumberHeadings:
+  true}` so a CR cover sheet / LS header survives as the `""` (preamble)
+  section (see below for the numbering), and repeated
   unnumbered headings are de-duplicated with `" (2)"` suffixes at store time.
   A converter change that alters TDoc output needs a bump of
   `tdocstore.cacheSchemaVersion`, which is separate from
@@ -80,8 +81,13 @@ make e2e                  # Playwright suite for web viewer JS behavior (CI job 
   `report` TDoc of the following meetings whose title names the meeting
   (`tdoc.ReportTitleMatches`) and falls back to the `Report/` folder
   (`tdoc.FindReportFile`); the agenda is the unrevised `agenda` TDoc of the
-  meeting's own list. Report headings are unnumbered after conversion
-  (Word auto-numbering), so their section numbers are their titles.
+  meeting's own list. Report headings on the MCC template carry no number
+  in their text — Word computes it from the heading style's numbering
+  definition — so TDocs are converted with `docx.ParseOptions
+  {NumberHeadings: true}`: `internal/converter/docx/numbering.go` reads
+  `word/numbering.xml` and the styles' `w:numPr` and numbers every heading
+  whose text has no number, in reading order. Specifications type their
+  numbers and are converted with it off, so their output is unchanged.
 - **OpenAPI search is a second FTS index.** `openapi_chunks` / `openapi_chunks_fts`
   (`db.OpenAPIIndexSchema`) hold one row per schema and per operation, derived
   from `openapi_specs` by `internal/openapiindex` and **rebuilt wholesale** —

--- a/README.md
+++ b/README.md
@@ -384,7 +384,9 @@ Converted documents and TDoc lists are kept in their own size-bounded cache
 TDocs are never imported into it and `search` does not cover them.
 
 `get_meeting_report` reads a meeting's approved report or final agenda by
-meeting name alone; the output header names the document it resolved to.
+meeting name alone; the output header names the document it resolved to,
+and the sections carry the numbers the document shows, so an agenda item's
+section can be read by number.
 
 Notes:
 

--- a/internal/converter/docx/numbering.go
+++ b/internal/converter/docx/numbering.go
@@ -1,0 +1,386 @@
+package docx
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Word numbers headings in one of two ways: the number is typed into the
+// heading text ("4.2.3\tTitle", every 3GPP specification), or the heading
+// style carries a numbering definition (w:numPr) and Word computes the
+// number when it lays the document out. Meeting reports use the second
+// way, so their headings arrive without a number. numbering.xml holds the
+// definitions: an abstract numbering (one lvl per depth, with a start
+// value, a format and a text template such as "%1.%2") and the concrete
+// numbering instances (w:num) that refer to them, possibly overriding a
+// level's start.
+
+// numLevel is one depth of a numbering definition.
+type numLevel struct {
+	start  int
+	format string // "decimal", "lowerLetter", "upperRoman", "bullet", "none", ...
+	text   string // "%1.%2"
+}
+
+// numInstance is a w:num: an abstract numbering plus per-level overrides.
+type numInstance struct {
+	abstractID string
+	overrides  map[int]numLevel
+}
+
+// numberingDefs is the content of word/numbering.xml.
+type numberingDefs struct {
+	abstracts map[string][]numLevel
+	nums      map[string]numInstance
+}
+
+const maxNumLevels = 9
+
+// parseNumbering reads word/numbering.xml. A malformed file yields the
+// definitions read up to the error together with the error, so the caller
+// can warn and still number what it can.
+func parseNumbering(data []byte) (*numberingDefs, error) {
+	defs := &numberingDefs{abstracts: map[string][]numLevel{}, nums: map[string]numInstance{}}
+	if len(data) == 0 {
+		return defs, nil
+	}
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	var (
+		abstractID string
+		levels     []numLevel
+		numID      string
+		num        numInstance
+		lvl        *numLevel
+		lvlIndex   int
+		inOverride bool
+		overIndex  int
+	)
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return defs, fmt.Errorf("parse numbering.xml: %w", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "abstractNum":
+				abstractID = getAttrVal(t, "abstractNumId")
+				levels = make([]numLevel, maxNumLevels)
+				for i := range levels {
+					levels[i] = numLevel{start: 1, format: "decimal"}
+				}
+			case "num":
+				numID = getAttrVal(t, "numId")
+				num = numInstance{overrides: map[int]numLevel{}}
+			case "abstractNumId":
+				if numID != "" {
+					num.abstractID = getAttrVal(t, "val")
+				}
+			case "lvlOverride":
+				// Only meaningful inside a w:num; a stray one in a
+				// malformed file must not write into a nil map.
+				if numID != "" {
+					inOverride = true
+					overIndex, _ = strconv.Atoi(getAttrVal(t, "ilvl"))
+				}
+			case "startOverride":
+				if inOverride {
+					if v, err := strconv.Atoi(getAttrVal(t, "val")); err == nil {
+						o := num.overrides[overIndex]
+						o.start = v
+						num.overrides[overIndex] = o
+					}
+				}
+			case "lvl":
+				lvlIndex, _ = strconv.Atoi(getAttrVal(t, "ilvl"))
+				l := numLevel{start: 1, format: "decimal"}
+				lvl = &l
+			case "start":
+				if lvl != nil {
+					if v, err := strconv.Atoi(getAttrVal(t, "val")); err == nil {
+						lvl.start = v
+					}
+				}
+			case "numFmt":
+				if lvl != nil {
+					lvl.format = getAttrVal(t, "val")
+				}
+			case "lvlText":
+				if lvl != nil {
+					lvl.text = getAttrVal(t, "val")
+				}
+			}
+		case xml.EndElement:
+			switch t.Name.Local {
+			case "lvl":
+				if lvl != nil && lvlIndex >= 0 && lvlIndex < maxNumLevels {
+					switch {
+					case inOverride:
+						num.overrides[overIndex] = *lvl
+					case levels != nil:
+						levels[lvlIndex] = *lvl
+					}
+				}
+				lvl = nil
+			case "lvlOverride":
+				inOverride = false
+			case "abstractNum":
+				if abstractID != "" {
+					defs.abstracts[abstractID] = levels
+				}
+				abstractID, levels = "", nil
+			case "num":
+				if numID != "" {
+					defs.nums[numID] = num
+				}
+				numID = ""
+			}
+		}
+	}
+	return defs, nil
+}
+
+// level returns the definition of one depth of a numbering instance, the
+// instance's override applied.
+func (d *numberingDefs) level(numID string, ilvl int) (numLevel, bool) {
+	num, ok := d.nums[numID]
+	if !ok || ilvl < 0 || ilvl >= maxNumLevels {
+		return numLevel{}, false
+	}
+	levels, ok := d.abstracts[num.abstractID]
+	if !ok {
+		return numLevel{}, false
+	}
+	l := levels[ilvl]
+	if o, ok := num.overrides[ilvl]; ok {
+		if o.start > 0 {
+			l.start = o.start
+		}
+		if o.text != "" {
+			l.format, l.text = o.format, o.text
+		}
+	}
+	return l, true
+}
+
+// numberer computes the numbers of a document's numbered paragraphs in
+// reading order, the way Word does when it lays the document out.
+type numberer struct {
+	defs     *numberingDefs
+	styles   map[string]styleNumbering
+	counters map[string][]int
+}
+
+func newNumberer(defs *numberingDefs, styles map[string]styleNumbering) *numberer {
+	return &numberer{defs: defs, styles: styles, counters: map[string][]int{}}
+}
+
+// paragraphNumber advances the numbering a paragraph belongs to and returns
+// the paragraph's number ("2.1"), or "" when the paragraph is not numbered
+// or its level renders no number (a bullet). The paragraph's own w:numPr
+// wins over its style's; a numId of 0 turns numbering off.
+func (n *numberer) paragraphNumber(p paragraphInfo) string {
+	if n == nil {
+		return ""
+	}
+	numID, ilvl := "", 0
+	if p.HasNumPr {
+		numID, ilvl = p.NumID, p.ILvl
+	}
+	if s, ok := resolveStyleNumbering(p.StyleID, n.styles); ok {
+		if numID == "" {
+			numID = s.numID
+		}
+		if !p.HasNumPr || !p.HasILvl {
+			ilvl = s.ilvl
+		}
+	}
+	if numID == "" || numID == "0" {
+		return ""
+	}
+	if _, ok := n.defs.level(numID, ilvl); !ok {
+		return ""
+	}
+	counters, ok := n.counters[numID]
+	if !ok {
+		counters = make([]int, maxNumLevels)
+		for i := range counters {
+			l, _ := n.defs.level(numID, i)
+			counters[i] = l.start - 1
+		}
+		n.counters[numID] = counters
+	}
+	counters[ilvl]++
+	for i := ilvl + 1; i < maxNumLevels; i++ {
+		l, _ := n.defs.level(numID, i)
+		counters[i] = l.start - 1
+	}
+	return n.label(numID, ilvl, counters)
+}
+
+// label renders a level's text template with the current counters.
+func (n *numberer) label(numID string, ilvl int, counters []int) string {
+	l, _ := n.defs.level(numID, ilvl)
+	switch l.format {
+	case "bullet", "none":
+		return ""
+	}
+	text := l.text
+	if text == "" {
+		text = "%" + strconv.Itoa(ilvl+1)
+	}
+	var sb strings.Builder
+	for i := 0; i < len(text); i++ {
+		if text[i] == '%' && i+1 < len(text) && text[i+1] >= '1' && text[i+1] <= '9' {
+			k := int(text[i+1] - '1')
+			lk, _ := n.defs.level(numID, k)
+			sb.WriteString(formatNumber(counters[k], lk.format))
+			i++
+			continue
+		}
+		sb.WriteByte(text[i])
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// formatNumber renders a counter in a w:numFmt.
+func formatNumber(v int, format string) string {
+	switch format {
+	case "lowerLetter":
+		return letters(v, 'a')
+	case "upperLetter":
+		return letters(v, 'A')
+	case "lowerRoman":
+		return strings.ToLower(roman(v))
+	case "upperRoman":
+		return roman(v)
+	case "decimalZero":
+		return fmt.Sprintf("%02d", v)
+	default:
+		return strconv.Itoa(v)
+	}
+}
+
+// letters renders 1 as "a", 26 as "z" and 27 as "aa", as Word does.
+func letters(v int, base byte) string {
+	if v < 1 {
+		return strconv.Itoa(v)
+	}
+	c := string(base + byte((v-1)%26))
+	return strings.Repeat(c, (v-1)/26+1)
+}
+
+func roman(v int) string {
+	if v < 1 || v > 3999 {
+		return strconv.Itoa(v)
+	}
+	var sb strings.Builder
+	for _, p := range []struct {
+		n int
+		s string
+	}{{1000, "M"}, {900, "CM"}, {500, "D"}, {400, "CD"}, {100, "C"}, {90, "XC"}, {50, "L"}, {40, "XL"}, {10, "X"}, {9, "IX"}, {5, "V"}, {4, "IV"}, {1, "I"}} {
+		for v >= p.n {
+			sb.WriteString(p.s)
+			v -= p.n
+		}
+	}
+	return sb.String()
+}
+
+// styleNumbering is the w:numPr a style declares, each part possibly
+// inherited from the style it is based on.
+type styleNumbering struct {
+	basedOn string
+	numID   string
+	ilvl    int
+	hasNum  bool
+	hasLvl  bool
+}
+
+// parseStyleNumbering reads the numbering each style in word/styles.xml
+// declares.
+func parseStyleNumbering(data []byte) map[string]styleNumbering {
+	styles := map[string]styleNumbering{}
+	if len(data) == 0 {
+		return styles
+	}
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	var (
+		id      string
+		cur     styleNumbering
+		inStyle bool
+		inNumPr bool
+	)
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "style":
+				inStyle = true
+				id = getAttrVal(t, "styleId")
+				cur = styleNumbering{}
+			case "basedOn":
+				if inStyle {
+					cur.basedOn = getAttrVal(t, "val")
+				}
+			case "numPr":
+				inNumPr = inStyle
+			case "numId":
+				if inNumPr {
+					cur.numID, cur.hasNum = getAttrVal(t, "val"), true
+				}
+			case "ilvl":
+				if inNumPr {
+					if v, err := strconv.Atoi(getAttrVal(t, "val")); err == nil {
+						cur.ilvl, cur.hasLvl = v, true
+					}
+				}
+			}
+		case xml.EndElement:
+			switch t.Name.Local {
+			case "numPr":
+				inNumPr = false
+			case "style":
+				if inStyle && id != "" {
+					styles[id] = cur
+				}
+				inStyle = false
+			}
+		}
+	}
+	return styles
+}
+
+// resolveStyleNumbering follows a style's w:basedOn chain for the numbering
+// it inherits: numId and ilvl each come from the nearest style that sets
+// them, as Word resolves paragraph properties.
+func resolveStyleNumbering(styleID string, styles map[string]styleNumbering) (styleNumbering, bool) {
+	var out styleNumbering
+	visited := map[string]bool{}
+	for id := styleID; id != "" && !visited[id]; {
+		visited[id] = true
+		s, ok := styles[id]
+		if !ok {
+			break
+		}
+		if !out.hasNum && s.hasNum {
+			out.numID, out.hasNum = s.numID, true
+		}
+		if !out.hasLvl && s.hasLvl {
+			out.ilvl, out.hasLvl = s.ilvl, true
+		}
+		id = s.basedOn
+	}
+	return out, out.hasNum
+}

--- a/internal/converter/docx/numbering_test.go
+++ b/internal/converter/docx/numbering_test.go
@@ -1,0 +1,254 @@
+package docx
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const numberingXML = `<?xml version="1.0"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:abstractNum w:abstractNumId="150">
+<w:multiLevelType w:val="multilevel"/>
+<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1"/><w:pStyle w:val="Heading1"/></w:lvl>
+<w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl>
+<w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2.%3"/></w:lvl>
+</w:abstractNum>
+<w:abstractNum w:abstractNumId="7">
+<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="bullet"/><w:lvlText w:val="&#xF0B7;"/></w:lvl>
+<w:lvl w:ilvl="1"><w:start w:val="3"/><w:numFmt w:val="lowerLetter"/><w:lvlText w:val="(%2)"/></w:lvl>
+<w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="upperRoman"/><w:lvlText w:val="%3."/></w:lvl>
+</w:abstractNum>
+<w:num w:numId="3"><w:abstractNumId w:val="150"/></w:num>
+<w:num w:numId="4"><w:abstractNumId w:val="7"/></w:num>
+<w:num w:numId="5"><w:abstractNumId w:val="150"/><w:lvlOverride w:ilvl="0"><w:startOverride w:val="10"/></w:lvlOverride><w:lvlOverride w:ilvl="1"><w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="upperLetter"/><w:lvlText w:val="%1-%2"/></w:lvl></w:lvlOverride></w:num>
+</w:numbering>`
+
+const numberedStylesXML = `<?xml version="1.0"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:numId w:val="3"/></w:numPr></w:pPr></w:style>
+<w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/><w:basedOn w:val="Heading1"/><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="3"/></w:numPr></w:pPr></w:style>
+<w:style w:type="paragraph" w:styleId="Heading3"><w:name w:val="heading 3"/><w:basedOn w:val="Heading2"/><w:pPr><w:numPr><w:ilvl w:val="2"/></w:numPr></w:pPr></w:style>
+<w:style w:type="paragraph" w:styleId="Heading4"><w:name w:val="heading 4"/><w:basedOn w:val="Normal"/></w:style>
+<w:style w:type="paragraph" w:styleId="ListPara"><w:name w:val="List Paragraph"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="4"/></w:numPr></w:pPr></w:style>
+</w:styles>`
+
+func TestParseNumbering(t *testing.T) {
+	defs, err := parseNumbering([]byte(numberingXML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs.abstracts) != 2 || len(defs.nums) != 3 {
+		t.Fatalf("abstracts %d, nums %d", len(defs.abstracts), len(defs.nums))
+	}
+	l, ok := defs.level("3", 1)
+	if !ok || l.start != 1 || l.format != "decimal" || l.text != "%1.%2" {
+		t.Errorf("num 3 level 1 = %+v, %v", l, ok)
+	}
+	// Levels the abstract numbering leaves out default to decimal from 1.
+	if l, ok := defs.level("3", 8); !ok || l.start != 1 || l.format != "decimal" || l.text != "" {
+		t.Errorf("num 3 level 8 = %+v, %v", l, ok)
+	}
+	// A start override and a whole-level override.
+	if l, ok := defs.level("5", 0); !ok || l.start != 10 || l.text != "%1" {
+		t.Errorf("num 5 level 0 = %+v, %v", l, ok)
+	}
+	if l, ok := defs.level("5", 1); !ok || l.start != 1 || l.format != "upperLetter" || l.text != "%1-%2" {
+		t.Errorf("num 5 level 1 = %+v, %v", l, ok)
+	}
+	for _, bad := range []struct {
+		num  string
+		ilvl int
+	}{{"9", 0}, {"3", -1}, {"3", 9}} {
+		if _, ok := defs.level(bad.num, bad.ilvl); ok {
+			t.Errorf("level(%q, %d) found", bad.num, bad.ilvl)
+		}
+	}
+	empty, err := parseNumbering(nil)
+	if err != nil || len(empty.nums) != 0 {
+		t.Errorf("empty numbering: %v, %+v", err, empty)
+	}
+	// A truncated file reports the error and keeps what was read before it.
+	truncated := numberingXML[:strings.Index(numberingXML, `<w:num w:numId="5"`)] + "<w:num w:numId=\"5\"><w:abstractNumId"
+	partial, err := parseNumbering([]byte(truncated))
+	if err == nil || partial == nil || len(partial.abstracts) != 2 || len(partial.nums) != 2 {
+		t.Errorf("truncated numbering: err %v, %+v", err, partial)
+	}
+	// A level override outside any w:num is ignored rather than crashing.
+	stray := `<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:lvlOverride w:ilvl="0"><w:startOverride w:val="3"/><w:lvl w:ilvl="0"><w:start w:val="2"/></w:lvl></w:lvlOverride><w:num w:numId="1"><w:abstractNumId w:val="150"/></w:num></w:numbering>`
+	if defs, err := parseNumbering([]byte(stray)); err != nil || len(defs.nums) != 1 || len(defs.nums["1"].overrides) != 0 {
+		t.Errorf("stray override: err %v, %+v", err, defs)
+	}
+}
+
+func TestNumbererSequence(t *testing.T) {
+	defs, _ := parseNumbering([]byte(numberingXML))
+	styles := parseStyleNumbering([]byte(numberedStylesXML))
+	n := newNumberer(defs, styles)
+	para := func(style string) paragraphInfo { return paragraphInfo{StyleID: style} }
+	got := []string{
+		n.paragraphNumber(para("Heading1")), // 1
+		n.paragraphNumber(para("Heading2")), // 1.1
+		n.paragraphNumber(para("Heading3")), // 1.1.1: ilvl from Heading3, numId inherited through Heading2
+		n.paragraphNumber(para("Heading2")), // 1.2, level 3 reset
+		n.paragraphNumber(para("Heading3")), // 1.2.1
+		n.paragraphNumber(para("Normal")),   // "" : not numbered
+		n.paragraphNumber(para("Heading4")), // "" : no numbering anywhere in its chain
+		n.paragraphNumber(para("Heading1")), // 2, deeper levels reset
+		n.paragraphNumber(para("Heading2")), // 2.1
+		// The paragraph's own numPr wins over the style's.
+		n.paragraphNumber(paragraphInfo{StyleID: "Heading2", HasNumPr: true, NumID: "0"}),                         // "" : numbering turned off
+		n.paragraphNumber(paragraphInfo{StyleID: "Heading1", HasNumPr: true, NumID: "3", ILvl: 2, HasILvl: true}), // 2.1.1
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "5", HasILvl: true}),            // 10
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "5", ILvl: 1, HasILvl: true}),   // 10-A
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "5", ILvl: 1, HasILvl: true}),   // 10-B
+		// A bullet renders nothing but still counts; a lettered level
+		// starts at its own start value.
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "4", HasILvl: true}),
+		n.paragraphNumber(para("ListPara")), // (c)
+		n.paragraphNumber(para("ListPara")), // (d)
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "4", ILvl: 2, HasILvl: true}), // I.
+		// An unknown numbering instance numbers nothing.
+		n.paragraphNumber(paragraphInfo{StyleID: "Normal", HasNumPr: true, NumID: "99", HasILvl: true}),
+	}
+	want := []string{"1", "1.1", "1.1.1", "1.2", "1.2.1", "", "", "2", "2.1", "", "2.1.1", "10", "10-A", "10-B", "", "(c)", "(d)", "I.", ""}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("sequence:\n got %q\nwant %q", got, want)
+	}
+	if (*numberer)(nil).paragraphNumber(para("Heading1")) != "" {
+		t.Error("nil numberer numbered a paragraph")
+	}
+}
+
+func TestFormatNumber(t *testing.T) {
+	for _, tt := range []struct {
+		v      int
+		format string
+		want   string
+	}{
+		{3, "decimal", "3"}, {3, "decimalZero", "03"}, {1, "lowerLetter", "a"}, {26, "upperLetter", "Z"}, {27, "lowerLetter", "aa"},
+		{0, "lowerLetter", "0"}, {4, "lowerRoman", "iv"}, {1994, "upperRoman", "MCMXCIV"}, {0, "upperRoman", "0"}, {7, "ordinal", "7"},
+	} {
+		if got := formatNumber(tt.v, tt.format); got != tt.want {
+			t.Errorf("formatNumber(%d, %s) = %q, want %q", tt.v, tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestStyleNumberingInheritance(t *testing.T) {
+	styles := parseStyleNumbering([]byte(numberedStylesXML))
+	s, ok := resolveStyleNumbering("Heading3", styles)
+	if !ok || s.numID != "3" || s.ilvl != 2 {
+		t.Errorf("Heading3 = %+v, %v", s, ok)
+	}
+	if _, ok := resolveStyleNumbering("Heading4", styles); ok {
+		t.Error("Heading4 resolved a numbering")
+	}
+	if _, ok := resolveStyleNumbering("Unknown", styles); ok {
+		t.Error("an unknown style resolved a numbering")
+	}
+	// A basedOn cycle terminates.
+	cyclic := map[string]styleNumbering{"A": {basedOn: "B"}, "B": {basedOn: "A"}}
+	if _, ok := resolveStyleNumbering("A", cyclic); ok {
+		t.Error("cycle resolved a numbering")
+	}
+	if len(parseStyleNumbering(nil)) != 0 {
+		t.Error("empty styles parsed something")
+	}
+}
+
+// numberedDocx builds a document whose headings are numbered by their
+// styles, the way a meeting report is, with one heading that types its
+// number and one paragraph that turns numbering off.
+func numberedDocx(t *testing.T) []byte {
+	t.Helper()
+	doc := `<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>
+<w:p><w:r><w:t>Cover text.</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Opening of the meeting</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Call for IPR</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="ListPara"/></w:pPr><w:r><w:t>a list item</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Agreement</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Approval of Agenda</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>7.1 Typed number</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading1"/><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr><w:r><w:t>Numbering turned off</w:t></w:r></w:p>
+<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Closing</w:t></w:r></w:p>
+</w:body>
+</w:document>`
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range map[string]string{
+		"[Content_Types].xml":          `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>`,
+		"_rels/.rels":                  `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`,
+		"word/document.xml":            doc,
+		"word/styles.xml":              numberedStylesXML,
+		"word/numbering.xml":           numberingXML,
+		"word/_rels/document.xml.rels": `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`,
+	} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestNumberHeadings(t *testing.T) {
+	data := numberedDocx(t)
+	numbers := func(opts ParseOptions) string {
+		res, err := ParseDocxFromBytesWithOptions(data, "report.docx", opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var parts []string
+		for _, s := range res.Sections {
+			parts = append(parts, s.Number+"="+s.Title+"@"+s.ParentNumber)
+		}
+		return strings.Join(parts, " | ")
+	}
+	// Off (the default, as specifications are converted): the headings
+	// keep their text as their number.
+	want := "Opening of the meeting=Opening of the meeting@ | Call for IPR=Call for IPR@Opening of the meeting | Agreement=Agreement@Opening of the meeting | Approval of Agenda=Approval of Agenda@ | 7.1=Typed number@ | Numbering turned off=Numbering turned off@ | Closing=Closing@"
+	if got := numbers(ParseOptions{}); got != want {
+		t.Errorf("without NumberHeadings:\n got %s\nwant %s", got, want)
+	}
+	// On: the numbers Word would show, the typed number kept, the
+	// paragraph with numbering turned off left alone, and the counter
+	// unaffected by it. The list paragraph belongs to another numbering.
+	want = "=Preamble@ | 1=Opening of the meeting@ | 1.1=Call for IPR@1 | 1.2=Agreement@1 | 2=Approval of Agenda@ | 7.1=Typed number@ | Numbering turned off=Numbering turned off@ | 4=Closing@"
+	if got := numbers(ParseOptions{KeepPreamble: true, NumberHeadings: true}); got != want {
+		t.Errorf("with NumberHeadings:\n got %s\nwant %s", got, want)
+	}
+	// A document without numbering.xml is numbered by nothing.
+	var buf bytes.Buffer
+	zr, _ := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	zw := zip.NewWriter(&buf)
+	for _, f := range zr.File {
+		if f.Name == "word/numbering.xml" {
+			continue
+		}
+		rc, _ := f.Open()
+		w, _ := zw.Create(f.Name)
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(rc)
+		rc.Close()
+		_, _ = w.Write(b.Bytes())
+	}
+	_ = zw.Close()
+	res, err := ParseDocxFromBytesWithOptions(buf.Bytes(), "plain.docx", ParseOptions{NumberHeadings: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Sections[0].Number != "Opening of the meeting" {
+		t.Errorf("without numbering.xml: %q", res.Sections[0].Number)
+	}
+}

--- a/internal/converter/docx/paragraph.go
+++ b/internal/converter/docx/paragraph.go
@@ -13,10 +13,16 @@ import (
 // paragraphInfo holds extracted information from a w:p element.
 type paragraphInfo struct {
 	StyleID string
-	Text    string
-	Runs    []runInfo
-	Images  []imageRef
-	IsCode  bool // true if the paragraph uses a monospace/code font
+	// HasNumPr, NumID, ILvl and HasILvl carry the paragraph's own w:numPr,
+	// the numbering Word applies on top of the style's (see numbering.go).
+	HasNumPr bool
+	NumID    string
+	ILvl     int
+	HasILvl  bool
+	Text     string
+	Runs     []runInfo
+	Images   []imageRef
+	IsCode   bool // true if the paragraph uses a monospace/code font
 	// SkippedDiagramLabels holds text-box labels found inside a grouped
 	// vector diagram (VML v:group, or DrawingML wpg:wgp reached through
 	// mc:AlternateContent) that had no embeddable raster image anywhere in
@@ -98,7 +104,7 @@ func parseParagraphFromDecoder(d *xml.Decoder, start xml.StartElement) paragraph
 // the parser stays safe for concurrent use.
 func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDepth int) paragraphInfo {
 	var info paragraphInfo
-	var inPPr, inPPrRPr, inRPr, inR, inT bool
+	var inPPr, inPPrRPr, inRPr, inR, inT, inNumPr bool
 	var paragraphCodeFont bool
 	var currentRun runInfo
 	var runTexts []string
@@ -211,6 +217,21 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 			case "pStyle":
 				if inPPr {
 					info.StyleID = getAttrVal(t, "val")
+				}
+			case "numPr":
+				if inPPr {
+					inNumPr = true
+					info.HasNumPr = true
+				}
+			case "numId":
+				if inNumPr {
+					info.NumID = getAttrVal(t, "val")
+				}
+			case "ilvl":
+				if inNumPr {
+					if v, err := strconv.Atoi(getAttrVal(t, "val")); err == nil {
+						info.ILvl, info.HasILvl = v, true
+					}
 				}
 			case "rPr":
 				if inPPr && !inR {
@@ -336,6 +357,8 @@ func parseParagraphFromDecoderDepth(d *xml.Decoder, _ xml.StartElement, drawDept
 			depth--
 			local := t.Name.Local
 			switch local {
+			case "numPr":
+				inNumPr = false
 			case "pPr":
 				inPPr = false
 				inPPrRPr = false

--- a/internal/converter/docx/parser.go
+++ b/internal/converter/docx/parser.go
@@ -125,6 +125,17 @@ type ParseOptions struct {
 	// sheet, a liaison statement's header and body. The section is omitted
 	// when nothing precedes the first heading.
 	KeepPreamble bool
+	// NumberHeadings gives a heading that carries no number in its text the
+	// number Word computes from the heading style's numbering definition
+	// (word/numbering.xml), so "Approval of Agenda" becomes section "2".
+	// Specifications type their clause numbers into the heading text and
+	// are unaffected; meeting reports written on the MCC template rely on
+	// automatic numbering.
+	NumberHeadings bool
+
+	// numbers is the document's numbering state, set up by the parser when
+	// NumberHeadings is on.
+	numbers *numberer
 }
 
 // PreambleTitle is the title of the section that KeepPreamble creates.
@@ -206,6 +217,15 @@ func parseFromZipReader(r *zip.Reader, filename string, opts ParseOptions) (*Par
 	bodyElements, err := parseBody(docData)
 	if err != nil {
 		return nil, fmt.Errorf("parse body: %w", err)
+	}
+
+	if opts.NumberHeadings {
+		numberingData, _ := readZipFile(r, "word/numbering.xml")
+		defs, err := parseNumbering(numberingData)
+		if err != nil {
+			log.Printf("warning: failed to parse numbering.xml in %s: %v", filename, err)
+		}
+		opts.numbers = newNumberer(defs, parseStyleNumbering(stylesData))
 	}
 
 	// Extract metadata
@@ -531,6 +551,10 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 			info := elem.Paragraph
 			styleName := resolveStyleName(info.StyleID, styleMap)
 			headingLevel := getHeadingLevel(styleName)
+			// Every numbered paragraph advances its numbering, heading or
+			// not, so a heading's automatic number is right whatever
+			// precedes it.
+			autoNumber := opts.numbers.paragraphNumber(info)
 
 			// Also detect heading styles beyond level 6
 			if headingLevel == 0 {
@@ -593,6 +617,9 @@ func parseSections(elements []bodyElement, styleMap map[string]string, codeStyle
 					// name distinct IEs/messages).
 					title = strings.TrimSpace(match[1])
 					number = title
+				} else if autoNumber != "" {
+					number = autoNumber
+					title = text
 				} else {
 					number = text
 					title = text

--- a/internal/tdoc/fetch.go
+++ b/internal/tdoc/fetch.go
@@ -123,7 +123,7 @@ func Fetch(ctx context.Context, client *http.Client, doc Document) (*Fetched, er
 		}
 	}
 
-	parsed, err := docx.ParseDocxWithOptions(docPath, docx.ParseOptions{KeepPreamble: true})
+	parsed, err := docx.ParseDocxWithOptions(docPath, docx.ParseOptions{KeepPreamble: true, NumberHeadings: true})
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", fetched.MainFile, err)
 	}

--- a/internal/tdocstore/tdocstore.go
+++ b/internal/tdocstore/tdocstore.go
@@ -44,7 +44,7 @@ const DefaultFileName = "tdocs.db"
 // entries are re-downloadable, so a wipe is cheaper than migrating. Bump it
 // when the stored content becomes incompatible — it tracks the converter,
 // like versionstore.cacheSchemaVersion, and the tables here.
-const cacheSchemaVersion = 1
+const cacheSchemaVersion = 2
 
 const schema = `
 CREATE TABLE IF NOT EXISTS tdocs (


### PR DESCRIPTION
A meeting report written on the MCC template numbers its headings through the heading style's numbering definition, which Word computes when it lays the document out. The converted report therefore has headings without numbers, and `get_meeting_report` can read a section only by its title ("Approval of Agenda"), never by the agenda item number the meeting itself uses.

Read `word/numbering.xml` and the styles' `w:numPr`, follow every paragraph's numbering in reading order, and give a heading whose text carries no number the one Word would show, so the RAN1#123 report's sections become `1`, `1.1`, ..., `7` as in its own table of contents.

- The parser numbers headings only with `ParseOptions.NumberHeadings`, which the meeting-document fetcher sets. Specifications type their clause numbers into the heading text and are converted with it off, so their output is unchanged and no database rebuild is needed.
- A heading that types its number keeps it, and a paragraph whose `w:numPr` names `numId` 0 stays unnumbered, as in Word.
- `tdocstore.cacheSchemaVersion` is bumped so already cached reports are converted again on the next open.

Out of scope: rendering list numbers in body text, which stay as they were.

Tested live: the RAN1#123 report's headings match its table of contents, `get-meeting-report R1-123 7` reads agenda item 7, and the RAN#110 and SA2#172 reports, whose numbers are typed, convert as before.